### PR TITLE
Decompile 30+ functions across level and core files

### DIFF
--- a/src/161C0.c
+++ b/src/161C0.c
@@ -65,7 +65,7 @@ INCLUDE_ASM("asm/nonmatchings/161C0", func_80017768);
 
 INCLUDE_ASM("asm/nonmatchings/161C0", func_8001788C);
 
-// arg0 and arg0->next may be Instance*
+// arg0 and arg1 may be Instance*
 void func_80017AB8(short* arg0, short arg1) {
     if (arg0 != NULL) {
         arg0[7] = arg1;

--- a/src/161C0.c
+++ b/src/161C0.c
@@ -65,7 +65,16 @@ INCLUDE_ASM("asm/nonmatchings/161C0", func_80017768);
 
 INCLUDE_ASM("asm/nonmatchings/161C0", func_8001788C);
 
-INCLUDE_ASM("asm/nonmatchings/161C0", func_80017AB8);
+// arg0 and arg0->next may be Instance*
+void func_80017AB8(short* arg0, short arg1) {
+    if (arg0 != NULL) {
+        arg0[7] = arg1;
+        arg0 = ((short**)arg0)[1];
+        if (arg0 != NULL) {
+            arg0[7] = arg1;
+        }
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/161C0", func_80017AE0);
 

--- a/src/1BA60.c
+++ b/src/1BA60.c
@@ -72,6 +72,13 @@ INCLUDE_ASM("asm/nonmatchings/1BA60", func_8001E838);
 
 INCLUDE_ASM("asm/nonmatchings/1BA60", func_8001E874);
 
-INCLUDE_ASM("asm/nonmatchings/1BA60", func_8001E980);
+// arg0 may be Instance*
+void func_8001E980(int* arg0, int arg1, unsigned short* arg2) {
+    if (!(arg2[0x45] & 0x10)) {
+        arg0[0x3E] = 0x80000;
+        ((short*)arg0)[0x2F] = 0;
+        ((char*)arg0)[0x4E] = 0x21;
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/1BA60", func_8001E9AC);

--- a/src/1F5F0.c
+++ b/src/1F5F0.c
@@ -1,5 +1,8 @@
 #include "common.h"
 
+#include "types/Instance.h"
+#include "types/GameTracker.h"
+
 INCLUDE_ASM("asm/nonmatchings/1F5F0", func_8001E9F0);
 
 INCLUDE_ASM("asm/nonmatchings/1F5F0", func_8001EF4C);
@@ -52,11 +55,17 @@ INCLUDE_ASM("asm/nonmatchings/1F5F0", func_800223F8);
 
 INCLUDE_ASM("asm/nonmatchings/1F5F0", func_800224CC);
 
-INCLUDE_ASM("asm/nonmatchings/1F5F0", func_80022714);
+void func_80022714(Instance* instance, GameTracker* gameTracker) {
+    func_800224CC(instance, gameTracker, 0, 0);
+}
 
-INCLUDE_ASM("asm/nonmatchings/1F5F0", func_80022738);
+void func_80022738(Instance* instance, GameTracker* gameTracker) {
+    func_800224CC(instance, gameTracker, 1, 0);
+}
 
-INCLUDE_ASM("asm/nonmatchings/1F5F0", func_8002275C);
+void func_8002275C(Instance* instance, GameTracker* gameTracker) {
+    func_800224CC(instance, gameTracker, 1, 1);
+}
 
 INCLUDE_ASM("asm/nonmatchings/1F5F0", func_80022780);
 

--- a/src/38670.c
+++ b/src/38670.c
@@ -14,9 +14,15 @@ void func_80037ABC(void) {
 void func_80037AC4(void) {
 }
 
-INCLUDE_ASM("asm/nonmatchings/38670", func_80037ACC);
+extern int D_8006FA88;
 
-INCLUDE_ASM("asm/nonmatchings/38670", func_80037AE0);
+void func_80037ACC(short arg0) {
+    D_8006FA88 = arg0;
+}
+
+void func_80037AE0(void) {
+    func_80037ACC(0x140);
+}
 
 extern int D_800BDEE8;
 extern int D_800BDEEC;

--- a/src/_23de0.c
+++ b/src/_23de0.c
@@ -14,4 +14,6 @@ INCLUDE_ASM("asm/nonmatchings/_23de0", func_80023F80);
 
 INCLUDE_ASM("asm/nonmatchings/_23de0", func_8002404C);
 
-INCLUDE_ASM("asm/nonmatchings/_23de0", func_800240C8);
+void func_800240C8(void) {
+    func_8002404C(0);
+}

--- a/src/_24cf0.c
+++ b/src/_24cf0.c
@@ -1,5 +1,6 @@
 #include "common.h"
 
+#include "types/Instance.h"
 #include "types/GameTracker.h"
 #include "types/BSPTree.h"
 
@@ -21,19 +22,33 @@ INCLUDE_ASM("asm/nonmatchings/_24cf0", func_80024C30);
 
 INCLUDE_ASM("asm/nonmatchings/_24cf0", func_80024C84);
 
-INCLUDE_ASM("asm/nonmatchings/_24cf0", func_8002527C);
+void func_8002527C(short* arg0, short arg1, short arg2, int arg3) {
+    arg0[6] = arg1;
+    arg0[7] = arg2;
+    ((int*)arg0)[4] = arg3;
+}
 
 INCLUDE_ASM("asm/nonmatchings/_24cf0", func_8002528C);
 
 INCLUDE_ASM("asm/nonmatchings/_24cf0", func_80025588);
 
-INCLUDE_ASM("asm/nonmatchings/_24cf0", func_8002569C);
+void func_8002569C(Instance* instance) {
+    instance->_F4[0] = 3;
+}
 
 INCLUDE_ASM("asm/nonmatchings/_24cf0", func_800256A8);
 
 INCLUDE_ASM("asm/nonmatchings/_24cf0", func_80025764);
 
-INCLUDE_ASM("asm/nonmatchings/_24cf0", func_80025798);
+int func_80025798(Instance* instance) {
+    int result;
+
+    result = 0;
+    if (instance->data != NULL) {
+        result = ((short*)instance->data)[0x6F];
+    }
+    return result;
+}
 
 INCLUDE_ASM("asm/nonmatchings/_24cf0", func_800257B4);
 
@@ -67,7 +82,12 @@ INCLUDE_ASM("asm/nonmatchings/_24cf0", func_80026674);
 
 INCLUDE_ASM("asm/nonmatchings/_24cf0", func_80026768);
 
-INCLUDE_ASM("asm/nonmatchings/_24cf0", func_800269C0);
+void func_800269C0(short* arg0) {
+    arg0[4] = 0;
+    arg0[5] = 0;
+    arg0[3] = 0;
+    arg0[2] = 0;
+}
 
 void func_800269D4(void) {
 }
@@ -88,9 +108,15 @@ INCLUDE_ASM("asm/nonmatchings/_24cf0", func_80027184);
 
 INCLUDE_ASM("asm/nonmatchings/_24cf0", func_80027398);
 
-INCLUDE_ASM("asm/nonmatchings/_24cf0", func_80027400);
+void func_80027400(Instance* instance) {
+    instance->_F4[0] = 4;
+    ((char*)instance->_40)[0xe] = 0;
+}
 
-INCLUDE_ASM("asm/nonmatchings/_24cf0", func_80027410);
+void func_80027410(Instance* instance) {
+    instance->_F4[0] = 0;
+    instance->_B8 = *(int*)instance->data;
+}
 
 INCLUDE_ASM("asm/nonmatchings/_24cf0", func_80027428);
 
@@ -115,7 +141,9 @@ INCLUDE_ASM("asm/nonmatchings/_24cf0", func_8002768C);
 
 INCLUDE_ASM("asm/nonmatchings/_24cf0", func_80027770);
 
-INCLUDE_ASM("asm/nonmatchings/_24cf0", func_8002780C);
+void func_8002780C(GameTracker* gameTracker) {
+    func_8002CA2C(6, ((int*)gameTracker)[0x4BF8/4]);
+}
 
 INCLUDE_ASM("asm/nonmatchings/_24cf0", func_80027834);
 

--- a/src/_287a0.c
+++ b/src/_287a0.c
@@ -75,15 +75,15 @@ INCLUDE_ASM("asm/nonmatchings/_287a0", func_8002A488);
 INCLUDE_ASM("asm/nonmatchings/_287a0", func_8002ADB4);
 
 void func_8002AE40(Instance* instance) {
-    void* lightGroup;
+    void* data;
 
-    lightGroup = instance->data;
+    data = instance->data;
     instance->_F4[0] = 0;
     instance->_F4[1] = 1;
     instance->currentAnimFrame = 0;
     ((char*)instance->_40)[0xe] = 0;
-    ((short*)lightGroup)[0x4E] = 0;
-    ((short*)lightGroup)[0x4F] = 0;
+    ((short*)data)[0x4E] = 0;
+    ((short*)data)[0x4F] = 0;
     instance->rotation.x = 0;
     instance->rotation.y = 0;
 }

--- a/src/_287a0.c
+++ b/src/_287a0.c
@@ -75,15 +75,15 @@ INCLUDE_ASM("asm/nonmatchings/_287a0", func_8002A488);
 INCLUDE_ASM("asm/nonmatchings/_287a0", func_8002ADB4);
 
 void func_8002AE40(Instance* instance) {
-    void* data;
+    void* lightGroup;
 
-    data = instance->data;
+    lightGroup = instance->data;
     instance->_F4[0] = 0;
     instance->_F4[1] = 1;
     instance->currentAnimFrame = 0;
     ((char*)instance->_40)[0xe] = 0;
-    ((short*)data)[0x4E] = 0;
-    ((short*)data)[0x4F] = 0;
+    ((short*)lightGroup)[0x4E] = 0;
+    ((short*)lightGroup)[0x4F] = 0;
     instance->rotation.x = 0;
     instance->rotation.y = 0;
 }

--- a/src/_287a0.c
+++ b/src/_287a0.c
@@ -81,7 +81,7 @@ void func_8002AE40(Instance* instance) {
     instance->_F4[0] = 0;
     instance->_F4[1] = 1;
     instance->currentAnimFrame = 0;
-    ((char*)instance->_40)[0xe] = 0;
+    instance->currentModelAnim = 0;
     ((short*)data)[0x4E] = 0;
     ((short*)data)[0x4F] = 0;
     instance->rotation.x = 0;

--- a/src/_287a0.c
+++ b/src/_287a0.c
@@ -1,5 +1,7 @@
 #include "common.h"
 
+#include "types/Instance.h"
+
 INCLUDE_ASM("asm/nonmatchings/_287a0", func_80027BA0);
 
 INCLUDE_ASM("asm/nonmatchings/_287a0", func_80027E7C);
@@ -72,7 +74,19 @@ INCLUDE_ASM("asm/nonmatchings/_287a0", func_8002A488);
 
 INCLUDE_ASM("asm/nonmatchings/_287a0", func_8002ADB4);
 
-INCLUDE_ASM("asm/nonmatchings/_287a0", func_8002AE40);
+void func_8002AE40(Instance* instance) {
+    void* data;
+
+    data = instance->data;
+    instance->_F4[0] = 0;
+    instance->_F4[1] = 1;
+    instance->currentAnimFrame = 0;
+    ((char*)instance->_40)[0xe] = 0;
+    ((short*)data)[0x4E] = 0;
+    ((short*)data)[0x4F] = 0;
+    instance->rotation.x = 0;
+    instance->rotation.y = 0;
+}
 
 INCLUDE_RODATA("asm/nonmatchings/_287a0", D_8007BE7C);
 

--- a/src/_2cd50.c
+++ b/src/_2cd50.c
@@ -2,7 +2,11 @@
 
 INCLUDE_ASM("asm/nonmatchings/_2cd50", func_8002C150);
 
-INCLUDE_ASM("asm/nonmatchings/_2cd50", func_8002C18C);
+extern short D_800EB80C[];
+
+void func_8002C18C(int arg0) {
+    D_800EB80C[arg0 * 6] = 4;
+}
 
 INCLUDE_ASM("asm/nonmatchings/_2cd50", func_8002C1AC);
 

--- a/src/_47260.c
+++ b/src/_47260.c
@@ -1,5 +1,6 @@
 #include "common.h"
 
+#include "INSTANCE.h"
 #include "SCRIPT.h"
 #include "SPLINE.h"
 
@@ -21,8 +22,6 @@ void func_80046730(Instance* instance) {
 INCLUDE_ASM("asm/nonmatchings/_47260", func_8004675C);
 
 INCLUDE_ASM("asm/nonmatchings/_47260", func_80046924);
-
-void INSTANCE_PlainDeath(Instance*, int, int, int);
 
 void func_80046978(Instance* instance) {
     INSTANCE_PlainDeath(instance, 5, -1, 0);

--- a/src/_47260.c
+++ b/src/_47260.c
@@ -10,13 +10,23 @@
 
 INCLUDE_ASM("asm/nonmatchings/_47260", func_80046660);
 
-INCLUDE_ASM("asm/nonmatchings/_47260", func_80046730);
+extern void func_80046660();
+
+void func_80046730(Instance* instance) {
+    instance->collideFunc = 0;
+    instance->processFunc = (void(*)(void*,void*))func_80046660;
+    func_8004A47C(instance);
+}
 
 INCLUDE_ASM("asm/nonmatchings/_47260", func_8004675C);
 
 INCLUDE_ASM("asm/nonmatchings/_47260", func_80046924);
 
-INCLUDE_ASM("asm/nonmatchings/_47260", func_80046978);
+void INSTANCE_PlainDeath(Instance*, int, int, int);
+
+void func_80046978(Instance* instance) {
+    INSTANCE_PlainDeath(instance, 5, -1, 0);
+}
 
 INCLUDE_ASM("asm/nonmatchings/_47260", func_800469A0);
 

--- a/src/level/CIRCUIT.c
+++ b/src/level/CIRCUIT.c
@@ -62,7 +62,7 @@ void circuit_bouncer_OnCollide(Instance* instance, GameTracker* gameTracker) {
              && (
                  (bsp->_08[4] == 0) || (bsp->_08[4] == 2)
              )) {
-        func_80022714(instance);
+        func_80022714(instance, gameTracker);
     }
 }
 
@@ -118,7 +118,7 @@ void circuit_crawler_OnCollide(Instance* instance, GameTracker* gameTracker) {
                 INSTANCE_PlainDeath(instance, 5, 3, 0);
             }
         } else if ((bsp->_06 == 1) && (bsp->instanceSpline == (void*)(gameTracker->player)) && ((instance->_F4[0] - 1) >= 2U)) {
-            func_80022714(instance);
+            func_80022714(instance, gameTracker);
         }
     }
 }

--- a/src/level/HORROR.c
+++ b/src/level/HORROR.c
@@ -8,6 +8,7 @@
 #include "types/Vector.h"
 extern int D_800E5FD8;
 extern int D_80154834;
+extern int D_80164C30_A8460;
 
 
 INCLUDE_ASM("asm/nonmatchings/level/HORROR", horror_drawer_OnCreate);
@@ -172,16 +173,73 @@ INCLUDE_ASM("asm/nonmatchings/level/HORROR", horror_spray_OnCollide);
 void horror_shittrn_OnCreate(Instance* instance, GameTracker* gameTracker) {
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/HORROR", horror_shittrn_OnUpdate);
+void horror_shittrn_OnUpdate(Instance* instance, GameTracker* gameTracker) {
+    SVector pos;
+    SVector randVec;
+    int i;
+
+    pos.x = instance->position.x;
+    pos.y = instance->position.y;
+    pos.z = instance->position.z;
+
+    for (i = 0; i < 2; i++) {
+        randVec.x = rand() % 60 - 30;
+        randVec.y = rand() % 60 - 30;
+        randVec.z = rand() % 30 + 25;
+        func_80019828(&pos, &randVec, &D_80164C30_A8460, pos.z);
+    }
+}
 
 void horror_shittrn_OnCollide(Instance* instance, GameTracker* gameTracker) {
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/HORROR", horror_bug_OnCreate);
+void horror_bug_OnCreate(Instance* instance, GameTracker* gameTracker) {
+    unsigned short* intro;
+
+    ((short*)&instance->_100)[1] = 0x18;
+    instance->flags |= 0x100000;
+    intro = (unsigned short*)instance->introData;
+
+    if (intro != NULL) {
+        *(short*)&instance->_100 = intro[0];
+        ((short*)&instance->_104)[1] = intro[1];
+        *(short*)&instance->_108 = intro[2];
+        ((short*)&instance->_108)[1] = intro[3];
+        *(short*)&instance->_10C = intro[4];
+        if (((short*)intro)[5] != 0) {
+            ((short*)&instance->_10C)[1] = ((short*)intro)[5];
+        } else {
+            ((short*)&instance->_10C)[1] = 0x40;
+        }
+    } else {
+        *(short*)&instance->_100 = 0x96;
+        ((short*)&instance->_104)[1] = ((unsigned short*)&instance->intro->position)[0] - 0x500;
+        *(short*)&instance->_108 = ((unsigned short*)&instance->intro->position)[1] - 0x780;
+        ((short*)&instance->_108)[1] = ((unsigned short*)&instance->intro->position)[0] + 0x500;
+        *(short*)&instance->_10C = ((unsigned short*)&instance->intro->position)[1] + 0x780;
+        ((short*)&instance->_10C)[1] = 0x40;
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/HORROR", horror_bug_OnUpdate);
 
-INCLUDE_ASM("asm/nonmatchings/level/HORROR", horror_bug_OnCollide);
+void horror_bug_OnCollide(Instance* instance, GameTracker* gameTracker) {
+    BSPTree* bsp;
+    short* temp;
+
+    bsp = instance->bspTree;
+    temp = (short*)&instance->_F4[2];
+
+    if (bsp->_06 == 1) {
+        if ((bsp->instanceSpline == gameTracker->player) && (bsp->_08[4] < 2U) && (bsp->_0C[5] >= 6U)) {
+            INSTANCE_PlainDeath(instance, 5, 3, 0);
+        } else if ((bsp->_06 == 1) && (bsp->instanceSpline == gameTracker->player) && ((bsp->_08[4] == 0) || (bsp->_08[4] == 2))) {
+            func_80022714(instance, gameTracker);
+            instance->_F4[0] = 0;
+            temp[4] = 0x5A;
+        }
+    }
+}
 
 void horror_bouncer_OnCreate(Instance* instance, GameTracker* gameTracker) {
     short* intro;
@@ -224,7 +282,7 @@ void horror_bouncer_OnCollide(Instance* instance, GameTracker* gameTracker) {
              && (
                  (bsp->_08[4] == 0) || (bsp->_08[4] == 2)
              )) {
-        func_80022714(instance);
+        func_80022714(instance, gameTracker);
     }
 }
 
@@ -259,9 +317,55 @@ INCLUDE_ASM("asm/nonmatchings/level/HORROR", horror_elevpan_OnUpdate);
 void horror_elevpan_OnCollide(Instance* instance, GameTracker* gameTracker) {
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/HORROR", horror_onoff_OnCreate);
+void horror_onoff_OnCreate(Instance* instance, GameTracker* gameTracker) {
+    if (instance->intro->flags & 0x1000) {
+        instance->intro->flags &= ~0x800;
+        return;
+    }
 
-INCLUDE_ASM("asm/nonmatchings/level/HORROR", horror_onoff_OnUpdate);
+    instance->_F4[0] = 0;
+    instance->flags |= 0x80;
+
+    if (instance->introData != NULL && *((int*)instance->introData) & 0x12) {
+        instance->_F4[0] = 1;
+    }
+
+    if (instance->intro->flags & 0x800) {
+        instance->_F4[0] = instance->_F4[0] != 1;
+    }
+
+    if (instance->object->data != NULL && *((int*)instance->object->data) != 0) {
+        instance->_100 = 1;
+    }
+
+    if (instance->_F4[0] == 0 || instance->_100 != 0) {
+        instance->currentAnimFrame = 0;
+    } else if (((short*)&instance->object->_08)[1] != 0) {
+        instance->currentAnimFrame = ((unsigned short*)(instance->object->animList[0]))[1] - 1;
+    }
+}
+
+void horror_onoff_OnUpdate(Instance* instance, GameTracker* gameTracker) {
+    instance->currentTextureAnimFrame = instance->_F4[0] ^ 1;
+
+    if (instance->_F4[1] == 1) {
+        if (instance->_F4[0] == 1 || instance->_100 != 0) {
+            func_8002DAF8(instance, -1);
+        } else {
+            func_8002DAF8(instance, -0x3E9);
+        }
+
+        if (instance->flags2 & 0x10) {
+            instance->flags2 &= ~0x10;
+            instance->_F4[1] = 0;
+            if (instance->_F4[0] == 0 || instance->_100 != 0) {
+                instance->currentAnimFrame = 0;
+            } else if (((short*)&instance->object->_08)[1] != 0) {
+                instance->currentAnimFrame = ((unsigned short*)(instance->object->animList[0]))[1] - 1;
+            }
+        }
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/HORROR", horror_onoff_OnCollide);
 

--- a/src/level/KUNGFU.c
+++ b/src/level/KUNGFU.c
@@ -85,7 +85,7 @@ void kungfu_crawler_OnCollide(Instance* instance, GameTracker* gameTracker) {
                 INSTANCE_PlainDeath(instance, 5, 3, 0);
             }
         } else if ((bsp->_06 == 1) && (bsp->instanceSpline == (void*)(gameTracker->player)) && ((instance->_F4[0] - 1) >= 2U)) {
-            func_80022714(instance);
+            func_80022714(instance, gameTracker);
         }
     }
 }
@@ -171,9 +171,55 @@ void func_8015AE8C_AA0AC(Instance* instance, GameTracker* gameTracker)
     }
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", kungfu_onoff_OnCreate);
+void kungfu_onoff_OnCreate(Instance* instance, GameTracker* gameTracker) {
+    if (instance->intro->flags & 0x1000) {
+        instance->intro->flags &= ~0x800;
+        return;
+    }
 
-INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", kungfu_onoff_OnUpdate);
+    instance->_F4[0] = 0;
+    instance->flags |= 0x80;
+
+    if (instance->introData != NULL && *((int*)instance->introData) & 0x12) {
+        instance->_F4[0] = 1;
+    }
+
+    if (instance->intro->flags & 0x800) {
+        instance->_F4[0] = instance->_F4[0] != 1;
+    }
+
+    if (instance->object->data != NULL && *((int*)instance->object->data) != 0) {
+        instance->_100 = 1;
+    }
+
+    if (instance->_F4[0] == 0 || instance->_100 != 0) {
+        instance->currentAnimFrame = 0;
+    } else if (((short*)&instance->object->_08)[1] != 0) {
+        instance->currentAnimFrame = ((unsigned short*)(instance->object->animList[0]))[1] - 1;
+    }
+}
+
+void kungfu_onoff_OnUpdate(Instance* instance, GameTracker* gameTracker) {
+    instance->currentTextureAnimFrame = instance->_F4[0] ^ 1;
+
+    if (instance->_F4[1] == 1) {
+        if (instance->_F4[0] == 1 || instance->_100 != 0) {
+            func_8002DAF8(instance, -1);
+        } else {
+            func_8002DAF8(instance, -0x3E9);
+        }
+
+        if (instance->flags2 & 0x10) {
+            instance->flags2 &= ~0x10;
+            instance->_F4[1] = 0;
+            if (instance->_F4[0] == 0 || instance->_100 != 0) {
+                instance->currentAnimFrame = 0;
+            } else if (((short*)&instance->object->_08)[1] != 0) {
+                instance->currentAnimFrame = ((unsigned short*)(instance->object->animList[0]))[1] - 1;
+            }
+        }
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", kungfu_onoff_OnCollide);
 

--- a/src/level/LOONEY.c
+++ b/src/level/LOONEY.c
@@ -2,6 +2,8 @@
 
 #include "level/LOONEY.h"
 
+extern int D_80161BD0_B9E80;
+
 void looney_rainbow_OnCreate(Instance* instance, GameTracker* gameTracker) {
 }
 
@@ -11,16 +13,73 @@ void looney_rainbow_OnUpdate(Instance* instance, GameTracker* gameTracker) {
 void looney_shittrn_OnCreate(Instance* instance, GameTracker* gameTracker) {
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/LOONEY", looney_shittrn_OnUpdate);
+void looney_shittrn_OnUpdate(Instance* instance, GameTracker* gameTracker) {
+    SVector pos;
+    SVector randVec;
+    int i;
+
+    pos.x = instance->position.x;
+    pos.y = instance->position.y;
+    pos.z = instance->position.z;
+
+    for (i = 0; i < 2; i++) {
+        randVec.x = rand() % 60 - 30;
+        randVec.y = rand() % 60 - 30;
+        randVec.z = rand() % 30 + 25;
+        func_80019828(&pos, &randVec, &D_80161BD0_B9E80, pos.z);
+    }
+}
 
 void looney_shittrn_OnCollide(Instance* instance, GameTracker* gameTracker) {
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/LOONEY", looney_bug_OnCreate);
+void looney_bug_OnCreate(Instance* instance, GameTracker* gameTracker) {
+    unsigned short* intro;
+
+    ((short*)&instance->_100)[1] = 0x18;
+    instance->flags |= 0x100000;
+    intro = (unsigned short*)instance->introData;
+
+    if (intro != NULL) {
+        *(short*)&instance->_100 = intro[0];
+        ((short*)&instance->_104)[1] = intro[1];
+        *(short*)&instance->_108 = intro[2];
+        ((short*)&instance->_108)[1] = intro[3];
+        *(short*)&instance->_10C = intro[4];
+        if (((short*)intro)[5] != 0) {
+            ((short*)&instance->_10C)[1] = ((short*)intro)[5];
+        } else {
+            ((short*)&instance->_10C)[1] = 0x40;
+        }
+    } else {
+        *(short*)&instance->_100 = 0x96;
+        ((short*)&instance->_104)[1] = ((unsigned short*)&instance->intro->position)[0] - 0x500;
+        *(short*)&instance->_108 = ((unsigned short*)&instance->intro->position)[1] - 0x780;
+        ((short*)&instance->_108)[1] = ((unsigned short*)&instance->intro->position)[0] + 0x500;
+        *(short*)&instance->_10C = ((unsigned short*)&instance->intro->position)[1] + 0x780;
+        ((short*)&instance->_10C)[1] = 0x40;
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/LOONEY", looney_bug_OnUpdate);
 
-INCLUDE_ASM("asm/nonmatchings/level/LOONEY", looney_bug_OnCollide);
+void looney_bug_OnCollide(Instance* instance, GameTracker* gameTracker) {
+    BSPTree* bsp;
+    short* temp;
+
+    bsp = instance->bspTree;
+    temp = (short*)&instance->_F4[2];
+
+    if (bsp->_06 == 1) {
+        if ((bsp->instanceSpline == gameTracker->player) && (bsp->_08[4] < 2U) && (bsp->_0C[5] >= 6U)) {
+            INSTANCE_PlainDeath(instance, 5, 3, 0);
+        } else if ((bsp->_06 == 1) && (bsp->instanceSpline == gameTracker->player) && ((bsp->_08[4] == 0) || (bsp->_08[4] == 2))) {
+            func_80022714(instance, gameTracker);
+            instance->_F4[0] = 0;
+            temp[4] = 0x5A;
+        }
+    }
+}
 
 void looney_bouncer_OnCreate(Instance* instance, GameTracker* gameTracker) {
     short* intro;
@@ -63,7 +122,7 @@ void looney_bouncer_OnCollide(Instance* instance, GameTracker* gameTracker) {
              && (
                  (bsp->_08[4] == 0) || (bsp->_08[4] == 2)
              )) {
-        func_80022714(instance);
+        func_80022714(instance, gameTracker);
     }
 }
 
@@ -117,7 +176,7 @@ void looney_crawler_OnCollide(Instance* instance, GameTracker* gameTracker) {
                 INSTANCE_PlainDeath(instance, 5, 3, 0);
             }
         } else if ((bsp->_06 == 1) && (bsp->instanceSpline == gameTracker->player) && ((instance->_F4[0] - 1) >= 2U)) {
-            func_80022714(instance);
+            func_80022714(instance, gameTracker);
         }
     }
 }

--- a/src/level/PREHST.c
+++ b/src/level/PREHST.c
@@ -55,7 +55,7 @@ void prehst_bouncer_OnCollide(Instance* instance, GameTracker* gameTracker) {
              && (
                  (bsp->_08[4] == 0) || (bsp->_08[4] == 2)
              )) {
-        func_80022714(instance);
+        func_80022714(instance, gameTracker);
     }
 }
 
@@ -109,7 +109,7 @@ void prehst_crawler_OnCollide(Instance* instance, GameTracker* gameTracker) {
                 INSTANCE_PlainDeath(instance, 5, 3, 0);
             }
         } else if ((bsp->_06 == 1) && (bsp->instanceSpline == gameTracker->player) && ((instance->_F4[0] - 1) >= 2U)) {
-            func_80022714(instance);
+            func_80022714(instance, gameTracker);
         }
     }
 }

--- a/src/level/SCIFI.c
+++ b/src/level/SCIFI.c
@@ -74,7 +74,7 @@ void scifi_crawler_OnCollide(Instance* instance, GameTracker* gameTracker) {
                 INSTANCE_PlainDeath(instance, 5, 3, 0);
             }
         } else if ((bsp->_06 == 1) && (bsp->instanceSpline == gameTracker->player)&& ((instance->_F4[0] - 1) >= 2U)) {
-            func_80022714(instance);
+            func_80022714(instance, gameTracker);
         }
     }
 }
@@ -89,9 +89,55 @@ INCLUDE_ASM("asm/nonmatchings/level/SCIFI", scifi_rocket_OnUpdate);
 
 INCLUDE_ASM("asm/nonmatchings/level/SCIFI", scifi_rocket_OnCollide);
 
-INCLUDE_ASM("asm/nonmatchings/level/SCIFI", scifi_onoff_OnCreate);
+void scifi_onoff_OnCreate(Instance* instance, GameTracker* gameTracker) {
+    if (instance->intro->flags & 0x1000) {
+        instance->intro->flags &= ~0x800;
+        return;
+    }
 
-INCLUDE_ASM("asm/nonmatchings/level/SCIFI", scifi_onoff_OnUpdate);
+    instance->_F4[0] = 0;
+    instance->flags |= 0x80;
+
+    if (instance->introData != NULL && *((int*)instance->introData) & 0x12) {
+        instance->_F4[0] = 1;
+    }
+
+    if (instance->intro->flags & 0x800) {
+        instance->_F4[0] = instance->_F4[0] != 1;
+    }
+
+    if (instance->object->data != NULL && *((int*)instance->object->data) != 0) {
+        instance->_100 = 1;
+    }
+
+    if (instance->_F4[0] == 0 || instance->_100 != 0) {
+        instance->currentAnimFrame = 0;
+    } else if (((short*)&instance->object->_08)[1] != 0) {
+        instance->currentAnimFrame = ((unsigned short*)(instance->object->animList[0]))[1] - 1;
+    }
+}
+
+void scifi_onoff_OnUpdate(Instance* instance, GameTracker* gameTracker) {
+    instance->currentTextureAnimFrame = instance->_F4[0] ^ 1;
+
+    if (instance->_F4[1] == 1) {
+        if (instance->_F4[0] == 1 || instance->_100 != 0) {
+            func_8002DAF8(instance, -1);
+        } else {
+            func_8002DAF8(instance, -0x3E9);
+        }
+
+        if (instance->flags2 & 0x10) {
+            instance->flags2 &= ~0x10;
+            instance->_F4[1] = 0;
+            if (instance->_F4[0] == 0 || instance->_100 != 0) {
+                instance->currentAnimFrame = 0;
+            } else if (((short*)&instance->object->_08)[1] != 0) {
+                instance->currentAnimFrame = ((unsigned short*)(instance->object->animList[0]))[1] - 1;
+            }
+        }
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/SCIFI", scifi_onoff_OnCollide);
 

--- a/src/level/SPY.c
+++ b/src/level/SPY.c
@@ -79,9 +79,55 @@ INCLUDE_ASM("asm/nonmatchings/level/SPY", func_8015A014_EB6E4);
 
 INCLUDE_ASM("asm/nonmatchings/level/SPY", func_8015A098_EB768);
 
-INCLUDE_ASM("asm/nonmatchings/level/SPY", spy_onoff_OnCreate);
+void spy_onoff_OnCreate(Instance* instance, GameTracker* gameTracker) {
+    if (instance->intro->flags & 0x1000) {
+        instance->intro->flags &= ~0x800;
+        return;
+    }
 
-INCLUDE_ASM("asm/nonmatchings/level/SPY", spy_onoff_OnUpdate);
+    instance->_F4[0] = 0;
+    instance->flags |= 0x80;
+
+    if (instance->introData != NULL && *((int*)instance->introData) & 0x12) {
+        instance->_F4[0] = 1;
+    }
+
+    if (instance->intro->flags & 0x800) {
+        instance->_F4[0] = instance->_F4[0] != 1;
+    }
+
+    if (instance->object->data != NULL && *((int*)instance->object->data) != 0) {
+        instance->_100 = 1;
+    }
+
+    if (instance->_F4[0] == 0 || instance->_100 != 0) {
+        instance->currentAnimFrame = 0;
+    } else if (((short*)&instance->object->_08)[1] != 0) {
+        instance->currentAnimFrame = ((unsigned short*)(instance->object->animList[0]))[1] - 1;
+    }
+}
+
+void spy_onoff_OnUpdate(Instance* instance, GameTracker* gameTracker) {
+    instance->currentTextureAnimFrame = instance->_F4[0] ^ 1;
+
+    if (instance->_F4[1] == 1) {
+        if (instance->_F4[0] == 1 || instance->_100 != 0) {
+            func_8002DAF8(instance, -1);
+        } else {
+            func_8002DAF8(instance, -0x3E9);
+        }
+
+        if (instance->flags2 & 0x10) {
+            instance->flags2 &= ~0x10;
+            instance->_F4[1] = 0;
+            if (instance->_F4[0] == 0 || instance->_100 != 0) {
+                instance->currentAnimFrame = 0;
+            } else if (((short*)&instance->object->_08)[1] != 0) {
+                instance->currentAnimFrame = ((unsigned short*)(instance->object->animList[0]))[1] - 1;
+            }
+        }
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/SPY", spy_onoff_OnCollide);
 


### PR DESCRIPTION
- Decompiled 30+ functions across 16 source files, all 100% matching
- Level functions: onoff_OnCreate/OnUpdate (HORROR, KUNGFU, SPY, SCIFI), shittrn_OnUpdate (HORROR, LOONEY), bug_OnCreate/OnCollide (HORROR, LOONEY)
- Core functions: small setters/wrappers in _24cf0.c, 1F5F0.c, _47260.c, _287a0.c, 1BA60.c, 161C0.c, _2cd50.c, 38670.c, _23de0.c
- Updated func_80022714/80022738/8002275C signatures to (Instance*, GameTracker*) and updated all callers
- Used proper Instance struct fields, added missing includes, forward declarations, and type comments per review feedback
- ROM diff confirms no differences, no new build warnings