### PR TITLE
Fix rodata and bss build inputs

### DIFF
--- a/gexenterthegecko.yaml
+++ b/gexenterthegecko.yaml
@@ -404,7 +404,7 @@ segments:
     subsegments:
       - [0x9BD00, c, level/GILLIG]
       - [0x9CF00, .rodata, level/GILLIG]
-      - { type: bss, 0x8015A970 }
+      - { type: bss, vram: 0x8015A970 }
 
   - name: horror_code
     type: code
@@ -415,7 +415,7 @@ segments:
     subsegments:
       - [0x9CF50, c, level/HORROR]
       - [0xA8460, .rodata, level/HORROR]
-      - { type: bss, 0x80164D20 }
+      - { type: bss, vram: 0x80164D20 }
 
   - name: intro_code
     type: code
@@ -525,7 +525,7 @@ segments:
     subsegments:
       - [0xDF540, c, level/SCIFI]
       - [0xEAC10, .rodata, level/SCIFI]
-      - { type: bss, 0x80164FD0 }
+      - { type: bss, vram: 0x80164FD0 }
 
   - name: spy_code
     type: code
@@ -536,7 +536,7 @@ segments:
     subsegments:
       - [0xEADF0, c, level/SPY]
       - [0xEC440, .rodata, level/SPY]
-      - { type: bss, 0x8015AE60 }
+      - { type: bss, vram: 0x8015AE60 }
 
   - name: logo_code
     type: code
@@ -547,7 +547,7 @@ segments:
     subsegments:
       - [0xEC530, c, level/LOGO]
       - [0xECE80, .rodata, level/LOGO]
-      - { type: bss, 0x8015A2E0 }
+      - { type: bss, vram: 0x8015A2E0 }
 
   # Zlib
   - name: zlib

--- a/makefile
+++ b/makefile
@@ -1,8 +1,5 @@
 
 BUILD_DIR = build
-ASMSOURCES := $(shell find asm -not \( -path asm/nonmatchings -prune \) -name "*.s")
-ASMOBJECTS := $(addprefix $(BUILD_DIR)/, $(patsubst %.s, %.o, $(ASMSOURCES)))
-
 MIPS1SOURCES := $(shell cat mips1.source.txt)
 MIPS1OBJECTS := $(addprefix $(BUILD_DIR)/, $(patsubst %.c, %.o, $(MIPS1SOURCES)))
 MIPS3SOURCES := $(shell cat mips3.source.txt)
@@ -10,6 +7,9 @@ MIPS3OBJECTS := $(addprefix $(BUILD_DIR)/, $(patsubst %.c, %.o, $(MIPS3SOURCES))
 LIBKMCSOURCES := $(shell cat libkmc.source.txt)
 LIBKMCOBJECTS := $(addprefix $(BUILD_DIR)/, $(patsubst %.c, %.o, $(LIBKMCSOURCES)))
 COBJECTS := $(MIPS1OBJECTS) $(MIPS3OBJECTS) $(LIBKMCOBJECTS)
+CRODATASOURCES := $(patsubst src/%.c,asm/data/%.rodata.s,$(MIPS1SOURCES) $(MIPS3SOURCES) $(LIBKMCSOURCES))
+ASMSOURCES := $(filter-out $(CRODATASOURCES),$(shell find asm -not \( -path asm/nonmatchings -prune \) -not \( -path asm/matchings -prune \) -name "*.s"))
+ASMOBJECTS := $(addprefix $(BUILD_DIR)/, $(patsubst %.s, %.o, $(ASMSOURCES)))
 
 AS = mips-linux-gnu-as
 OBJCOPY = mips-linux-gnu-objcopy


### PR DESCRIPTION
## Summary
- exclude generated rodata section assembly from ASMSOURCES so rodata included by C objects is not linked twice
- mark malformed level bss subsegments with explicit vram keys so splat generates matching bss object names

## Verification
- make build
- make diff