### PR TITLE
Decompile 110+ functions across 24 core files

### DIFF
--- a/src/14AC0.c
+++ b/src/14AC0.c
@@ -18,8 +18,32 @@ INCLUDE_ASM("asm/nonmatchings/14AC0", func_80014C80);
 
 INCLUDE_ASM("asm/nonmatchings/14AC0", func_80014D00);
 
-INCLUDE_ASM("asm/nonmatchings/14AC0", func_80014D94);
+extern char D_800E5DDE;
 
-INCLUDE_ASM("asm/nonmatchings/14AC0", func_80014DD4);
+int func_80014D94(int arg0) {
+    int i;
+
+    for (i = arg0 - 1; i >= 0; i--) {
+        if (((char*)&D_800E5DDE)[i * 0x20] != 0) {
+            return i;
+        }
+    }
+    return arg0;
+}
+
+extern int D_80157034;
+
+int func_80014DD4(int arg0) {
+    int i;
+    int max;
+
+    max = D_80157034;
+    for (i = arg0 + 1; i < max; i++) {
+        if (((char*)&D_800E5DDE)[i * 0x20] != 0) {
+            return i;
+        }
+    }
+    return arg0;
+}
 
 INCLUDE_ASM("asm/nonmatchings/14AC0", func_80014E28);

--- a/src/161C0.c
+++ b/src/161C0.c
@@ -1,6 +1,7 @@
 #include "common.h"
 
 #include "LIST.h"
+#include "types/Instance.h"
 
 INCLUDE_ASM("asm/nonmatchings/161C0", func_800155C0);
 
@@ -14,11 +15,32 @@ INCLUDE_ASM("asm/nonmatchings/161C0", G2Quat_Slerp_VM);
 
 INCLUDE_ASM("asm/nonmatchings/161C0", func_80015DA0);
 
-INCLUDE_ASM("asm/nonmatchings/161C0", func_80015E80);
+void func_80015E80(short* arg0, short arg1) {
+    if (arg0 != NULL) {
+        arg0[6] |= arg1;
+        arg0 = ((short**)arg0)[1];
+        if (arg0 != NULL) {
+            arg0[6] |= arg1;
+        }
+    }
+}
 
-INCLUDE_ASM("asm/nonmatchings/161C0", func_80015EC0);
+void func_80015EC0(short* arg0, int* arg1) {
+    arg0[6] |= 0x10;
+    LIST_DeleteFunc(((NodeType*)arg0));
+    LIST_InsertFunc(((NodeType*)((char*)arg1 + 0x11418)), ((NodeType*)arg0));
+}
 
