### PR TITLE
Decompile 6 functions (verified with clean builds)

### DIFF
--- a/src/_2cd50.c
+++ b/src/_2cd50.c
@@ -8,9 +8,17 @@ void func_8002C18C(int arg0) {
     D_800EB80C[arg0 * 6] = 4;
 }
 
-INCLUDE_ASM("asm/nonmatchings/_2cd50", func_8002C1AC);
+void func_8002C1AC(int arg0) {
+    func_8002C18C(arg0);
+    D_800EB80C[arg0 * 6] = 5;
+}
 
-INCLUDE_ASM("asm/nonmatchings/_2cd50", func_8002C1EC);
+void func_8002C1EC(void) {
+    int i;
+    for (i = 0; i < 7; i++) {
+        func_8002C18C(i);
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/_2cd50", func_8002C224);
 

--- a/src/_4a780.c
+++ b/src/_4a780.c
@@ -62,11 +62,17 @@ INCLUDE_ASM("asm/nonmatchings/_4a780", func_8004A98C);
 
 INCLUDE_ASM("asm/nonmatchings/_4a780", func_8004A9C8);
 
-INCLUDE_ASM("asm/nonmatchings/_4a780", func_8004AA38);
+void func_8004AA38(Instance* instance, SVector pos) {
+    func_8004A9C8(instance, pos.x, pos.y, pos.z, pos.pad);
+}
 
-INCLUDE_ASM("asm/nonmatchings/_4a780", func_8004AA70);
+void func_8004AA70(Instance* instance, short* arg1, short arg2) {
+    func_8004A9C8(instance, arg1[0], arg1[1], arg1[2], arg2);
+}
 
-INCLUDE_ASM("asm/nonmatchings/_4a780", func_8004AAA8);
+void func_8004AAA8(Instance* instance, unsigned short arg1, short arg2) {
+    func_80050508(instance, arg1, arg2, 0x5A, 0xBB8);
+}
 
 int func_8004AADC(void) {
     return 0;

--- a/src/_7fb0.c
+++ b/src/_7fb0.c
@@ -24,7 +24,9 @@ INCLUDE_RODATA("asm/nonmatchings/_7fb0", D_8007B7B0);
 
 INCLUDE_ASM("asm/nonmatchings/_7fb0", func_80007D68);
 
-INCLUDE_ASM("asm/nonmatchings/_7fb0", func_8000853C);
+void func_8000853C(int arg0, int arg1, int arg2, int arg3, int arg4, int arg5, int arg6, int arg7, int arg8) {
+    func_80007D68(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
+}
 
 INCLUDE_ASM("asm/nonmatchings/_7fb0", func_80008580);
 


### PR DESCRIPTION
- 6 functions decompiled and verified with `make clean && make split && make build && make diff`
- func_8002C1AC, func_8002C1EC (_2cd50.c) - loop/wrapper
- func_8004AA38, func_8004AA70, func_8004AAA8 (_4a780.c) - wrappers
- func_8000853C (_7fb0.c) - 9-arg passthrough wrapper
- All verified with full clean builds to prevent CI failures