### PR TITLE
Decompile 12 small functions across 9 source files

### DIFF
--- a/src/161C0.c
+++ b/src/161C0.c
@@ -65,7 +65,15 @@ INCLUDE_ASM("asm/nonmatchings/161C0", func_80017768);
 
 INCLUDE_ASM("asm/nonmatchings/161C0", func_8001788C);
 
-INCLUDE_ASM("asm/nonmatchings/161C0", func_80017AB8);
+void func_80017AB8(short* arg0, short arg1) {
+    if (arg0 != NULL) {
+        arg0[7] = arg1;
+        arg0 = ((short**)arg0)[1];
+        if (arg0 != NULL) {
+            arg0[7] = arg1;
+        }
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/161C0", func_80017AE0);
 

--- a/src/1BA60.c
+++ b/src/1BA60.c
@@ -72,6 +72,12 @@ INCLUDE_ASM("asm/nonmatchings/1BA60", func_8001E838);
 
 INCLUDE_ASM("asm/nonmatchings/1BA60", func_8001E874);
 
-INCLUDE_ASM("asm/nonmatchings/1BA60", func_8001E980);
+void func_8001E980(int* arg0, int arg1, void* arg2) {
+    if (!(((unsigned short*)arg2)[0x45] & 0x10)) {
+        arg0[0x3E] = 0x80000;
+        ((short*)arg0)[0x2F] = 0;
+        ((char*)arg0)[0x4E] = 0x21;
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/1BA60", func_8001E9AC);

--- a/src/1F5F0.c
+++ b/src/1F5F0.c
@@ -52,11 +52,17 @@ INCLUDE_ASM("asm/nonmatchings/1F5F0", func_800223F8);
 
 INCLUDE_ASM("asm/nonmatchings/1F5F0", func_800224CC);
 
-INCLUDE_ASM("asm/nonmatchings/1F5F0", func_80022714);
+void func_80022714(void* arg0, int arg1) {
+    func_800224CC(arg0, arg1, 0, 0);
+}
 
-INCLUDE_ASM("asm/nonmatchings/1F5F0", func_80022738);
+void func_80022738(void* arg0, int arg1) {
+    func_800224CC(arg0, arg1, 1, 0);
+}
 
-INCLUDE_ASM("asm/nonmatchings/1F5F0", func_8002275C);
+void func_8002275C(void* arg0, int arg1) {
+    func_800224CC(arg0, arg1, 1, 1);
+}
 
 INCLUDE_ASM("asm/nonmatchings/1F5F0", func_80022780);
 

--- a/src/MATH3D.c
+++ b/src/MATH3D.c
@@ -309,10 +309,4 @@ INCLUDE_ASM("asm/nonmatchings/MATH3D", func_80030C50);
 
 INCLUDE_ASM("asm/nonmatchings/MATH3D", func_80030CB4);
 
-extern int D_800BF1C8;
-
-void func_80030D34(void) {
-    if (D_800BF1C8 != 0) {
-        D_800BF1C8--;
-    }
-}
+INCLUDE_ASM("asm/nonmatchings/MATH3D", func_80030D34);

--- a/src/MATH3D.c
+++ b/src/MATH3D.c
@@ -309,4 +309,10 @@ INCLUDE_ASM("asm/nonmatchings/MATH3D", func_80030C50);
 
 INCLUDE_ASM("asm/nonmatchings/MATH3D", func_80030CB4);
 
-INCLUDE_ASM("asm/nonmatchings/MATH3D", func_80030D34);
+extern int D_800BF1C8;
+
+void func_80030D34(void) {
+    if (D_800BF1C8 != 0) {
+        D_800BF1C8--;
+    }
+}

--- a/src/_23de0.c
+++ b/src/_23de0.c
@@ -14,4 +14,6 @@ INCLUDE_ASM("asm/nonmatchings/_23de0", func_80023F80);
 
 INCLUDE_ASM("asm/nonmatchings/_23de0", func_8002404C);
 
-INCLUDE_ASM("asm/nonmatchings/_23de0", func_800240C8);
+void func_800240C8(void) {
+    func_8002404C(0);
+}

--- a/src/_24cf0.c
+++ b/src/_24cf0.c
@@ -115,7 +115,9 @@ INCLUDE_ASM("asm/nonmatchings/_24cf0", func_8002768C);
 
 INCLUDE_ASM("asm/nonmatchings/_24cf0", func_80027770);
 
-INCLUDE_ASM("asm/nonmatchings/_24cf0", func_8002780C);
+void func_8002780C(GameTracker* gameTracker) {
+    func_8002CA2C(6, ((int*)gameTracker)[0x4BF8/4]);
+}
 
 INCLUDE_ASM("asm/nonmatchings/_24cf0", func_80027834);
 

--- a/src/_287a0.c
+++ b/src/_287a0.c
@@ -72,7 +72,19 @@ INCLUDE_ASM("asm/nonmatchings/_287a0", func_8002A488);
 
 INCLUDE_ASM("asm/nonmatchings/_287a0", func_8002ADB4);
 
-INCLUDE_ASM("asm/nonmatchings/_287a0", func_8002AE40);
+void func_8002AE40(int* arg0) {
+    int* data;
+
+    data = ((int*)arg0)[8];
+    arg0[0x3D] = 0;
+    arg0[0x3E] = 1;
+    ((short*)arg0)[0x2F] = 0;
+    ((char*)arg0)[0x4E] = 0;
+    ((short*)data)[0x4E] = 0;
+    ((short*)data)[0x4F] = 0;
+    ((short*)arg0)[0x30] = 0;
+    ((short*)arg0)[0x31] = 0;
+}
 
 INCLUDE_RODATA("asm/nonmatchings/_287a0", D_8007BE7C);
 

--- a/src/_2cd50.c
+++ b/src/_2cd50.c
@@ -2,7 +2,11 @@
 
 INCLUDE_ASM("asm/nonmatchings/_2cd50", func_8002C150);
 
-INCLUDE_ASM("asm/nonmatchings/_2cd50", func_8002C18C);
+extern short D_800EB80C;
+
+void func_8002C18C(int arg0) {
+    (&D_800EB80C)[arg0 * 6] = 4;
+}
 
 INCLUDE_ASM("asm/nonmatchings/_2cd50", func_8002C1AC);
 

--- a/src/_47260.c
+++ b/src/_47260.c
@@ -10,9 +10,11 @@
 
 INCLUDE_ASM("asm/nonmatchings/_47260", func_80046660);
 
+extern void func_80046660();
+
 void func_80046730(Instance* instance) {
-    instance->_B0 = 0;
-    instance->_AC = (int)func_80046660;
+    ((int*)instance)[0x2C] = 0;
+    ((int*)instance)[0x2B] = (int)func_80046660;
     func_8004A47C(instance);
 }
 

--- a/src/_47260.c
+++ b/src/_47260.c
@@ -10,13 +10,19 @@
 
 INCLUDE_ASM("asm/nonmatchings/_47260", func_80046660);
 
-INCLUDE_ASM("asm/nonmatchings/_47260", func_80046730);
+void func_80046730(Instance* instance) {
+    instance->_B0 = 0;
+    instance->_AC = (int)func_80046660;
+    func_8004A47C(instance);
+}
 
 INCLUDE_ASM("asm/nonmatchings/_47260", func_8004675C);
 
 INCLUDE_ASM("asm/nonmatchings/_47260", func_80046924);
 
-INCLUDE_ASM("asm/nonmatchings/_47260", func_80046978);
+void func_80046978(Instance* instance) {
+    INSTANCE_PlainDeath(instance, 5, -1, 0);
+}
 
 INCLUDE_ASM("asm/nonmatchings/_47260", func_800469A0);
 


### PR DESCRIPTION
- Decompiled 12 small functions across 161C0.c, 1BA60.c, 1F5F0.c, MATH3D.c, _23de0.c, _24cf0.c, _287a0.c, _2cd50.c, _47260.c
- All wrappers, setters, and initializers, 100% matching
- ROM diff confirms no differences