-INCLUDE_ASM("asm/nonmatchings/161C0", func_80015F14);
+int* func_80015F14(int* arg0) {
+    int* node;
+
+    node = (int*)LIST_GetFunc(((NodeType*)((char*)arg0 + 0x2C08)));
+    if (node != NULL) {
+        node[2] = 0;
+        LIST_InsertFunc(((NodeType*)((char*)arg0 + 0x2C00)), ((NodeType*)node));
+    }
+    return node;
+}
 
 // At least used to create two shadows
 void* func_80015F60(void* arg0) {
@@ -49,13 +71,22 @@ INCLUDE_ASM("asm/nonmatchings/161C0", func_80016D58);
 
 INCLUDE_ASM("asm/nonmatchings/161C0", func_80016F84);
 
-INCLUDE_ASM("asm/nonmatchings/161C0", func_800170E8);
+void func_800170E8(int arg0, int arg1, int arg2, int arg3, int arg4, int arg5, int arg6, int arg7, short arg8) {
+    func_80016F84(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, 0, (int)arg8);
+}
 
-INCLUDE_ASM("asm/nonmatchings/161C0", func_80017138);
+void func_80017138(Instance* instance, int arg1, int arg2, int arg3, int arg4, int arg5, int arg6, int arg7, short arg8) {
+    int* animList;
+
+    animList = (int*)instance->object->animList;
+    func_800170E8(animList[instance->currentModel], arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
+}
 
 INCLUDE_ASM("asm/nonmatchings/161C0", func_8001719C);
 
-INCLUDE_ASM("asm/nonmatchings/161C0", func_80017598);
+void func_80017598(int arg0, int arg1, int arg2, int arg3, int arg4, int arg5, int arg6) {
+    func_8001719C(arg0, arg1, arg2, arg3, arg4, arg5, arg6, 0);
+}
 
 INCLUDE_ASM("asm/nonmatchings/161C0", func_800175D0);
 
@@ -80,13 +111,51 @@ INCLUDE_ASM("asm/nonmatchings/161C0", func_80017AE0);
 
 INCLUDE_ASM("asm/nonmatchings/161C0", func_80017C58);
 
-INCLUDE_ASM("asm/nonmatchings/161C0", func_80017CD8);
+void func_80017CD8(short* arg0, short arg1, short arg2, short arg3) {
+    if (arg0 != NULL) {
+        arg0[0x4C/2] = arg1;
+        arg0[0x4E/2] = arg2;
+        arg0[0x50/2] = arg3;
+        arg0[6] &= ~2;
+        arg0 = ((short**)arg0)[1];
+        if (arg0 != NULL) {
+            arg0[0x4C/2] = arg1;
+            arg0[0x4E/2] = arg2;
+            arg0[0x50/2] = arg3;
+            arg0[6] &= ~2;
+        }
+    }
+}
 
-INCLUDE_ASM("asm/nonmatchings/161C0", func_80017D28);
+void func_80017D28(short* arg0, short arg1, short arg2, short arg3) {
+    if (arg0 != NULL) {
+        arg0[0x52/2] = arg1;
+        arg0[0x54/2] = arg2;
+        arg0[0x56/2] = arg3;
+        arg0[6] &= ~2;
+        arg0 = ((short**)arg0)[1];
+        if (arg0 != NULL) {
+            arg0[0x52/2] = arg1;
+            arg0[0x54/2] = arg2;
+            arg0[0x56/2] = arg3;
+            arg0[6] &= ~2;
+        }
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/161C0", func_80017D78);
 
-INCLUDE_ASM("asm/nonmatchings/161C0", func_80017E48);
+void func_80017E48(short* arg0, short arg1) {
+    if (arg0 != NULL) {
+        arg0[0x44/2] = arg1;
+        arg0[6] |= 0x100;
+        arg0 = ((short**)arg0)[1];
+        if (arg0 != NULL) {
+            arg0[0x44/2] = arg1;
+            arg0[6] |= 0x100;
+        }
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/161C0", func_80017E88);
 
@@ -110,6 +179,11 @@ INCLUDE_ASM("asm/nonmatchings/161C0", func_80018AB4);
 
 INCLUDE_ASM("asm/nonmatchings/161C0", func_80018B60);
 
-INCLUDE_ASM("asm/nonmatchings/161C0", func_80018DC0);
+void func_80018DC0(int* arg0) {
+    int* sub;
+
+    sub = ((int**)arg0)[0x2C/4];
+    func_80018B60(arg0, 0, 0, sub[0x4D4/4], sub[0x4D8/4], sub[0x4DC/4]);
+}
 
 INCLUDE_ASM("asm/nonmatchings/161C0", func_80018DFC);

--- a/src/1BA60.c
+++ b/src/1BA60.c
@@ -1,10 +1,31 @@
 #include "common.h"
 
+#include "types/Instance.h"
+#include "types/GameTracker.h"
+
 INCLUDE_ASM("asm/nonmatchings/1BA60", func_8001AE60);
 
-INCLUDE_ASM("asm/nonmatchings/1BA60", func_8001B760);
+extern Instance* PlayerInstance;
 
-INCLUDE_ASM("asm/nonmatchings/1BA60", func_8001B7C0);
+void func_8001B760(int* arg0) {
+    int* dest;
+
+    dest = (int*)((char*)PlayerInstance->data + 0xF8);
+    memcpy(dest, arg0, 0x2C);
+}
+
+void func_8001B7C0(Instance* instance) {
+    int vel;
+    int limit;
+
+    vel = instance->_D0[2] + instance->_E0[1];
+    limit = -instance->_F0[0];
+    instance->_D0[2] = vel;
+    if (vel < limit) {
+        instance->_D0[2] = limit;
+    }
+    instance->position.z = instance->position.z + instance->_D0[2];
+}
 
 INCLUDE_ASM("asm/nonmatchings/1BA60", func_8001B804);
 
@@ -20,17 +41,58 @@ INCLUDE_ASM("asm/nonmatchings/1BA60", func_8001C650);
 
 INCLUDE_ASM("asm/nonmatchings/1BA60", func_8001C738);
 
-INCLUDE_ASM("asm/nonmatchings/1BA60", func_8001C920);
+void func_8001C920(Instance* instance, int arg1, void* arg2) {
+    short timer;
+
+    timer = ((short*)arg2)[0xDC/2];
+    if (timer != 0) {
+        timer--;
+        ((short*)arg2)[0xDC/2] = timer;
+        if (instance->_F4[1] != 0x4000000) {
+            if (timer & 2) {
+                instance->flags |= 0x800;
+            } else {
+                instance->flags &= ~0x800;
+            }
+        }
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/1BA60", func_8001C978);
 
 INCLUDE_ASM("asm/nonmatchings/1BA60", func_8001CB9C);
 
-INCLUDE_ASM("asm/nonmatchings/1BA60", func_8001CDFC);
+void func_8001CDFC(short* arg0, short arg1, short arg2) {
+    short val;
+
+    val = *arg0;
+    if (val + arg2 < arg1) {
+        *arg0 = val + arg2;
+    }
+    val = *arg0;
+    if (arg1 < val - arg2) {
+        *arg0 = val - arg2;
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/1BA60", func_8001CE54);
 
-INCLUDE_ASM("asm/nonmatchings/1BA60", func_8001CF90);
+extern int D_8006CFA4;
+
+void func_8001CF90(Instance* instance, GameTracker* gameTracker) {
+    int val;
+
+    instance->_F4[0] = 3;
+    if (((int*)gameTracker)[0x4BF4/4] == 1) {
+        val = 0xBE;
+    } else {
+        val = 0x5A;
+    }
+    D_8006CFA4 = val;
+    if (((int*)gameTracker)[0x4C08/4] & 0x20000) {
+        D_8006CFA4 -= 0x1E;
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/1BA60", func_8001CFE8);
 
@@ -44,21 +106,86 @@ INCLUDE_ASM("asm/nonmatchings/1BA60", func_8001DA8C);
 
 INCLUDE_ASM("asm/nonmatchings/1BA60", func_8001DC80);
 
-INCLUDE_ASM("asm/nonmatchings/1BA60", func_8001DDD8);
+void func_8001DDD8(Instance* instance, int arg1, void* arg2) {
+    if (!(((unsigned short*)arg2)[0x45] & 1)) {
+        instance->_F4[1] = 0x40;
+        ((char*)instance->_40)[0xe] = 0x13;
+        instance->currentAnimFrame = 0;
+        if (((unsigned short*)arg2)[0x45] & 0x100) {
+            ((short*)arg2)[0xA4] = instance->position.z;
+            ((short*)arg2)[0x76] = 0;
+        } else {
+            ((short*)arg2)[0x76] = ((unsigned short*)arg2)[8];
+        }
+    }
+}
 
-INCLUDE_ASM("asm/nonmatchings/1BA60", func_8001DE2C);
+void func_8001DE2C(Instance* instance, GameTracker* gameTracker, int arg2, void* arg3) {
+    if ((((int*)arg3)[1] & 0x3830) || (((int*)arg3)[0] & 0x8000000F)) {
+        if (!(instance->flags & 0x100)) {
+            if (((short*)gameTracker)[0x4C12/2] == 4) {
+                instance->currentModelAnim = 0;
+                instance->currentAnimFrame = 0;
+                instance->_F4[1] = 1;
+            }
+        }
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/1BA60", func_8001DE8C);
 
 INCLUDE_ASM("asm/nonmatchings/1BA60", func_8001DFC0);
 
-INCLUDE_ASM("asm/nonmatchings/1BA60", func_8001E064);
+void func_8001E064(Instance* instance, void* arg1, int arg2, void* arg3) {
+    Instance* other;
 
-INCLUDE_ASM("asm/nonmatchings/1BA60", func_8001E0C4);
+    if ((((int*)arg3)[1] & 0x800) || (((int*)((int*)arg1)[3])[0xFC/4] & 0x800)) {
+        ((char*)instance->_40)[0xe] = 0x22;
+        instance->currentAnimFrame = 0;
+        instance->_F4[1] = 0x100000;
+        other = (Instance*)((int*)arg1)[3];
+        other->_F4[2] &= ~0x800;
+    }
+}
 
-INCLUDE_ASM("asm/nonmatchings/1BA60", func_8001E114);
+void func_8001E0C4(Instance* instance, int arg1, int arg2, void* arg3) {
+    if (((int*)arg3)[1] & 0x10) {
+        if (!(instance->_F4[2] & 0x8000)) {
+            instance->_F4[1] = 0x20;
+            ((char*)instance->_40)[0xe] = 0x19;
+            instance->currentAnimFrame = 0;
+            instance->_F4[2] &= ~8;
+        }
+    }
+}
 
-INCLUDE_ASM("asm/nonmatchings/1BA60", func_8001E154);
+void func_8001E114(Instance* instance, int arg1, int arg2, void* arg3) {
+    if (((int*)arg3)[1] & 0x3000) {
+        if (!(instance->_F4[2] & 0x8000)) {
+            instance->_F4[1] = 0x1000;
+            ((char*)instance->_40)[0xe] = 0x1B;
+            instance->currentAnimFrame = 0;
+        }
+    }
+}
+
+void func_8001E154(Instance* instance, int arg1, void* arg2, void* arg3) {
+    if (((int*)arg3)[1] & 0x20) {
+        instance->_F4[1] = 0x2000;
+        instance->currentModelAnim = 0x1E;
+        instance->currentAnimFrame = 0;
+        {
+            int* p;
+            p = (int*)((int*)arg2)[0xB8/4];
+            p[0] = ((int*)arg2)[0xAC/4];
+            p = (int*)((int*)arg2)[0xC4/4];
+            p[0] = ((int*)arg2)[0xAC/4];
+            p = (int*)((int*)arg2)[0xD0/4];
+            p[0] = ((int*)arg2)[0xAC/4];
+        }
+        instance->_F4[2] &= ~8;
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/1BA60", func_8001E1C0);
 
@@ -68,7 +195,14 @@ INCLUDE_ASM("asm/nonmatchings/1BA60", func_8001E648);
 
 INCLUDE_ASM("asm/nonmatchings/1BA60", func_8001E6E0);
 
-INCLUDE_ASM("asm/nonmatchings/1BA60", func_8001E838);
+void func_8001E838(Instance* instance, int arg1, void* arg2) {
+    if (((unsigned short*)arg2)[0x45] & 2) {
+        if (!(instance->_F4[2] & 0x8000)) {
+            instance->_F4[1] = 0x400;
+            ((char*)instance->_40)[0xe] = 0x18;
+        }
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/1BA60", func_8001E874);
 
@@ -81,4 +215,12 @@ void func_8001E980(int* arg0, int arg1, unsigned short* arg2) {
     }
 }
 
-INCLUDE_ASM("asm/nonmatchings/1BA60", func_8001E9AC);
+void func_8001E9AC(Instance* instance, int arg1, void* arg2) {
+    if (((unsigned short*)arg2)[0x45] & 0x40) {
+        if (!(instance->_F4[2] & 0x8000)) {
+            instance->_F4[1] = 0x800;
+            ((char*)instance->_40)[0xe] = 0x17;
+            instance->currentAnimFrame = 0;
+        }
+    }
+}

--- a/src/1F5F0.c
+++ b/src/1F5F0.c
@@ -13,7 +13,21 @@ INCLUDE_ASM("asm/nonmatchings/1F5F0", func_8001F444);
 
 INCLUDE_ASM("asm/nonmatchings/1F5F0", func_8001F6F4);
 
-INCLUDE_ASM("asm/nonmatchings/1F5F0", func_80020164);
+extern int D_8006D288;
+
+int func_80020164(Instance* instance) {
+    if (instance->_F4[2] & 0x10000000) {
+        return 1;
+    }
+    {
+        int* data;
+        data = (int*)D_8006D288;
+        if (((int*)data)[3] != 0) {
+            return (((unsigned short*)((int*)data)[3])[3] & 2) != 0;
+        }
+    }
+    return 0;
+}
 
 INCLUDE_ASM("asm/nonmatchings/1F5F0", func_800201B4);
 

--- a/src/2BA70.c
+++ b/src/2BA70.c
@@ -1,8 +1,23 @@
 #include "common.h"
 
+#include "types/Instance.h"
+
 INCLUDE_ASM("asm/nonmatchings/2BA70", func_8002AE70);
 
-INCLUDE_ASM("asm/nonmatchings/2BA70", func_8002AF18);
+extern int D_8007BEB4;
+extern int D_8007BEB8;
+
+void func_8002AF18(Instance* instance, void* arg1) {
+    int* data;
+
+    data = (int*)((int*)arg1)[6];
+    data = (int*)((int*)data)[8];
+    if (data[0] == D_8007BEB4 && data[1] == D_8007BEB8) {
+        func_8002B428(instance, arg1);
+    } else {
+        func_8002B0F0(instance, arg1);
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/2BA70", func_8002AF84);
 
@@ -12,4 +27,19 @@ INCLUDE_ASM("asm/nonmatchings/2BA70", func_8002B2D8);
 
 INCLUDE_ASM("asm/nonmatchings/2BA70", func_8002B428);
 
-INCLUDE_ASM("asm/nonmatchings/2BA70", func_8002B7CC);
+void func_8002B7CC(Instance* instance) {
+    int* data;
+
+    data = (int*)((int*)instance->data)[0xE0/4];
+    if (func_8002AE70(instance, data) != 0) {
+        instance->_F4[1] = 0x10000;
+        instance->flags |= 0x100;
+        instance->_D0[0] = 0;
+        instance->_D0[1] = 0;
+        instance->_D0[2] = 0;
+        instance->_E0[1] = 0;
+        instance->_E0[0] = 0;
+        instance->_D0[3] = 0;
+        instance->_F4[2] |= 1;
+    }
+}

--- a/src/2C440.c
+++ b/src/2C440.c
@@ -1,6 +1,19 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/nonmatchings/2C440", func_8002B840);
+extern short D_80131798;
+extern short D_8014E828;
+extern int D_801317B8;
+extern int D_8014E848;
+extern int D_80200000;
+extern int D_80225800;
+
+void func_8002B840(void) {
+    D_80131798 = 2;
+    D_8014E828 = 2;
+    D_801317B8 = (int)&D_80200000;
+    D_8014E848 = (int)&D_80225800;
+    osViSetSpecialFeatures(0x42);
+}
 
 INCLUDE_ASM("asm/nonmatchings/2C440", func_8002B894);
 

--- a/src/368B0.c
+++ b/src/368B0.c
@@ -1,6 +1,15 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/nonmatchings/368B0", func_80035CB0);
+unsigned int func_80035CB0(unsigned int arg0, unsigned int arg1) {
+    unsigned int r;
+    unsigned int g;
+    unsigned int b;
+
+    r = ((arg0 >> 24) * (arg1 >> 24)) >> 8;
+    g = (((arg0 >> 16) & 0xFF) * ((arg1 >> 16) & 0xFF)) >> 8;
+    b = (((arg0 >> 8) & 0xFF) * ((arg1 >> 8) & 0xFF)) & 0xFF00;
+    return (r << 24) + 0xFF + (g << 16) + b;
+}
 
 INCLUDE_ASM("asm/nonmatchings/368B0", func_80035D1C);
 

--- a/src/38670.c
+++ b/src/38670.c
@@ -1,6 +1,16 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/nonmatchings/38670", func_80037A70);
+extern int D_800BDEE0;
+extern int D_800BDEE4;
+extern int D_800BDEF0;
+
+void func_80037A70(void) {
+    D_800BDEE0 = 0xA;
+    D_800BDEE4 = 0x10;
+    D_800BDEE8 = 0x28;
+    D_800BDEEC = 0x1E;
+    D_800BDEF0 = 0;
+}
 
 void func_80037AAC(void) {
 }
@@ -45,7 +55,21 @@ INCLUDE_ASM("asm/nonmatchings/38670", func_80037F68);
 
 INCLUDE_ASM("asm/nonmatchings/38670", func_8003860C);
 
-INCLUDE_ASM("asm/nonmatchings/38670", func_80038798);
+extern int D_800BD6D0[];
+
+void func_80038798(char arg0, short arg1, short arg2, char arg3, char arg4, char arg5) {
+    char* entry;
+
+    if (D_800BDEF0 < 0xFF) {
+        entry = (char*)&D_800BD6D0[D_800BDEF0 * 2];
+        ((short*)entry)[0] = arg1;
+        ((short*)entry)[1] = arg2;
+        entry[4] = arg0;
+        entry[5] = arg3;
+        entry[6] = arg5;
+        D_800BDEF0++;
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/38670", vPrint3DTextf);
 
@@ -68,11 +92,45 @@ INCLUDE_ASM("asm/nonmatchings/38670", func_800390CC);
 
 INCLUDE_ASM("asm/nonmatchings/38670", func_8003922C);
 
-INCLUDE_ASM("asm/nonmatchings/38670", func_8003959C);
+extern int D_800EB87C;
+extern int D_800E5D20;
+extern int D_80157050;
+
+void func_8003959C(void) {
+    int* dl;
+
+    dl = (int*)D_80157050;
+    D_800EB87C = -1;
+    D_800E5D20 = 1;
+    D_80157050 = (int)(dl + 2);
+    dl[0] = 0xB6000000;
+    dl[1] = 0x3000;
+    D_80157050 = (int)(dl + 4);
+    dl[2] = 0xFCFFFFFF;
+    dl[3] = 0xFFFE793C;
+}
 
 INCLUDE_ASM("asm/nonmatchings/38670", func_80039600);
 
-INCLUDE_ASM("asm/nonmatchings/38670", func_80039688);
+extern int D_8006FC08;
+extern int D_8006FAA4;
+extern int D_8006FAB4;
+extern int D_8006FAC4;
+extern int D_8006FAD4;
+
+void func_80039688(char arg0, char arg1, char arg2, char* arg3) {
+    int color;
+
+    arg3[0x96] = arg2;
+    arg3[0x94] = arg0;
+    arg3[0x95] = arg1;
+    color = ((unsigned char)arg3[0x94] << 24) | ((unsigned char)arg3[0x95] << 16) | ((unsigned char)arg2 << 8);
+    D_8006FC08 = color;
+    D_8006FAA4 = color;
+    D_8006FAB4 = color;
+    D_8006FAC4 = color;
+    D_8006FAD4 = color;
+}
 
 INCLUDE_ASM("asm/nonmatchings/38670", func_800396E0);
 
@@ -84,7 +142,17 @@ INCLUDE_ASM("asm/nonmatchings/38670", func_80039980);
 
 INCLUDE_ASM("asm/nonmatchings/38670", func_80039A58);
 
-INCLUDE_ASM("asm/nonmatchings/38670", func_80039C20);
+void func_80039C20(int* arg0) {
+    short counter;
+
+    counter = ((short*)arg0)[0x98/2];
+    if (counter < -1) {
+        func_80039A58(arg0, counter + 1);
+    } else {
+        ((short*)arg0)[0x98/2] = counter - 1;
+        func_80039A58(arg0, -1);
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/38670", func_80039C68);
 

--- a/src/3FB20.c
+++ b/src/3FB20.c
@@ -9,9 +9,37 @@ INCLUDE_ASM("asm/nonmatchings/3FB20", func_8003F334);
 
 INCLUDE_ASM("asm/nonmatchings/3FB20", func_8003F458);
 
-INCLUDE_ASM("asm/nonmatchings/3FB20", func_8003F614);
+extern int D_800EB7F8;
+extern int gameTracker4;
+extern short D_800AF040;
+extern short D_800AF042;
+extern int D_800AF044;
+extern int D_800AF048;
 
-INCLUDE_ASM("asm/nonmatchings/3FB20", func_8003F678);
+void func_8003F614(short arg0, int arg1, short arg2, int arg3) {
+    if (D_800EB7F8 == 0) {
+        if (((short*)gameTracker4)[0x4C12/2] != 6) {
+            *((short*)&D_800AF040) = arg0;
+            D_800AF044 = arg1;
+            D_800AF042 = arg2;
+            D_800AF048 = arg3;
+            D_800EB7F8 = (int)&D_800AF040;
+        }
+    }
+}
+extern int gameTracker4;
+extern short D_80078104;
+extern int D_80078108;
+
+void func_8003F678(short arg0, int arg1) {
+    if (D_800EB7F8 == 0) {
+        if (((short*)gameTracker4)[0x4C12/2] != 6) {
+            D_80078104 = arg0;
+            D_80078108 = arg1;
+            D_800EB7F8 = (int)&D_80078104;
+        }
+    }
+}
 
 extern short D_80078110;
 extern short D_80078112;

--- a/src/405D0.c
+++ b/src/405D0.c
@@ -6,6 +6,24 @@ INCLUDE_ASM("asm/nonmatchings/405D0", func_8003FA48);
 
 INCLUDE_ASM("asm/nonmatchings/405D0", func_8003FAD0);
 
-INCLUDE_ASM("asm/nonmatchings/405D0", func_8003FD84);
+extern int D_80156BD4;
+extern int D_80156BE4;
+extern char D_800E9760;
+
+int func_8003FD84(void) {
+    int bitPos;
+    int bytePos;
+    int bit;
+
+    bytePos = D_80156BE4;
+    bitPos = D_80156BD4;
+    bit = (((char*)&D_800E9760)[bytePos] >> bitPos) & 1;
+    D_80156BD4 = bitPos - 1;
+    if (bitPos - 1 < 0) {
+        D_80156BD4 = 7;
+        D_80156BE4 = bytePos + 1;
+    }
+    return bit;
+}
 
 INCLUDE_ASM("asm/nonmatchings/405D0", func_8003FDD8);

--- a/src/42BD0.c
+++ b/src/42BD0.c
@@ -2,7 +2,12 @@
 
 INCLUDE_ASM("asm/nonmatchings/42BD0", func_80041FD0);
 
-INCLUDE_ASM("asm/nonmatchings/42BD0", func_80042120);
+int func_80042120(short* arg0, int arg1) {
+    short* ptr;
+
+    ptr = arg0 + arg1;
+    return MATH3D_FastSqrt(ptr[0] * ptr[0] + ptr[3] * ptr[3] + ptr[6] * ptr[6]) >> 6;
+}
 
 INCLUDE_ASM("asm/nonmatchings/42BD0", func_80042184);
 

--- a/src/4FC20.c
+++ b/src/4FC20.c
@@ -82,15 +82,42 @@ void func_800508D4(void) {
     D_80156B14 = (unsigned int*)&gameTracker8->_4B12[0x3E];
 }
 
-INCLUDE_ASM("asm/nonmatchings/4FC20", func_80050930);
+extern int gameTracker8;
 
-INCLUDE_ASM("asm/nonmatchings/4FC20", func_80050980);
+int func_80050930(int arg0) {
+    if (((char*)gameTracker8)[0x4C60] != 0) {
+        if (arg0 != 0 && arg0 < 0x1E7) {
+            return MusStartEffect(arg0);
+        }
+    }
+    return 0;
+}
+
+int func_80050980(int arg0) {
+    if (((short*)gameTracker8)[0x4C12/2] != 6) {
+        if (((char*)gameTracker8)[0x4C60] != 0) {
+            if (arg0 != 0 && arg0 < 0x1E7) {
+                return MusStartEffect(arg0);
+            }
+        }
+    }
+    return 0;
+}
 
 INCLUDE_ASM("asm/nonmatchings/4FC20", func_800509E0);
 
 INCLUDE_ASM("asm/nonmatchings/4FC20", func_80050A80);
 
-INCLUDE_ASM("asm/nonmatchings/4FC20", func_80050B64);
+int func_80050B64(int arg0) {
+    if (((short*)gameTracker8)[0x4C12/2] != 6) {
+        if (((char*)gameTracker8)[0x4C62] != 0) {
+            if (arg0 != 0 && arg0 < 0x1E7) {
+                return MusStartEffect(arg0);
+            }
+        }
+    }
+    return 0;
+}
 
 extern int D_8006F5AC[]; // large and in charge (24 bytes)
 extern int D_800BDF08[];

--- a/src/52EE0.c
+++ b/src/52EE0.c
@@ -1,5 +1,11 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/nonmatchings/52EE0", func_800522E0);
+extern int D_800791E0;
+extern int D_800791E4;
+
+void func_800522E0(int arg0) {
+    D_800791E0 += arg0;
+    D_800791E4 = D_800791E0 >> 8;
+}
 
 INCLUDE_ASM("asm/nonmatchings/52EE0", func_80052308);

--- a/src/CAMERA.c
+++ b/src/CAMERA.c
@@ -56,7 +56,11 @@ void func_80001DF4(short arg0) // set z rot?
     ptr[0x260/2] = 0;
 }
 
-INCLUDE_ASM("asm/nonmatchings/CAMERA", func_80001E3C);
+void func_80001E3C(int* dst, int* src, int factor) {
+    dst[0] = src[0] + ((dst[0] - src[0]) * factor >> 12);
+    dst[1] = src[1] + ((dst[1] - src[1]) * factor >> 12);
+    dst[2] = src[2] + ((dst[2] - src[2]) * factor >> 12);
+}
 
 INCLUDE_ASM("asm/nonmatchings/CAMERA", func_80001EAC);
 
@@ -64,7 +68,9 @@ int CAMERA_LengthSVector(SVECTOR* sv) {
     return (MATH3D_FastSqrt2((sv->x * sv->x + sv->y * sv->y + sv->z * sv->z) << 4, 4) + 8) >> 4;
 }
 
-INCLUDE_ASM("asm/nonmatchings/CAMERA", func_80002134);
+int func_80002134(short* vec) {
+    return (MATH3D_FastSqrt2((vec[0] * vec[0] + vec[1] * vec[1] + vec[2] * vec[2]) << 2, 2) + 2) >> 2;
+}
 
 INCLUDE_ASM("asm/nonmatchings/CAMERA", CAMERA_SetValue);
 
@@ -152,7 +158,17 @@ void CAMERA_SetTimer(Camera* camera, int arg1)
     CAMERA_Save(camera, -1);
 }
 
-INCLUDE_ASM("asm/nonmatchings/CAMERA", func_80003A0C);
+void func_80003A0C(int* arg0) {
+    if (arg0[0x2C8/4] != 3) {
+        if (arg0[0x468/4] > 0) {
+            arg0[0x468/4]--;
+            if (arg0[0x468/4] == 0) {
+                CAMERA_Restore(arg0, -1);
+                arg0[0x2C8/4] = 3;
+            }
+        }
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/CAMERA", func_80003A68);
 
@@ -165,7 +181,14 @@ void CAMERA_ChangeTo(CameraKey* key)
 
 INCLUDE_ASM("asm/nonmatchings/CAMERA", CAMERA_SetShake);
 
-INCLUDE_ASM("asm/nonmatchings/CAMERA", func_80003DAC);
+void func_80003DAC(short* result, SVECTOR* v1, SVECTOR* v2) {
+    SVECTOR diff;
+
+    diff.x = v2->x - v1->x;
+    diff.y = v2->y - v1->y;
+    diff.z = v2->z - v1->z;
+    *result = ratan2(diff.y, diff.x) + 0x400;
+}
 
 INCLUDE_ASM("asm/nonmatchings/CAMERA", func_80003E18);
 
@@ -196,9 +219,32 @@ void func_800058E4(SVECTOR* newPoint, SVECTOR* oldPoint)
 
 INCLUDE_ASM("asm/nonmatchings/CAMERA", func_80005920);
 
-INCLUDE_ASM("asm/nonmatchings/CAMERA", func_80005DB4);
+extern int D_8006CF10;
 
-INCLUDE_ASM("asm/nonmatchings/CAMERA", func_80005E18);
+void func_80005DB4(short arg0, short arg1) {
+    int buf[7];
+
+    buf[0] = arg0;
+    buf[1] = arg1;
+    buf[2] = 0;
+    buf[3] = 0;
+    buf[4] = 0;
+    buf[5] = 0;
+    buf[6] = 0;
+    D_8006CF10 = 0x80;
+    func_80011B20(buf, ((int*)gameTracker8)[1]);
+    D_8006CF10 = 0;
+}
+
+int func_80005E18(int* vec, short angle) {
+    MATRIX mat;
+    int result[3];
+
+    MATH3D_SetUnityMatrix(&mat);
+    RotMatrixZ(-angle, &mat);
+    MATH3D_ApplyMatrix(&mat, vec, result);
+    return -(short)ratan2(result[1], result[2]);
+}
 
 INCLUDE_ASM("asm/nonmatchings/CAMERA", func_80005E8C);
 
@@ -219,7 +265,22 @@ void func_800064D0(SVECTOR* newPoint, SVECTOR* oldPoint)
     func_800058E4(newPoint, oldPoint);
 }
 
-INCLUDE_ASM("asm/nonmatchings/CAMERA", func_800064F0);
+int func_800064F0(int arg0, int arg1) {
+    arg0 &= 0xFFF;
+    arg1 &= 0xFFF;
+    if (arg0 < arg1) {
+        if (arg1 - arg0 < 0x800) {
+            return 1;
+        }
+        return -1;
+    } else if (arg1 < arg0) {
+        if (arg0 - arg1 < 0x800) {
+            return -1;
+        }
+        return 1;
+    }
+    return 0;
+}
 
 INCLUDE_ASM("asm/nonmatchings/CAMERA", func_80006548);
 
@@ -241,6 +302,17 @@ int func_80007334()
     return 0;
 }
 
-INCLUDE_ASM("asm/nonmatchings/CAMERA", func_8000733C);
+void func_8000733C(SVECTOR* result, short arg1) {
+    SVECTOR input;
+    int output[3];
+
+    input.x = 0;
+    input.y = 0;
+    input.z = arg1;
+    MATH3D_ApplyMatrix(((int*)gameTracker8)[2], &input, output);
+    result->x = output[0];
+    result->y = output[1];
+    result->z = output[2];
+}
 
 INCLUDE_RODATA("asm/nonmatchings/CAMERA", D_8007B7A4);

--- a/src/MATH3D.c
+++ b/src/MATH3D.c
@@ -301,11 +301,55 @@ void MATH3D_SetIdentityQuat(G2Quat* q)
     q->w = 4096;
 }
 
-INCLUDE_ASM("asm/nonmatchings/MATH3D", func_80030BA0);
+extern int D_800E8184;
+extern int D_800BF1C0;
+extern int D_800BF1C4;
+extern int D_800BF1C8;
+extern int D_800BF1CC;
+extern int D_800BF1D0;
+extern int inflate;
 
-INCLUDE_ASM("asm/nonmatchings/MATH3D", func_80030BE0);
+void func_80030BA0(void) {
+    int base;
+    int size;
 
-INCLUDE_ASM("asm/nonmatchings/MATH3D", func_80030C50);
+    base = D_800E8184;
+    size = (int)&inflate - base;
+    D_800BF1C8 = 0;
+    D_800BF1C0 = base;
+    D_800BF1C4 = size;
+    D_800BF1CC = base;
+    D_800BF1D0 = size;
+}
+
+extern int D_800BF2CC;
+
+int func_80030BE0(int arg0) {
+    int idx;
+    int result;
+
+    arg0 = (arg0 + 0xF) & ~0xF;
+    idx = D_800BF1C8;
+    result = D_800BF1CC[idx * 2] + arg0;
+    D_800BF1CC[idx * 2] = result;
+    idx = D_800BF1C8;
+    D_800BF1D0[idx * 2] -= arg0;
+    D_800BF2CC = arg0;
+    return result;
+}
+
+extern int D_800BF1CC[];
+extern int D_800BF1D0[];
+
+void func_80030C50(int arg0) {
+    int idx;
+
+    idx = D_800BF1C8;
+    arg0 &= ~0xF;
+    D_800BF1CC[idx * 2] -= arg0;
+    idx = D_800BF1C8;
+    D_800BF1D0[idx * 2] += arg0;
+}
 
 INCLUDE_ASM("asm/nonmatchings/MATH3D", func_80030CB4);
 

--- a/src/_24cf0.c
+++ b/src/_24cf0.c
@@ -4,7 +4,25 @@
 #include "types/GameTracker.h"
 #include "types/BSPTree.h"
 
-INCLUDE_ASM("asm/nonmatchings/_24cf0", func_800240F0);
+void func_800240F0(Instance* instance, void* arg1) {
+    void* data;
+
+    if (instance != NULL) {
+        instance->flags &= ~0x400;
+    }
+    if (arg1 != NULL) {
+        data = (void*)((int*)arg1)[3];
+        if (data != NULL) {
+            data = (void*)((int*)data)[8];
+            if (data != NULL) {
+                ((int*)data)[0x130/4] = 0;
+                ((short*)data)[0x134/2] = 0;
+                ((short*)data)[0xDE/2] = 0;
+                ((short*)data)[0x18C/2] = 0;
+            }
+        }
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/_24cf0", func_80024148);
 
@@ -18,7 +36,20 @@ INCLUDE_ASM("asm/nonmatchings/_24cf0", func_80024A80);
 
 INCLUDE_ASM("asm/nonmatchings/_24cf0", func_80024B94);
 
-INCLUDE_ASM("asm/nonmatchings/_24cf0", func_80024C30);
+void func_80024C30(Instance* instance, void* arg1) {
+    Instance* target;
+    int* entry;
+
+    target = (Instance*)((int*)arg1)[0x130/4];
+    if (target != NULL) {
+        entry = (int*)((char*)instance->matrix + ((short*)arg1)[0x134/2] * 0x20);
+        target->position.x = entry[0x14/4];
+        target = (Instance*)((int*)arg1)[0x130/4];
+        target->position.y = entry[0x18/4];
+        target = (Instance*)((int*)arg1)[0x130/4];
+        target->position.z = entry[0x1C/4];
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/_24cf0", func_80024C84);
 
@@ -38,7 +69,16 @@ void func_8002569C(Instance* instance) {
 
 INCLUDE_ASM("asm/nonmatchings/_24cf0", func_800256A8);
 
-INCLUDE_ASM("asm/nonmatchings/_24cf0", func_80025764);
+extern int D_800B83BC;
+
+void func_80025764(Instance* instance, int arg1, short arg2) {
+    if (instance->data != NULL) {
+        if (((short*)instance->data)[0x6F] == 0) {
+            D_800B83BC = 2;
+        }
+        ((short*)instance->data)[0x6F] = arg2;
+    }
+}
 
 int func_80025798(Instance* instance) {
     int result;
@@ -50,13 +90,61 @@ int func_80025798(Instance* instance) {
     return result;
 }
 
-INCLUDE_ASM("asm/nonmatchings/_24cf0", func_800257B4);
+int func_800257B4(Instance* instance) {
+    int state;
+    void* data;
+    int result;
 
-INCLUDE_ASM("asm/nonmatchings/_24cf0", func_80025800);
+    state = instance->_F4[0];
+    data = instance->data;
+    result = 0;
+    if (state == 1 || state == 0x8000) {
+        result = 1;
+    } else if (data != NULL) {
+        if (((unsigned short*)data)[0x45] & 0x80) {
+            result = 1;
+        }
+    }
+    return result;
+}
 
-INCLUDE_ASM("asm/nonmatchings/_24cf0", func_80025850);
+short* func_80025800(void) {
+    short* ptr;
+    short i;
 
-INCLUDE_ASM("asm/nonmatchings/_24cf0", func_80025884);
+    ptr = D_80157650;
+    for (i = 0; i < 0x14; i++) {
+        if (ptr[0] == 0) {
+            ptr[0] = 1;
+            return ptr;
+        }
+        ptr += 4;
+    }
+    return NULL;
+}
+
+extern short D_80157650[];
+
+void func_80025850(void) {
+    short i;
+    for (i = 0; i < 0x14; i++) {
+        D_80157650[i * 4] = 0;
+    }
+}
+
+short* func_80025884(short arg0) {
+    short* ptr;
+    short i;
+
+    ptr = D_80157650;
+    for (i = 0; i < 0x14; i++) {
+        if (ptr[0] != 0 && ptr[3] == arg0) {
+            return ptr;
+        }
+        ptr += 4;
+    }
+    return NULL;
+}
 
 INCLUDE_ASM("asm/nonmatchings/_24cf0", func_800258E4);
 
@@ -68,7 +156,16 @@ INCLUDE_ASM("asm/nonmatchings/_24cf0", func_80025B4C);
 
 INCLUDE_ASM("asm/nonmatchings/_24cf0", func_80025E8C);
 
-INCLUDE_ASM("asm/nonmatchings/_24cf0", func_80025F70);
+void func_80025F70(GameTracker* gameTracker, Instance* instance, void* arg2) {
+    func_800240F0(instance, arg2);
+    D_800B83BC = 0;
+    INSTANCE_KillInstance(instance);
+    func_80025850();
+    if (((int*)gameTracker)[0x13C/4] != 0) {
+        func_800331BC(((int*)gameTracker)[0x13C/4]);
+        ((int*)gameTracker)[0x13C/4] = 0;
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/_24cf0", func_80025FDC);
 
@@ -98,15 +195,54 @@ INCLUDE_ASM("asm/nonmatchings/_24cf0", func_80026FA4);
 
 INCLUDE_ASM("asm/nonmatchings/_24cf0", func_80027028);
 
-INCLUDE_ASM("asm/nonmatchings/_24cf0", func_800270C8);
+void func_800270C8(Instance* instance, void* arg1) {
+    int offset;
+    int* data;
 
-INCLUDE_ASM("asm/nonmatchings/_24cf0", func_80027110);
+    offset = instance->_110 * 6 + 0x162;
+    data = (int*)((int*)arg1)[3];
+    data = (int*)((int*)data)[8];
+    func_80027028(instance, (char*)((int*)data)[0x70/4] + offset);
+}
 
-INCLUDE_ASM("asm/nonmatchings/_24cf0", func_80027144);
+void func_80027110(Instance* instance, short arg1, void* arg2) {
+    void* data;
+
+    data = (void*)((int*)arg2)[3];
+    instance->flags |= 0x400;
+    data = (void*)((int*)data)[8];
+    if (((int*)data)[0x4C] == 0) {
+        ((int*)data)[0x4C] = (int)instance;
+        ((short*)data)[0x9A] = arg1;
+    }
+}
+
+void func_80027144(Instance* instance) {
+    func_800240F0(instance);
+    func_8002E350(instance);
+    D_800B83BC = 0;
+    func_80050A80(0, 0xA);
+}
 
 INCLUDE_ASM("asm/nonmatchings/_24cf0", func_80027184);
 
-INCLUDE_ASM("asm/nonmatchings/_24cf0", func_80027398);
+int func_80027398(void) {
+    int state;
+    void* data;
+
+    state = PlayerInstance->_F4[0];
+    data = PlayerInstance->data;
+    if (state != 0) {
+        return 0;
+    }
+    if (PlayerInstance->_F4[1] != 1) {
+        return 0;
+    }
+    if (((int*)data)[0x74/4] & 2) {
+        return 0;
+    }
+    return ((unsigned char*)gameTracker8)[0x4CA1] != 0x16;
+}
 
 void func_80027400(Instance* instance) {
     instance->_F4[0] = 4;
@@ -118,7 +254,16 @@ void func_80027410(Instance* instance) {
     instance->_B8 = *(int*)instance->data;
 }
 
-INCLUDE_ASM("asm/nonmatchings/_24cf0", func_80027428);
+extern Instance* PlayerInstance;
+
+void func_80027428(int arg0) {
+    short* data;
+
+    data = (short*)PlayerInstance->data;
+    if (data[0x78/2] == 0) {
+        data[0x82/2] = ((unsigned short*)data)[0x86/2] + arg0 - ((unsigned short*)data)[0x88/2];
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/_24cf0", func_80027468);
 
@@ -131,9 +276,33 @@ int func_80027500(BSPTree* bsp, GameTracker* gameTracker) {
     return 0;
 }
 
-INCLUDE_ASM("asm/nonmatchings/_24cf0", func_80027548);
+int func_80027548(BSPTree* bsp, GameTracker* gameTracker) {
+    int result;
 
-INCLUDE_ASM("asm/nonmatchings/_24cf0", func_80027578);
+    result = 0;
+    if (bsp->instanceSpline == gameTracker->player) {
+        result = bsp->_06 == 4;
+    }
+    return result;
+}
+
+extern int* gameTracker8;
+
+int func_80027578(void) {
+    int state;
+    short* data;
+    int result;
+
+    state = PlayerInstance->_F4[0];
+    data = (short*)((int*)gameTracker8[3])[8];
+    result = 0;
+    if ((unsigned int)(state - 2) < 2) {
+        result = 1;
+    } else if (data[0xDC/2] != 0) {
+        result = 1;
+    }
+    return result;
+}
 
 INCLUDE_ASM("asm/nonmatchings/_24cf0", func_800275C4);
 

--- a/src/_287a0.c
+++ b/src/_287a0.c
@@ -1,6 +1,7 @@
 #include "common.h"
 
 #include "types/Instance.h"
+#include "types/GameTracker.h"
 
 INCLUDE_ASM("asm/nonmatchings/_287a0", func_80027BA0);
 
@@ -10,7 +11,15 @@ INCLUDE_ASM("asm/nonmatchings/_287a0", func_800280A0);
 
 INCLUDE_ASM("asm/nonmatchings/_287a0", func_8002829C);
 
-INCLUDE_ASM("asm/nonmatchings/_287a0", func_80028454);
+void func_80028454(Instance* instance, GameTracker* gameTracker) {
+    if ((unsigned int)(((int*)gameTracker)[0x4C48/4] - 1) < 9) {
+        if (((int*)gameTracker)[0x4C4C/4] == 0x64) {
+            if (func_80052FB8() != 0) {
+                func_8001C738(((int*)gameTracker)[3], gameTracker, ((int*)((int*)gameTracker)[3])[8], 0);
+            }
+        }
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/_287a0", func_800284C4);
 
@@ -32,13 +41,44 @@ INCLUDE_ASM("asm/nonmatchings/_287a0", func_800292D4);
 
 INCLUDE_ASM("asm/nonmatchings/_287a0", func_80029390);
 
-INCLUDE_ASM("asm/nonmatchings/_287a0", func_80029434);
+void func_80029434(Instance* instance, int arg1, void* arg2) {
+    if (!(((unsigned short*)arg2)[0x45] & 0x40)) {
+        instance->_F4[1] = 0x100;
+        ((char*)instance->_40)[0xe] = 0x11;
+        instance->currentAnimFrame = 0;
+    }
+    if ((instance->currentAnimFrame & 7) == 0) {
+        func_800247B4(instance, arg1, arg2, 0);
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/_287a0", func_8002948C);
 
-INCLUDE_ASM("asm/nonmatchings/_287a0", func_800295A0);
+void func_800295A0(Instance* instance, int arg1, void* arg2) {
+    if (instance->flags2 & 0x10) {
+        instance->_F4[1] = 0x1000;
+        ((char*)instance->_40)[0xe] = 0x1D;
+        instance->currentAnimFrame = 0;
+    } else {
+        int* p;
+        p = (int*)((int*)arg2)[0xB8/4];
+        p[0] = ((int*)arg2)[0xAC/4];
+        p = (int*)((int*)arg2)[0xC4/4];
+        p[0] = ((int*)arg2)[0xAC/4];
+        p = (int*)((int*)arg2)[0xD0/4];
+        p[0] = ((int*)arg2)[0xAC/4];
+    }
+}
 
-INCLUDE_ASM("asm/nonmatchings/_287a0", func_80029600);
+void func_80029600(Instance* instance, int arg1, void* arg2) {
+    if (instance->flags2 & 0x10) {
+        instance->_F4[1] = 1;
+        ((char*)instance->_40)[0xe] = 0;
+        instance->currentAnimFrame = 0;
+        ((short*)arg2)[0x4E] = 0;
+        ((short*)arg2)[0x4F] = 0;
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/_287a0", func_80029630);
 
@@ -58,7 +98,15 @@ INCLUDE_ASM("asm/nonmatchings/_287a0", func_80029FA4);
 
 INCLUDE_ASM("asm/nonmatchings/_287a0", func_8002A0AC);
 
-INCLUDE_ASM("asm/nonmatchings/_287a0", func_8002A140);
+void func_8002A140(Instance* instance, int arg1, void* arg2) {
+    if (instance->flags2 & 0x10) {
+        instance->_F4[1] = 2;
+        ((char*)instance->_40)[0xe] = 8;
+        ((short*)arg2)[0x4E] = 0;
+        ((short*)arg2)[0x4F] = 0;
+        ((short*)arg2)[0x6E] = 0x3C;
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/_287a0", func_8002A178);
 

--- a/src/_2cd50.c
+++ b/src/_2cd50.c
@@ -1,16 +1,31 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/nonmatchings/_2cd50", func_8002C150);
-
+extern short D_800EB808[];
 extern short D_800EB80C[];
+
+void func_8002C150(void) {
+    int i;
+    for (i = 0; i < 7; i++) {
+        D_800EB80C[i * 6] = 4;
+        D_800EB808[i * 6] = 0;
+    }
+}
 
 void func_8002C18C(int arg0) {
     D_800EB80C[arg0 * 6] = 4;
 }
 
-INCLUDE_ASM("asm/nonmatchings/_2cd50", func_8002C1AC);
+void func_8002C1AC(int arg0) {
+    func_8002C18C(arg0);
+    D_800EB80C[arg0 * 6] = 5;
+}
 
-INCLUDE_ASM("asm/nonmatchings/_2cd50", func_8002C1EC);
+void func_8002C1EC(void) {
+    int i;
+    for (i = 0; i < 7; i++) {
+        func_8002C18C(i);
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/_2cd50", func_8002C224);
 

--- a/src/_443f0.c
+++ b/src/_443f0.c
@@ -28,7 +28,17 @@ INCLUDE_ASM("asm/nonmatchings/_443f0", common_icecube_OnUpdate);
 
 INCLUDE_ASM("asm/nonmatchings/_443f0", common_icecube_OnCollide);
 
-INCLUDE_ASM("asm/nonmatchings/_443f0", func_800444B8);
+void func_800444B8(Instance* instance, int arg1) {
+    int frameSize;
+    int* data;
+
+    instance->_11C = arg1;
+    data = (int*)((int*)instance->object->animList[0])[0];
+    frameSize = ((int*)data)[3];
+    instance->_D0[0] = arg1 * frameSize * 2;
+    instance->_D0[1] = (arg1 + 1) * frameSize * 2 - 1;
+    instance->currentAnimFrame = instance->_D0[1];
+}
 
 INCLUDE_ASM("asm/nonmatchings/_443f0", common_powerbug_OnCreate);
 

--- a/src/_47260.c
+++ b/src/_47260.c
@@ -21,7 +21,17 @@ void func_80046730(Instance* instance) {
 
 INCLUDE_ASM("asm/nonmatchings/_47260", func_8004675C);
 
-INCLUDE_ASM("asm/nonmatchings/_47260", func_80046924);
+extern void func_8004675C();
+
+void func_80046924(Instance* instance) {
+    instance->processFunc = (void(*)(void*,void*))func_8004675C;
+    instance->collideFunc = 0;
+    instance->_F4[2] = 0x1000;
+    instance->_100 = (int)func_80015F14(D_800EB8A0);
+    instance->_104 = 0;
+    func_8004A47C(instance);
+}
+
 
 void func_80046978(Instance* instance) {
     INSTANCE_PlainDeath(instance, 5, -1, 0);
@@ -33,9 +43,24 @@ INCLUDE_ASM("asm/nonmatchings/_47260", func_80046A18);
 
 INCLUDE_ASM("asm/nonmatchings/_47260", func_80046AA0);
 
-INCLUDE_ASM("asm/nonmatchings/_47260", func_80046C48);
+void func_80046C48(Instance* instance) {
+    int* animList;
 
-INCLUDE_ASM("asm/nonmatchings/_47260", func_80046CB0);
+    animList = (int*)instance->object->animList;
+    if (animList != NULL) {
+        instance->currentAnimFrame--;
+        if ((short)instance->currentAnimFrame < 0) {
+            animList = (int*)animList[instance->currentModelAnim];
+            instance->currentAnimFrame = ((unsigned short*)animList[0])[1] - 1;
+        }
+    }
+}
+
+void func_80046CB0(Instance* instance) {
+    func_800469A0(instance);
+    func_80046A18(instance);
+    func_80046C48(instance);
+}
 
 void func_80046CE4(Instance* instance)
 {
@@ -44,7 +69,17 @@ void func_80046CE4(Instance* instance)
 
 INCLUDE_ASM("asm/nonmatchings/_47260", func_80046D04);
 
-INCLUDE_ASM("asm/nonmatchings/_47260", func_80046DA4);
+void func_80046DA4(Instance* instance, int* arg1, int* arg2) {
+    instance->processFunc = (void(*)(void*,void*))instance->_D0[0];
+    *arg2 = (short)instance->_D0[1];
+    *arg1 = (short)instance->_D0[1 + 1];
+    instance->_D0[0] = 0;
+    ((short*)&instance->_D0[1])[0] = 0;
+    ((short*)&instance->_D0[1])[1] = 0;
+    ((short*)&instance->_D0[2])[0] = 0;
+    ((short*)&instance->_D0[2])[1] = 0;
+    ((short*)&instance->_D0[3])[0] = 0;
+}
 
 INCLUDE_ASM("asm/nonmatchings/_47260", func_80046DDC);
 
@@ -61,20 +96,61 @@ INCLUDE_ASM("asm/nonmatchings/_47260", func_80047058);
 
 INCLUDE_ASM("asm/nonmatchings/_47260", func_80047240);
 
-INCLUDE_ASM("asm/nonmatchings/_47260", func_800472A4);
+extern int D_800EB8A0;
+extern void func_80016894();
 
-INCLUDE_ASM("asm/nonmatchings/_47260", func_800472F0);
+void func_800472A4(Instance* instance) {
+    func_8001719C(instance, 0, 0, 0, D_800EB8A0, 0, (int)func_80016894, 8);
+}
 
-INCLUDE_ASM("asm/nonmatchings/_47260", func_80047344);
+extern char D_8007E6D4[];
+extern char D_8007E6C8[];
+
+int* func_800472F0(int arg0) {
+    char* name;
+    int* obj;
+
+    if (arg0 == 0) {
+        name = D_8007E6D4;
+    } else {
+        name = D_8007E6C8;
+    }
+    obj = (int*)OBTABLE_FindObject(name);
+    if (obj != NULL) {
+        return (int*)((int*)obj[3])[0];
+    }
+    return NULL;
+}
+
+int func_80047344(Instance* instance, int arg1) {
+    int flags;
+
+    flags = instance->object->oflags2;
+    if (arg1 == 1) {
+        if (flags & 0x8000) {
+            arg1 = 5;
+        } else if (flags & 0x10000) {
+            arg1 = 4;
+        } else if (flags & 0x20000) {
+            arg1 = 3;
+        }
+    }
+    return arg1;
+}
 
 INCLUDE_ASM("asm/nonmatchings/_47260", func_800473A4);
 
 INCLUDE_ASM("asm/nonmatchings/_47260", func_80047438);
 
-INCLUDE_ASM("asm/nonmatchings/_47260", func_80047724);
+void func_80047724(Instance* instance) {
+    int arg1;
+    int arg2;
+
+    func_80046DA4(instance, &arg1, &arg2);
+    func_80047768(instance, arg1, arg2, 0);
+}
 
 extern void func_80047438(Instance*, GameTracker*);
-extern void func_80047724();
 
 void func_80047768(Instance* instance, int arg1, int arg2, int arg3) {
     Object* temp_a1 = instance->object;
@@ -660,7 +736,9 @@ INCLUDE_ASM("asm/nonmatchings/_47260", func_80048DE4);
 
 INCLUDE_ASM("asm/nonmatchings/_47260", func_80048E7C);
 
-INCLUDE_ASM("asm/nonmatchings/_47260", func_80049224);
+void func_80049224(Instance* instance, int arg1, int arg2, int arg3) {
+    func_80048E7C(instance, arg1, arg2, (char*)instance->intro + 0x10, 0x40);
+}
 
 INCLUDE_ASM("asm/nonmatchings/_47260", func_80049250);
 

--- a/src/_4a780.c
+++ b/src/_4a780.c
@@ -18,15 +18,61 @@ int func_8004A344(int*** arg0) {
   return *var_v0[1];
 }
 
-INCLUDE_ASM("asm/nonmatchings/_4a780", func_8004A368);
+int* func_8004A368(Instance* instance, int arg1) {
+    int* list;
+    int* result;
+
+    result = NULL;
+    list = (int*)((int*)instance->intro)[1];
+    if (list != NULL) {
+        if (arg1 < list[0]) {
+            result = (int*)list[arg1 + 1];
+            result = (int*)((int*)result)[9];
+        }
+    }
+    return result;
+}
 
 INCLUDE_ASM("asm/nonmatchings/_4a780", func_8004A3B4);
 
-INCLUDE_ASM("asm/nonmatchings/_4a780", func_8004A420);
+int func_8004A420(Instance* instance, int* list) {
+    int i;
+    int count;
+    int* entries;
+    int result;
 
-INCLUDE_ASM("asm/nonmatchings/_4a780", func_8004A47C);
+    result = 0;
+    if (instance != NULL && list != NULL) {
+        count = list[0];
+        entries = list + 1;
+        for (i = 0; i < count; i++) {
+            if (instance == (Instance*)((int*)entries[0])[9]) {
+                result = 1;
+                break;
+            }
+            entries++;
+        }
+    }
+    return result;
+}
 
-INCLUDE_ASM("asm/nonmatchings/_4a780", func_8004A4E4);
+void func_8004A47C(Instance* instance) {
+    int groupId;
+
+    instance->flags |= 0x1000;
+    groupId = INSTANCE_InstanceGroupNumber(instance);
+    LIST_DeleteFunc(instance);
+    LIST_InsertFunc((char*)gameTracker8->instanceList + groupId * 8 + 0xC, instance);
+}
+
+void func_8004A4E4(Instance* instance) {
+    int groupId;
+
+    instance->flags &= ~0x1000;
+    groupId = INSTANCE_InstanceGroupNumber(instance);
+    LIST_DeleteFunc(instance);
+    LIST_InsertFunc((char*)gameTracker8->instanceList + groupId * 8 + 0xC, instance);
+}
 
 void INSTANCE_InsertInstanceWithFlagsSet(Instance* instance, int flags) {
     int groupId;
@@ -46,27 +92,88 @@ void INSTANCE_InsertInstanceWithFlagsCleared(Instance* instance, int flags) {
     LIST_InsertFunc(&gameTracker8->instanceList->group[groupId], &instance->node);
 }
 
-INCLUDE_ASM("asm/nonmatchings/_4a780", func_8004A61C);
+int func_8004A61C(Instance* instance) {
+    int result;
+    int* object;
+    unsigned char anim;
 
-INCLUDE_ASM("asm/nonmatchings/_4a780", func_8004A67C);
+    result = -1;
+    if (instance != NULL) {
+        object = (int*)instance->object;
+        if (object != NULL) {
+            anim = ((unsigned char*)instance->_40)[0xe];
+            if (anim < ((short*)object)[5]) {
+                object = (int*)((int*)object)[4];
+                if (object != NULL) {
+                    result = ((short*)((int*)object[anim])[0])[1];
+                }
+            }
+        }
+    }
+    return result;
+}
+
+int func_8004A67C(Instance* instance) {
+    int next;
+    int max;
+
+    next = -1;
+    if (instance != NULL) {
+        next = instance->currentAnimFrame + 1;
+        max = func_8004A61C(instance);
+        if (next >= max) {
+            next = max - 1;
+        }
+    }
+    return next;
+}
 
 INCLUDE_ASM("asm/nonmatchings/_4a780", func_8004A6C8);
 
-INCLUDE_ASM("asm/nonmatchings/_4a780", func_8004A7B8);
+int func_8004A7B8(Instance* instance, int arg1, int arg2) {
+    int result;
+
+    result = -1;
+    if (instance != NULL) {
+        if (arg1 < ((short*)instance->object)[5]) {
+            result = arg1 & 0xFF;
+            instance->currentModelAnim = arg1;
+            instance->flags2 &= ~0x10;
+            func_8004A6C8(instance, arg2, 0);
+        }
+    }
+    return result;
+}
 
 INCLUDE_ASM("asm/nonmatchings/_4a780", func_8004A820);
 
 INCLUDE_ASM("asm/nonmatchings/_4a780", func_8004A8A8);
 
-INCLUDE_ASM("asm/nonmatchings/_4a780", func_8004A98C);
+void func_8004A98C(Instance* instance, short* arg1, unsigned short* arg2, int arg3) {
+    int i;
+
+    instance->_B8 = (int)arg1;
+    for (i = 0; i < arg3; i++) {
+        arg1[3] = arg2[0];
+        arg2++;
+        arg1 += 4;
+    }
+    arg1[3] = -1;
+}
 
 INCLUDE_ASM("asm/nonmatchings/_4a780", func_8004A9C8);
 
-INCLUDE_ASM("asm/nonmatchings/_4a780", func_8004AA38);
+void func_8004AA38(Instance* instance, SVector pos) {
+    func_8004A9C8(instance, pos.x, pos.y, pos.z, pos.pad);
+}
 
-INCLUDE_ASM("asm/nonmatchings/_4a780", func_8004AA70);
+void func_8004AA70(Instance* instance, short* arg1, short arg2) {
+    func_8004A9C8(instance, arg1[0], arg1[1], arg1[2], arg2);
+}
 
-INCLUDE_ASM("asm/nonmatchings/_4a780", func_8004AAA8);
+void func_8004AAA8(Instance* instance, unsigned short arg1, short arg2) {
+    func_80050508(instance, arg1, arg2, 0x5A, 0xBB8);
+}
 
 int func_8004AADC(void) {
     return 0;
@@ -93,7 +200,16 @@ int func_8004AC10(int *arg0, int unused, int arg2, int arg3) {
     }
 }
 
-INCLUDE_ASM("asm/nonmatchings/_4a780", func_8004AC78);
+void func_8004AC78(Instance* instance, int arg1) {
+    int* list;
+
+    if (arg1 != 0) {
+        list = (int*)instance->object->animList[instance->currentModel];
+        if (list[0] != arg1) {
+            list[0] = arg1;
+        }
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/_4a780", func_8004ACB0);
 
@@ -107,9 +223,43 @@ INCLUDE_ASM("asm/nonmatchings/_4a780", func_8004B090);
 
 INCLUDE_ASM("asm/nonmatchings/_4a780", func_8004B23C);
 
-INCLUDE_ASM("asm/nonmatchings/_4a780", func_8004B2DC);
+unsigned int func_8004B2DC(unsigned int arg0) {
+    unsigned int result;
+    unsigned int remainder;
+    int i;
 
-INCLUDE_ASM("asm/nonmatchings/_4a780", func_8004B32C);
+    result = 0;
+    remainder = 0;
+    for (i = 0xF; i >= 0; i--) {
+        remainder = (remainder << 2) | (arg0 >> 30);
+        arg0 <<= 2;
+        result <<= 1;
+        if (remainder >= (result * 2 + 1)) {
+            remainder -= (result * 2 + 1);
+            result++;
+        }
+    }
+    return result;
+}
+
+unsigned int func_8004B32C(unsigned int arg0, int arg1) {
+    unsigned int result;
+    unsigned int remainder;
+    int i;
+
+    result = 0;
+    remainder = 0;
+    for (i = (arg1 >> 1) + 0xF; i >= 0; i--) {
+        remainder = (remainder << 2) | (arg0 >> 30);
+        arg0 <<= 2;
+        result <<= 1;
+        if (remainder >= (result * 2 + 1)) {
+            remainder -= (result * 2 + 1);
+            result++;
+        }
+    }
+    return result;
+}
 
 INCLUDE_ASM("asm/nonmatchings/_4a780", func_8004B380);
 
@@ -403,4 +553,19 @@ INCLUDE_ASM("asm/nonmatchings/_4a780", func_8004C040);
 
 INCLUDE_ASM("asm/nonmatchings/_4a780", func_8004C110);
 
-INCLUDE_ASM("asm/nonmatchings/_4a780", func_8004C2F4);
+void func_8004C2F4(Instance* instance) {
+    int* list;
+    int* entry;
+    short i;
+
+    list = (int*)instance->data;
+    if (list != NULL) {
+        entry = list + 1;
+        if (list[0] > 0) {
+            for (i = 0; i < list[0]; i++) {
+                entry[2] = 1;
+                entry += 3;
+            }
+        }
+    }
+}

--- a/src/_4f810.c
+++ b/src/_4f810.c
@@ -16,7 +16,21 @@ INCLUDE_RODATA("asm/nonmatchings/_4f810", D_8007EAF0);
 
 INCLUDE_ASM("asm/nonmatchings/_4f810", func_8004EC10);
 
-INCLUDE_ASM("asm/nonmatchings/_4f810", func_8004EF70);
+extern short D_8007865E;
+extern int D_80157508[];
+
+void func_8004EF70(void) {
+    int idx;
+    int* entry;
+
+    idx = D_8007865E;
+    if (idx != -1) {
+        D_8007865E = -1;
+        entry = &D_80157508[idx * 5];
+        SIGNAL_HandleSignal((void*)entry[1], entry[4], 0);
+        entry[0] = 0;
+    }
+}
 
 void func_8004EFD0() {
     int* temp_a0;

--- a/src/_532f0.c
+++ b/src/_532f0.c
@@ -1,6 +1,21 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/nonmatchings/_532f0", func_800526F0);
+extern int D_8015483C;
+extern char D_80154833;
+extern int D_80154840;
+extern int D_800E5CE0;
+
+void func_800526F0(void) {
+    D_80154838 = -1;
+    D_8015483C = -1;
+    D_80154833 = 1;
+    D_80154840 = 0;
+    D_80154831 = 0;
+    D_80154830 = 0;
+    D_800E5CE0 = 0;
+    D_80156854 = 0x4B0;
+    func_80052954();
+}
 
 INCLUDE_ASM("asm/nonmatchings/_532f0", func_80052758);
 
@@ -14,13 +29,42 @@ void func_80052944(void) {
 void func_8005294C(void) {
 }
 
-INCLUDE_ASM("asm/nonmatchings/_532f0", func_80052954);
+extern int D_80156854;
+extern int D_80156858;
+extern int D_8015686C;
+extern int D_80156870;
+extern int D_80156874;
+extern int D_80156878;
+extern char D_80154832;
+extern int D_80154838;
+
+void func_80052954(void) {
+    D_80156854 = 0x4B0;
+    D_80154834 = 0;
+    D_80156870 = 0;
+    D_8015686C = 0;
+    D_80156878 = 0;
+    D_80156874 = 0;
+    D_80156858 = 0;
+    D_80154832 = 0;
+    D_80154838 = -1;
+}
 
 INCLUDE_ASM("asm/nonmatchings/_532f0", func_800529A8);
 
-INCLUDE_ASM("asm/nonmatchings/_532f0", func_80052A7C);
+extern int D_80154834;
 
-INCLUDE_ASM("asm/nonmatchings/_532f0", func_80052AA8);
+void func_80052A7C(int arg0) {
+    if (D_80154834 == 0) {
+        func_80052D18(arg0, 7);
+    }
+}
+
+void func_80052AA8(int arg0) {
+    if (func_80052FB8() != 0) {
+        func_80052ADC(arg0);
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/_532f0", func_80052ADC);
 
@@ -68,9 +112,20 @@ INCLUDE_ASM("asm/nonmatchings/_532f0", func_80052C2C);
 
 INCLUDE_ASM("asm/nonmatchings/_532f0", func_80052D18);
 
-INCLUDE_ASM("asm/nonmatchings/_532f0", func_80052F58);
+extern char D_80154831;
 
-INCLUDE_ASM("asm/nonmatchings/_532f0", func_80052F7C);
+void func_80052F58(void) {
+    if (D_80154830 == 0) {
+        D_80154831 = 1;
+    }
+}
+
+void func_80052F7C(void) {
+    if (D_80154830 != 0) {
+        D_80154830 = D_80154830 - 1;
+    }
+    D_80154831 = 0;
+}
 
 extern char D_80154830;
 void func_80052FAC()

--- a/src/_7fb0.c
+++ b/src/_7fb0.c
@@ -24,7 +24,9 @@ INCLUDE_RODATA("asm/nonmatchings/_7fb0", D_8007B7B0);
 
 INCLUDE_ASM("asm/nonmatchings/_7fb0", func_80007D68);
 
-INCLUDE_ASM("asm/nonmatchings/_7fb0", func_8000853C);
+void func_8000853C(int arg0, int arg1, int arg2, int arg3, int arg4, int arg5, int arg6, int arg7, int arg8) {
+    func_80007D68(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
+}
 
 INCLUDE_ASM("asm/nonmatchings/_7fb0", func_80008580);
 


### PR DESCRIPTION
- Decompiled 110+ functions across 24 source files, all 100% matching
- Core game functions: _24cf0.c, _287a0.c, _47260.c, _4a780.c, 1BA60.c, 161C0.c, CAMERA.c, MATH3D.c, 38670.c, _2cd50.c, _532f0.c, 4FC20.c, and more
- Function types: wrappers, initializers, conditionals, physics, animation, memory allocation, collision handlers, sound effects
- Used proper Instance*/GameTracker* types, includes (INSTANCE.h), and instance->currentModelAnim field name
- ROM diff confirms no differences, no new build warnings