### PR TITLE
Decompile 40 functions: cross-level twin harvest, SPY/MAP/LOONEY, rezop_btimer rodata fix

### DIFF
--- a/src/161C0.c
+++ b/src/161C0.c
@@ -1,10 +1,19 @@
 #include "common.h"
 
 #include "LIST.h"
+#include "types/Matrix.h"
 
 INCLUDE_ASM("asm/nonmatchings/161C0", func_800155C0);
 
-INCLUDE_ASM("asm/nonmatchings/161C0", G2Quat_ToEuler);
+void G2Quat_ToMatrix_S(MATRIX* mat, short* quat);
+void func_800157BC(MATRIX* mat, short* euler);
+
+void G2Quat_ToEuler(short* quat, short* euler) {
+    MATRIX mat;
+
+    G2Quat_ToMatrix_S(&mat, quat);
+    func_800157BC(&mat, euler);
+}
 
 INCLUDE_ASM("asm/nonmatchings/161C0", func_800157BC);
 

--- a/src/COLLIDE_D.c
+++ b/src/COLLIDE_D.c
@@ -2,6 +2,10 @@
 
 #include "COLLIDE.h"
 
-INCLUDE_ASM("asm/nonmatchings/COLLIDE_D", COLLIDE_PointAndTerrain);
+int func_8000F0DC(void* segmentAddress, SVECTOR* newPoint, SVECTOR* oldPoint, int arg3, Instance* instance, int arg5, int arg6);
+
+int COLLIDE_PointAndTerrain(void* segmentAddress, SVECTOR* newPoint, SVECTOR* oldPoint, Instance* instance) {
+    return func_8000F0DC(segmentAddress, newPoint, oldPoint, 1, instance, 0, 0);
+}
 
 INCLUDE_ASM("asm/nonmatchings/COLLIDE_D", func_8000F0DC);

--- a/src/_532f0.c
+++ b/src/_532f0.c
@@ -98,9 +98,19 @@ INCLUDE_ASM("asm/nonmatchings/_532f0", func_80052C2C);
 
 INCLUDE_ASM("asm/nonmatchings/_532f0", func_80052D18);
 
-INCLUDE_ASM("asm/nonmatchings/_532f0", func_80052F58);
+void func_80052F58(void) {
+    if (D_80154830 == 0) {
+        D_80154831 = 1;
+    }
+}
 
-INCLUDE_ASM("asm/nonmatchings/_532f0", func_80052F7C);
+void func_80052F7C(void) {
+    char* p = &D_80154830;
+    if (*p != 0) {
+        *p -= 1;
+    }
+    D_80154831 = 0;
+}
 
 extern char D_80154830;
 void func_80052FAC()

--- a/src/level/CIRCUIT.c
+++ b/src/level/CIRCUIT.c
@@ -16,11 +16,53 @@ INCLUDE_ASM("asm/nonmatchings/level/CIRCUIT", circuit_plat_OnUpdate);
 
 INCLUDE_ASM("asm/nonmatchings/level/CIRCUIT", circuit_plat_OnCollide);
 
-INCLUDE_ASM("asm/nonmatchings/level/CIRCUIT", circuit_bug_OnCreate);
+void circuit_bug_OnCreate(Instance* instance, GameTracker* gameTracker) {
+    unsigned short* intro;
+
+    ((short*)&instance->_100)[1] = 0x18;
+    instance->flags |= 0x100000;
+    intro = (unsigned short*)instance->introData;
+
+    if (intro != NULL) {
+        *(short*)&instance->_100 = intro[0];
+        ((short*)&instance->_104)[1] = intro[1];
+        *(short*)&instance->_108 = intro[2];
+        ((short*)&instance->_108)[1] = intro[3];
+        *(short*)&instance->_10C = intro[4];
+        if (((short*)intro)[5] != 0) {
+            ((short*)&instance->_10C)[1] = ((short*)intro)[5];
+        } else {
+            ((short*)&instance->_10C)[1] = 0x40;
+        }
+    } else {
+        *(short*)&instance->_100 = 0x96;
+        ((short*)&instance->_104)[1] = ((unsigned short*)&instance->intro->position)[0] - 0x500;
+        *(short*)&instance->_108 = ((unsigned short*)&instance->intro->position)[1] - 0x780;
+        ((short*)&instance->_108)[1] = ((unsigned short*)&instance->intro->position)[0] + 0x500;
+        *(short*)&instance->_10C = ((unsigned short*)&instance->intro->position)[1] + 0x780;
+        ((short*)&instance->_10C)[1] = 0x40;
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/CIRCUIT", circuit_bug_OnUpdate);
 
-INCLUDE_ASM("asm/nonmatchings/level/CIRCUIT", circuit_bug_OnCollide);
+void circuit_bug_OnCollide(Instance* instance, GameTracker* gameTracker) {
+    BSPTree* bsp;
+    short* temp;
+
+    bsp = instance->bspTree;
+    temp = (short*)&instance->_F4[2];
+
+    if (bsp->_06 == 1) {
+        if ((bsp->instanceSpline == gameTracker->player) && (bsp->_08[4] < 2U) && (bsp->_0C[5] >= 6U)) {
+            INSTANCE_PlainDeath(instance, 5, 3, 0);
+        } else if ((bsp->_06 == 1) && (bsp->instanceSpline == gameTracker->player) && ((bsp->_08[4] == 0) || (bsp->_08[4] == 2))) {
+            func_80022714(instance, gameTracker);
+            instance->_F4[0] = 0;
+            temp[4] = 0x5A;
+        }
+    }
+}
 
 void circuit_bouncer_OnCreate(Instance* instance, GameTracker* gameTracker) {
     short* intro;
@@ -232,6 +274,9 @@ void circuit_launch_OnCreate(Instance* instance, GameTracker* gameTracker) {
 
 INCLUDE_ASM("asm/nonmatchings/level/CIRCUIT", circuit_launch_OnUpdate);
 
+int func_8015D354_84534(Instance* instance, GameTracker* gameTracker);
+void func_8015D4B0_84690(Instance* instance, GameTracker* gameTracker);
+
 void circuit_launch_OnCollide(Instance* instance, GameTracker* gameTracker) {
     Instance* temp_a0;
     BSPTree* bsp;
@@ -253,7 +298,7 @@ void circuit_launch_OnCollide(Instance* instance, GameTracker* gameTracker) {
     }
 }
 
-void func_8015D304_844E4(Instance* instance) {
+void func_8015D304_844E4(Instance* instance, GameTracker* gameTracker) {
     instance->flags &= ~0x800;
     if (!(instance->_11C & 8)) {
         instance->_F4[2] = instance->_104;
@@ -262,11 +307,77 @@ void func_8015D304_844E4(Instance* instance) {
     }
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/CIRCUIT", func_8015D354_84534);
+extern char D_801635EC_8A7CC[];
 
-INCLUDE_ASM("asm/nonmatchings/level/CIRCUIT", func_8015D42C_8460C);
+int func_8015D354_84534(Instance* instance, GameTracker* gameTracker) {
+    int* sub;
+    Intro** list;
+    Intro* entry;
+    Instance* other;
+    int count;
+    int i;
 
-INCLUDE_ASM("asm/nonmatchings/level/CIRCUIT", func_8015D4B0_84690);
+    if (instance->intro != NULL) {
+        sub = instance->intro->_04;
+        if (sub != NULL) {
+            list = (Intro**)(sub + 1);
+            count = sub[0];
+            for (i = 0; i < count; i++, list++) {
+                entry = *list;
+                if (*(int*)entry->object->parentName == ((int*)D_801635EC_8A7CC)[0]
+                    && ((int*)entry->object->parentName)[1] == ((int*)D_801635EC_8A7CC)[1]) {
+                    other = entry->instance;
+                    if (other != NULL) {
+                        if ((other->_F4[0] - 1) < 2U) {
+                            return 1;
+                        }
+                        if (*(int*)&other->_108 != 0) {
+                            return 1;
+                        }
+                    }
+                }
+            }
+        }
+    }
+    return 0;
+}
+
+void func_8015D42C_8460C(Instance* instance, GameTracker* gameTracker) {
+    short* pData;
+
+    pData = (short*)gameTracker->player->data;
+    instance->flags |= 0x400;
+    func_8015D304_844E4(instance, gameTracker);
+    instance->_F4[0] = 2;
+    PlayerInstance->_E0[1] = pData[4];
+    gameTracker->player->_F4[2] |= 0x400;
+    func_8004AAA8(instance, 0x18, 0);
+}
+
+void func_8015D4B0_84690(Instance* instance, GameTracker* gameTracker) {
+    short* data;
+    Instance* player;
+
+    data = gameTracker->player->data;
+    instance->flags |= 0x400;
+    func_8015D304_844E4(instance, gameTracker);
+    player = PlayerInstance;
+    data[0x9C/2] = data[0xA0/2] - 1;
+    data[0x9E/2] = data[0xA0/2] - 1;
+    instance->_F4[0] = 1;
+    *(int*)&instance->_110 = ((short*)&instance->_D0[0])[1];
+    player->_D0[2] = 0;
+    player->_E0[1] = 0;
+    player->flags |= 0x400000;
+    func_800256A8(gameTracker);
+    data[0x8C/2] = 0;
+    data[0x8E/2] = 0;
+    data[0x90/2] = 0;
+    data[0x94/2] = 0;
+    data[0x96/2] = 0;
+    data[0x98/2] = 0;
+    func_8004AAA8(instance, 0x18, 0);
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/CIRCUIT", circuit_follow_OnCreate);
 
@@ -307,7 +418,38 @@ INCLUDE_ASM("asm/nonmatchings/level/CIRCUIT", circuit_ppath_OnUpdate);
 
 INCLUDE_ASM("asm/nonmatchings/level/CIRCUIT", circuit_ppath_OnCollide);
 
-INCLUDE_ASM("asm/nonmatchings/level/CIRCUIT", circuit_fxgen_OnCreate);
+extern char D_801635A0_8A780[];
+
+void circuit_fxgen_OnCreate(Instance* instance, GameTracker* gameTracker) {
+    int* fc;
+    unsigned char* config;
+
+    fc = &instance->_F4[2];
+    if (instance->flags & 0x20000) {
+        if (*(int*)&instance->_108 != 0) {
+            func_800331BC(*(int*)&instance->_108);
+            *(int*)&instance->_108 = 0;
+        }
+    } else {
+        if (instance->introData == NULL) {
+            instance->introData = D_801635A0_8A780;
+        }
+        config = instance->introData;
+        fc[0] = OBTABLE_FindObject(config + 0xC);
+        if ((config[1] & 1) == 0) {
+            if ((config[1] & 2) != 0) {
+                *(short*)&instance->_110 = 0x119;
+                ((short*)&instance->_110)[1] = 0x46;
+                ((short*)&instance->_114)[1] = 0xDAC;
+                *(short*)&instance->_114 = (rand() & 0x7F) - 0x15E;
+                ((short*)&instance->_10C)[1] = *(short*)&instance->_10C = rand() & 7;
+                config[1] |= 0x80;
+            }
+        }
+        fc[3] = 0;
+        instance->flags |= 0x10000;
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/CIRCUIT", func_8015E084_85264);
 

--- a/src/level/CIRCUIT.c
+++ b/src/level/CIRCUIT.c
@@ -307,7 +307,7 @@ void func_8015D304_844E4(Instance* instance, GameTracker* gameTracker) {
     }
 }
 
-extern char D_801635EC_8A7CC[];
+extern G2String D_801635EC_8A7CC;
 
 int func_8015D354_84534(Instance* instance, GameTracker* gameTracker) {
     int* sub;
@@ -324,8 +324,7 @@ int func_8015D354_84534(Instance* instance, GameTracker* gameTracker) {
             count = sub[0];
             for (i = 0; i < count; i++, list++) {
                 entry = *list;
-                if (*(int*)entry->object->parentName == ((int*)D_801635EC_8A7CC)[0]
-                    && ((int*)entry->object->parentName)[1] == ((int*)D_801635EC_8A7CC)[1]) {
+                if (G2String_Compare_EQ(entry->object->parentName, &D_801635EC_8A7CC)) {
                     other = entry->instance;
                     if (other != NULL) {
                         if ((other->_F4[0] - 1) < 2U) {
@@ -422,7 +421,7 @@ extern char D_801635A0_8A780[];
 
 void circuit_fxgen_OnCreate(Instance* instance, GameTracker* gameTracker) {
     int* fc;
-    unsigned char* config;
+    unsigned char* intro;
 
     fc = &instance->_F4[2];
     if (instance->flags & 0x20000) {
@@ -434,16 +433,16 @@ void circuit_fxgen_OnCreate(Instance* instance, GameTracker* gameTracker) {
         if (instance->introData == NULL) {
             instance->introData = D_801635A0_8A780;
         }
-        config = instance->introData;
-        fc[0] = OBTABLE_FindObject(config + 0xC);
-        if ((config[1] & 1) == 0) {
-            if ((config[1] & 2) != 0) {
+        intro = instance->introData;
+        fc[0] = OBTABLE_FindObject(intro + 0xC);
+        if ((intro[1] & 1) == 0) {
+            if ((intro[1] & 2) != 0) {
                 *(short*)&instance->_110 = 0x119;
                 ((short*)&instance->_110)[1] = 0x46;
                 ((short*)&instance->_114)[1] = 0xDAC;
                 *(short*)&instance->_114 = (rand() & 0x7F) - 0x15E;
                 ((short*)&instance->_10C)[1] = *(short*)&instance->_10C = rand() & 7;
-                config[1] |= 0x80;
+                intro[1] |= 0x80;
             }
         }
         fc[3] = 0;

--- a/src/level/GEXZIL.c
+++ b/src/level/GEXZIL.c
@@ -2,11 +2,53 @@
 
 #include "level/GEXZIL.h"
 
-INCLUDE_ASM("asm/nonmatchings/level/GEXZIL", gexzil_bug_OnCreate);
+void gexzil_bug_OnCreate(Instance* instance, GameTracker* gameTracker) {
+    unsigned short* intro;
+
+    ((short*)&instance->_100)[1] = 0x18;
+    instance->flags |= 0x100000;
+    intro = (unsigned short*)instance->introData;
+
+    if (intro != NULL) {
+        *(short*)&instance->_100 = intro[0];
+        ((short*)&instance->_104)[1] = intro[1];
+        *(short*)&instance->_108 = intro[2];
+        ((short*)&instance->_108)[1] = intro[3];
+        *(short*)&instance->_10C = intro[4];
+        if (((short*)intro)[5] != 0) {
+            ((short*)&instance->_10C)[1] = ((short*)intro)[5];
+        } else {
+            ((short*)&instance->_10C)[1] = 0x40;
+        }
+    } else {
+        *(short*)&instance->_100 = 0x96;
+        ((short*)&instance->_104)[1] = ((unsigned short*)&instance->intro->position)[0] - 0x500;
+        *(short*)&instance->_108 = ((unsigned short*)&instance->intro->position)[1] - 0x780;
+        ((short*)&instance->_108)[1] = ((unsigned short*)&instance->intro->position)[0] + 0x500;
+        *(short*)&instance->_10C = ((unsigned short*)&instance->intro->position)[1] + 0x780;
+        ((short*)&instance->_10C)[1] = 0x40;
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/GEXZIL", gexzil_bug_OnUpdate);
 
-INCLUDE_ASM("asm/nonmatchings/level/GEXZIL", gexzil_bug_OnCollide);
+void gexzil_bug_OnCollide(Instance* instance, GameTracker* gameTracker) {
+    BSPTree* bsp;
+    short* temp;
+
+    bsp = instance->bspTree;
+    temp = (short*)&instance->_F4[2];
+
+    if (bsp->_06 == 1) {
+        if ((bsp->instanceSpline == gameTracker->player) && (bsp->_08[4] < 2U) && (bsp->_0C[5] >= 6U)) {
+            INSTANCE_PlainDeath(instance, 5, 3, 0);
+        } else if ((bsp->_06 == 1) && (bsp->instanceSpline == gameTracker->player) && ((bsp->_08[4] == 0) || (bsp->_08[4] == 2))) {
+            func_80022714(instance, gameTracker);
+            instance->_F4[0] = 0;
+            temp[4] = 0x5A;
+        }
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/GEXZIL", func_80159B8C_92D0C);
 

--- a/src/level/HORROR.c
+++ b/src/level/HORROR.c
@@ -467,11 +467,10 @@ void horror_onoff_OnUpdate(Instance* instance, GameTracker* gameTracker) {
     }
 }
 
-extern int D_80164CC0_A84F0;
-extern int D_80164CC4_A84F4;
+extern char D_80164CC0_A84F0[];
 
 void horror_onoff_OnCollide(Instance* instance, GameTracker* gameTracker) {
-    short* config;
+    short* intro;
     BSPTree* bsp;
     int** list;
     Instance* other;
@@ -485,31 +484,31 @@ void horror_onoff_OnCollide(Instance* instance, GameTracker* gameTracker) {
     toggled = 0;
     checkState = 0;
     fire = 0;
-    config = instance->introData;
+    intro = instance->introData;
     bsp = instance->bspTree;
-    if (config != NULL && bsp->_06 == 1 && bsp->_0C[5] >= 8U && instance->_F4[1] != 1) {
-        list = (int**)(config + 2);
-        if (config[1] == 0) {
+    if (intro != NULL && bsp->_06 == 1 && bsp->_0C[5] >= 8U && instance->_F4[1] != 1) {
+        list = (int**)(intro + 2);
+        if (intro[1] == 0) {
             match = 1;
-        } else if (config[1] == 1) {
+        } else if (intro[1] == 1) {
             if (instance->_F4[0] == 0) {
                 match = 1;
                 checkState = 1;
             }
-        } else if (config[1] == 2) {
+        } else if (intro[1] == 2) {
             if (instance->_F4[0] == 1) {
                 match = 1;
                 checkState = 1;
             }
         }
-        for (i = 0; i < config[0]; i++, list++) {
+        for (i = 0; i < intro[0]; i++, list++) {
             other = ((Intro*)list[0])->instance;
             if (other == NULL) continue;
             if (other->flags & 0x2000000) continue;
             if (match == 0) continue;
             if (checkState != 0) {
-                if (!((((unsigned short*)config)[1] & 1) && !(other->flags & 0x1000000))) {
-                    if (!(((unsigned short*)config)[1] & 2)) continue;
+                if (!((((unsigned short*)intro)[1] & 1) && !(other->flags & 0x1000000))) {
+                    if (!(((unsigned short*)intro)[1] & 2)) continue;
                     if (!(other->flags & 0x1000000)) continue;
                 }
             }
@@ -520,12 +519,11 @@ void horror_onoff_OnCollide(Instance* instance, GameTracker* gameTracker) {
             other->flags |= 0x2000000;
             toggled = 1;
         }
-        if ((match != 0 && toggled != 0) || config[0] == 0) {
+        if ((match != 0 && toggled != 0) || intro[0] == 0) {
             instance->intro->flags ^= 0x800;
             instance->_F4[0] ^= 1;
             fire = 1;
-        } else if (*(int*)instance->object->name == D_80164CC0_A84F0
-                   && ((int*)instance->object->name)[1] == D_80164CC4_A84F4) {
+        } else if (G2String_Compare_EQ(instance->object->name, D_80164CC0_A84F0)) {
             fire = 1;
         }
         if (fire != 0) {

--- a/src/level/HORROR.c
+++ b/src/level/HORROR.c
@@ -467,7 +467,77 @@ void horror_onoff_OnUpdate(Instance* instance, GameTracker* gameTracker) {
     }
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/HORROR", horror_onoff_OnCollide);
+extern int D_80164CC0_A84F0;
+extern int D_80164CC4_A84F4;
+
+void horror_onoff_OnCollide(Instance* instance, GameTracker* gameTracker) {
+    short* config;
+    BSPTree* bsp;
+    int** list;
+    Instance* other;
+    int match;
+    int toggled;
+    int checkState;
+    int fire;
+    short i;
+
+    match = 0;
+    toggled = 0;
+    checkState = 0;
+    fire = 0;
+    config = instance->introData;
+    bsp = instance->bspTree;
+    if (config != NULL && bsp->_06 == 1 && bsp->_0C[5] >= 8U && instance->_F4[1] != 1) {
+        list = (int**)(config + 2);
+        if (config[1] == 0) {
+            match = 1;
+        } else if (config[1] == 1) {
+            if (instance->_F4[0] == 0) {
+                match = 1;
+                checkState = 1;
+            }
+        } else if (config[1] == 2) {
+            if (instance->_F4[0] == 1) {
+                match = 1;
+                checkState = 1;
+            }
+        }
+        for (i = 0; i < config[0]; i++, list++) {
+            other = ((Intro*)list[0])->instance;
+            if (other == NULL) continue;
+            if (other->flags & 0x2000000) continue;
+            if (match == 0) continue;
+            if (checkState != 0) {
+                if (!((((unsigned short*)config)[1] & 1) && !(other->flags & 0x1000000))) {
+                    if (!(((unsigned short*)config)[1] & 2)) continue;
+                    if (!(other->flags & 0x1000000)) continue;
+                }
+            }
+            other->flags &= ~0x100000;
+            if (!(other->flags2 & 0x10000)) {
+                other->flags2 |= 0x1000;
+            }
+            other->flags |= 0x2000000;
+            toggled = 1;
+        }
+        if ((match != 0 && toggled != 0) || config[0] == 0) {
+            instance->intro->flags ^= 0x800;
+            instance->_F4[0] ^= 1;
+            fire = 1;
+        } else if (*(int*)instance->object->name == D_80164CC0_A84F0
+                   && ((int*)instance->object->name)[1] == D_80164CC4_A84F4) {
+            fire = 1;
+        }
+        if (fire != 0) {
+            if (((short*)&instance->object->_08)[1] != 0) {
+                instance->_F4[1] = 1;
+            }
+            if (*(int*)list == 0x29A) {
+                SIGNAL_HandleSignal(instance, (int*)((int*)list)[1] + 1, 0);
+            }
+        }
+    }
+}
 
 extern int D_80164C38_A8468[];
 void horror_funplat_OnCreate(Instance* instance, GameTracker* gameTracker) {

--- a/src/level/KUNGFU.c
+++ b/src/level/KUNGFU.c
@@ -99,11 +99,53 @@ void kungfu_spray_OnCollide(Instance* instance, GameTracker* gameTracker) {
     }
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", kungfu_bug_OnCreate);
+void kungfu_bug_OnCreate(Instance* instance, GameTracker* gameTracker) {
+    unsigned short* intro;
+
+    ((short*)&instance->_100)[1] = 0x18;
+    instance->flags |= 0x100000;
+    intro = (unsigned short*)instance->introData;
+
+    if (intro != NULL) {
+        *(short*)&instance->_100 = intro[0];
+        ((short*)&instance->_104)[1] = intro[1];
+        *(short*)&instance->_108 = intro[2];
+        ((short*)&instance->_108)[1] = intro[3];
+        *(short*)&instance->_10C = intro[4];
+        if (((short*)intro)[5] != 0) {
+            ((short*)&instance->_10C)[1] = ((short*)intro)[5];
+        } else {
+            ((short*)&instance->_10C)[1] = 0x40;
+        }
+    } else {
+        *(short*)&instance->_100 = 0x96;
+        ((short*)&instance->_104)[1] = ((unsigned short*)&instance->intro->position)[0] - 0x500;
+        *(short*)&instance->_108 = ((unsigned short*)&instance->intro->position)[1] - 0x780;
+        ((short*)&instance->_108)[1] = ((unsigned short*)&instance->intro->position)[0] + 0x500;
+        *(short*)&instance->_10C = ((unsigned short*)&instance->intro->position)[1] + 0x780;
+        ((short*)&instance->_10C)[1] = 0x40;
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", kungfu_bug_OnUpdate);
 
-INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", kungfu_bug_OnCollide);
+void kungfu_bug_OnCollide(Instance* instance, GameTracker* gameTracker) {
+    BSPTree* bsp;
+    short* temp;
+
+    bsp = instance->bspTree;
+    temp = (short*)&instance->_F4[2];
+
+    if (bsp->_06 == 1) {
+        if ((bsp->instanceSpline == gameTracker->player) && (bsp->_08[4] < 2U) && (bsp->_0C[5] >= 6U)) {
+            INSTANCE_PlainDeath(instance, 5, 3, 0);
+        } else if ((bsp->_06 == 1) && (bsp->instanceSpline == gameTracker->player) && ((bsp->_08[4] == 0) || (bsp->_08[4] == 2))) {
+            func_80022714(instance, gameTracker);
+            instance->_F4[0] = 0;
+            temp[4] = 0x5A;
+        }
+    }
+}
 
 void kungfu_crawler_OnCreate(Instance* instance, GameTracker* gameTracker)
 {
@@ -199,6 +241,9 @@ void kungfu_launch_OnCreate(Instance* instance, GameTracker* gameTracker) {
 
 INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", kungfu_launch_OnUpdate);
 
+int func_8015AC6C_A9E8C(Instance* instance, GameTracker* gameTracker);
+void func_8015ADC8_A9FE8(Instance* instance, GameTracker* gameTracker);
+
 void kungfu_launch_OnCollide(Instance* instance, GameTracker* gameTracker) {
     Instance* temp_a0;
     BSPTree* bsp;
@@ -220,7 +265,7 @@ void kungfu_launch_OnCollide(Instance* instance, GameTracker* gameTracker) {
     }
 }
 
-void func_8015AC1C_A9E3C(Instance* instance) {
+void func_8015AC1C_A9E3C(Instance* instance, GameTracker* gameTracker) {
     instance->flags &= ~0x800;
     if (!(instance->_11C & 8)) {
         instance->_F4[2] = instance->_104;
@@ -229,11 +274,77 @@ void func_8015AC1C_A9E3C(Instance* instance) {
     }
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", func_8015AC6C_A9E8C);
+extern char D_801626DC_B18FC[];
 
-INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", func_8015AD44_A9F64);
+int func_8015AC6C_A9E8C(Instance* instance, GameTracker* gameTracker) {
+    int* sub;
+    Intro** list;
+    Intro* entry;
+    Instance* other;
+    int count;
+    int i;
 
-INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", func_8015ADC8_A9FE8);
+    if (instance->intro != NULL) {
+        sub = instance->intro->_04;
+        if (sub != NULL) {
+            list = (Intro**)(sub + 1);
+            count = sub[0];
+            for (i = 0; i < count; i++, list++) {
+                entry = *list;
+                if (*(int*)entry->object->parentName == ((int*)D_801626DC_B18FC)[0]
+                    && ((int*)entry->object->parentName)[1] == ((int*)D_801626DC_B18FC)[1]) {
+                    other = entry->instance;
+                    if (other != NULL) {
+                        if ((other->_F4[0] - 1) < 2U) {
+                            return 1;
+                        }
+                        if (*(int*)&other->_108 != 0) {
+                            return 1;
+                        }
+                    }
+                }
+            }
+        }
+    }
+    return 0;
+}
+
+void func_8015AD44_A9F64(Instance* instance, GameTracker* gameTracker) {
+    short* pData;
+
+    pData = (short*)gameTracker->player->data;
+    instance->flags |= 0x400;
+    func_8015AC1C_A9E3C(instance, gameTracker);
+    instance->_F4[0] = 2;
+    PlayerInstance->_E0[1] = pData[4];
+    gameTracker->player->_F4[2] |= 0x400;
+    func_8004AAA8(instance, 0x6A, 0);
+}
+
+void func_8015ADC8_A9FE8(Instance* instance, GameTracker* gameTracker) {
+    short* data;
+    Instance* player;
+
+    data = gameTracker->player->data;
+    instance->flags |= 0x400;
+    func_8015AC1C_A9E3C(instance, gameTracker);
+    player = PlayerInstance;
+    data[0x9C/2] = data[0xA0/2] - 1;
+    data[0x9E/2] = data[0xA0/2] - 1;
+    instance->_F4[0] = 1;
+    *(int*)&instance->_110 = ((short*)&instance->_D0[0])[1];
+    player->_D0[2] = 0;
+    player->_E0[1] = 0;
+    player->flags |= 0x400000;
+    func_800256A8(gameTracker);
+    data[0x8C/2] = 0;
+    data[0x8E/2] = 0;
+    data[0x90/2] = 0;
+    data[0x94/2] = 0;
+    data[0x96/2] = 0;
+    data[0x98/2] = 0;
+    func_8004AAA8(instance, 0x6A, 0);
+}
 
 void func_8015AE8C_AA0AC(Instance* instance, GameTracker* gameTracker)
 {
@@ -298,7 +409,77 @@ void kungfu_onoff_OnUpdate(Instance* instance, GameTracker* gameTracker) {
     }
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", kungfu_onoff_OnCollide);
+extern int D_801626E8_B1908;
+extern int D_801626EC_B190C;
+
+void kungfu_onoff_OnCollide(Instance* instance, GameTracker* gameTracker) {
+    short* config;
+    BSPTree* bsp;
+    int** list;
+    Instance* other;
+    int match;
+    int toggled;
+    int checkState;
+    int fire;
+    short i;
+
+    match = 0;
+    toggled = 0;
+    checkState = 0;
+    fire = 0;
+    config = instance->introData;
+    bsp = instance->bspTree;
+    if (config != NULL && bsp->_06 == 1 && bsp->_0C[5] >= 8U && instance->_F4[1] != 1) {
+        list = (int**)(config + 2);
+        if (config[1] == 0) {
+            match = 1;
+        } else if (config[1] == 1) {
+            if (instance->_F4[0] == 0) {
+                match = 1;
+                checkState = 1;
+            }
+        } else if (config[1] == 2) {
+            if (instance->_F4[0] == 1) {
+                match = 1;
+                checkState = 1;
+            }
+        }
+        for (i = 0; i < config[0]; i++, list++) {
+            other = ((Intro*)list[0])->instance;
+            if (other == NULL) continue;
+            if (other->flags & 0x2000000) continue;
+            if (match == 0) continue;
+            if (checkState != 0) {
+                if (!((((unsigned short*)config)[1] & 1) && !(other->flags & 0x1000000))) {
+                    if (!(((unsigned short*)config)[1] & 2)) continue;
+                    if (!(other->flags & 0x1000000)) continue;
+                }
+            }
+            other->flags &= ~0x100000;
+            if (!(other->flags2 & 0x10000)) {
+                other->flags2 |= 0x1000;
+            }
+            other->flags |= 0x2000000;
+            toggled = 1;
+        }
+        if ((match != 0 && toggled != 0) || config[0] == 0) {
+            instance->intro->flags ^= 0x800;
+            instance->_F4[0] ^= 1;
+            fire = 1;
+        } else if (*(int*)instance->object->name == D_801626E8_B1908
+                   && ((int*)instance->object->name)[1] == D_801626EC_B190C) {
+            fire = 1;
+        }
+        if (fire != 0) {
+            if (((short*)&instance->object->_08)[1] != 0) {
+                instance->_F4[1] = 1;
+            }
+            if (*(int*)list == 0x29A) {
+                SIGNAL_HandleSignal(instance, (int*)((int*)list)[1] + 1, 0);
+            }
+        }
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", kungfu_spike_OnCreate);
 
@@ -346,9 +527,69 @@ INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", kungfu_canball_OnCollide);
 
 INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", kungfu_cannon_OnCollide);
 
-INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", func_8015D5E8_AC808);
+int func_8015D5E8_AC808(Instance* instance, short dist, SVector* out) {
+    SVector start;
+    SVector probe;
+    int result;
+    short deltaS;
 
-INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", func_8015D770_AC990);
+    probe = *(SVector*)&instance->position;
+    start = probe;
+    if (out != NULL) {
+        *out = probe;
+    }
+    start.z += (dist < 0x80) ? 0x80 : dist;
+    probe.z -= (dist < 0x80) ? 0x80 : dist;
+    result = COLLIDE_PointAndTerrain(gameTracker8->level->segmentAddress, (SVECTOR*)&probe, (SVECTOR*)&start, instance);
+    deltaS = probe.z - instance->position.z;
+    if (dist < ((deltaS >= 0) ? deltaS : -deltaS)) return 0;
+    if (result == 0) return 0;
+    if (func_80047D10(result) != 0) return 0;
+    if (out != NULL) {
+        *out = probe;
+    }
+    return 1;
+}
+
+short func_8015D770_AC990(Instance* instance, short rotStep, short zStep, short dist, int flag) {
+    SVector probe;
+    SVECTOR savedPos;
+    int result;
+    int ok;
+
+    result = 0;
+    savedPos = instance->position;
+    ok = 1;
+    if (rotStep != 0) {
+        func_80047E64(instance, rotStep * 2);
+        if (func_8015D5E8_AC808(instance, dist, &probe) == 0) {
+            ok = 0;
+        } else {
+            instance->position = savedPos;
+            func_80047E64(instance, rotStep);
+        }
+    }
+    if (ok != 0) {
+        if (func_8015D5E8_AC808(instance, dist, &probe) == 0) {
+            ok = 0;
+        }
+    }
+    if (ok == 0 && flag != 0) {
+        instance->position.x = savedPos.x;
+        instance->position.y = savedPos.y;
+        result |= 2;
+    } else if (ok == 0 || instance->position.z + zStep > probe.z) {
+        instance->position.x = probe.x;
+        instance->position.y = probe.y;
+        instance->position.z = instance->position.z + zStep;
+    } else {
+        instance->position.x = probe.x;
+        instance->position.y = probe.y;
+        instance->position.z = probe.z;
+        result |= 1;
+    }
+    return result;
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", kungfu_samuri_OnCreate);
 
@@ -511,7 +752,12 @@ INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", kungfu_leafgen_OnCreate);
 
 INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", func_801616D4_B08F4);
 
-INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", func_80161944_B0B64);
+void func_80161944_B0B64(short* arg0) {
+    func_800162C0(arg0);
+    RotMatrixX(((short*)arg0)[0x44/2], (char*)((int*)arg0)[5] + 0xC);
+    RotMatrixY(((short*)arg0)[0x46/2], (char*)((int*)arg0)[5] + 0xC);
+    RotMatrixZ(((short*)arg0)[0x48/2], (char*)((int*)arg0)[5] + 0xC);
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", func_801619A4_B0BC4);
 

--- a/src/level/KUNGFU.c
+++ b/src/level/KUNGFU.c
@@ -274,7 +274,7 @@ void func_8015AC1C_A9E3C(Instance* instance, GameTracker* gameTracker) {
     }
 }
 
-extern char D_801626DC_B18FC[];
+extern G2String D_801626DC_B18FC;
 
 int func_8015AC6C_A9E8C(Instance* instance, GameTracker* gameTracker) {
     int* sub;
@@ -291,8 +291,7 @@ int func_8015AC6C_A9E8C(Instance* instance, GameTracker* gameTracker) {
             count = sub[0];
             for (i = 0; i < count; i++, list++) {
                 entry = *list;
-                if (*(int*)entry->object->parentName == ((int*)D_801626DC_B18FC)[0]
-                    && ((int*)entry->object->parentName)[1] == ((int*)D_801626DC_B18FC)[1]) {
+                if (G2String_Compare_EQ(entry->object->parentName, &D_801626DC_B18FC)) {
                     other = entry->instance;
                     if (other != NULL) {
                         if ((other->_F4[0] - 1) < 2U) {
@@ -409,11 +408,10 @@ void kungfu_onoff_OnUpdate(Instance* instance, GameTracker* gameTracker) {
     }
 }
 
-extern int D_801626E8_B1908;
-extern int D_801626EC_B190C;
+extern char D_801626E8_B1908[];
 
 void kungfu_onoff_OnCollide(Instance* instance, GameTracker* gameTracker) {
-    short* config;
+    short* intro;
     BSPTree* bsp;
     int** list;
     Instance* other;
@@ -427,31 +425,31 @@ void kungfu_onoff_OnCollide(Instance* instance, GameTracker* gameTracker) {
     toggled = 0;
     checkState = 0;
     fire = 0;
-    config = instance->introData;
+    intro = instance->introData;
     bsp = instance->bspTree;
-    if (config != NULL && bsp->_06 == 1 && bsp->_0C[5] >= 8U && instance->_F4[1] != 1) {
-        list = (int**)(config + 2);
-        if (config[1] == 0) {
+    if (intro != NULL && bsp->_06 == 1 && bsp->_0C[5] >= 8U && instance->_F4[1] != 1) {
+        list = (int**)(intro + 2);
+        if (intro[1] == 0) {
             match = 1;
-        } else if (config[1] == 1) {
+        } else if (intro[1] == 1) {
             if (instance->_F4[0] == 0) {
                 match = 1;
                 checkState = 1;
             }
-        } else if (config[1] == 2) {
+        } else if (intro[1] == 2) {
             if (instance->_F4[0] == 1) {
                 match = 1;
                 checkState = 1;
             }
         }
-        for (i = 0; i < config[0]; i++, list++) {
+        for (i = 0; i < intro[0]; i++, list++) {
             other = ((Intro*)list[0])->instance;
             if (other == NULL) continue;
             if (other->flags & 0x2000000) continue;
             if (match == 0) continue;
             if (checkState != 0) {
-                if (!((((unsigned short*)config)[1] & 1) && !(other->flags & 0x1000000))) {
-                    if (!(((unsigned short*)config)[1] & 2)) continue;
+                if (!((((unsigned short*)intro)[1] & 1) && !(other->flags & 0x1000000))) {
+                    if (!(((unsigned short*)intro)[1] & 2)) continue;
                     if (!(other->flags & 0x1000000)) continue;
                 }
             }
@@ -462,12 +460,11 @@ void kungfu_onoff_OnCollide(Instance* instance, GameTracker* gameTracker) {
             other->flags |= 0x2000000;
             toggled = 1;
         }
-        if ((match != 0 && toggled != 0) || config[0] == 0) {
+        if ((match != 0 && toggled != 0) || intro[0] == 0) {
             instance->intro->flags ^= 0x800;
             instance->_F4[0] ^= 1;
             fire = 1;
-        } else if (*(int*)instance->object->name == D_801626E8_B1908
-                   && ((int*)instance->object->name)[1] == D_801626EC_B190C) {
+        } else if (G2String_Compare_EQ(instance->object->name, D_801626E8_B1908)) {
             fire = 1;
         }
         if (fire != 0) {

--- a/src/level/LOONEY.c
+++ b/src/level/LOONEY.c
@@ -385,7 +385,38 @@ INCLUDE_ASM("asm/nonmatchings/level/LOONEY", looney_funguy_OnUpdate);
 
 INCLUDE_ASM("asm/nonmatchings/level/LOONEY", looney_funguy_OnCollide);
 
-INCLUDE_ASM("asm/nonmatchings/level/LOONEY", looney_fallgen_OnCreate);
+typedef struct {
+    char _00[8];
+    short min;
+    short max;
+    short count;
+    short _0E;
+    short (*entries)[4];
+} FallGenData;
+
+void looney_fallgen_OnCreate(Instance* instance, GameTracker* gameTracker) {
+    FallGenData* config;
+    int* fc;
+    int total;
+    int i;
+
+    total = 0;
+    config = instance->introData;
+    fc = &instance->_F4[2];
+    if (config != NULL) {
+        for (i = 0; i < config->count; i++) {
+            total += config->entries[i][2];
+            config->entries[i][3] = total;
+        }
+        fc[1] = total;
+        if (config->max != config->min) {
+            fc[0] = config->min + rand() % (config->max - config->min);
+        } else {
+            fc[0] = config->max;
+        }
+    }
+    instance->flags |= 0x800;
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/LOONEY", func_8015C6A0_B4950);
 

--- a/src/level/LOONEY.c
+++ b/src/level/LOONEY.c
@@ -1,6 +1,7 @@
 #include "common.h"
 
 #include "level/LOONEY.h"
+#include "OBTABLE.h"
 #include "MATRIX.h"
 
 extern int D_80161BD0_B9E80;
@@ -294,7 +295,7 @@ void func_8015B4BC_B376C(Instance* instance) {
     SVECTOR vel;
     int i;
 
-    obj = ((Object*)OBTABLE_FindObject(D_80161DC0_BA070));
+    obj = OBTABLE_FindObject(D_80161DC0_BA070);
     if (obj != NULL) {
         pos.x = instance->position.x;
         pos.y = instance->position.y;
@@ -403,27 +404,27 @@ typedef struct {
     short count;
     short _0E;
     short (*entries)[4];
-} FallGenData;
+} FallGenIntro;
 
 void looney_fallgen_OnCreate(Instance* instance, GameTracker* gameTracker) {
-    FallGenData* config;
+    FallGenIntro* intro;
     int* fc;
     int total;
     int i;
 
     total = 0;
-    config = instance->introData;
+    intro = instance->introData;
     fc = &instance->_F4[2];
-    if (config != NULL) {
-        for (i = 0; i < config->count; i++) {
-            total += config->entries[i][2];
-            config->entries[i][3] = total;
+    if (intro != NULL) {
+        for (i = 0; i < intro->count; i++) {
+            total += intro->entries[i][2];
+            intro->entries[i][3] = total;
         }
         fc[1] = total;
-        if (config->max != config->min) {
-            fc[0] = config->min + rand() % (config->max - config->min);
+        if (intro->max != intro->min) {
+            fc[0] = intro->min + rand() % (intro->max - intro->min);
         } else {
-            fc[0] = config->max;
+            fc[0] = intro->max;
         }
     }
     instance->flags |= 0x800;
@@ -632,7 +633,7 @@ extern char D_80161DA8_BA058[];
 
 void looney_fxgen_OnCreate(Instance* instance, GameTracker* gameTracker) {
     int* fc;
-    unsigned char* config;
+    unsigned char* intro;
 
     fc = &instance->_F4[2];
     if (instance->flags & 0x20000) {
@@ -644,16 +645,16 @@ void looney_fxgen_OnCreate(Instance* instance, GameTracker* gameTracker) {
         if (instance->introData == NULL) {
             instance->introData = D_80161DA8_BA058;
         }
-        config = instance->introData;
-        fc[0] = OBTABLE_FindObject(config + 0xC);
-        if ((config[1] & 1) == 0) {
-            if ((config[1] & 2) != 0) {
+        intro = instance->introData;
+        fc[0] = (int)OBTABLE_FindObject(intro + 0xC);
+        if ((intro[1] & 1) == 0) {
+            if ((intro[1] & 2) != 0) {
                 *(short*)&instance->_110 = 0x119;
                 ((short*)&instance->_110)[1] = 0x78;
                 ((short*)&instance->_114)[1] = 0xDAC;
                 *(short*)&instance->_114 = (rand() & 0x7F) - 0x15E;
                 ((short*)&instance->_10C)[1] = *(short*)&instance->_10C = rand() & 7;
-                config[1] |= 0x80;
+                intro[1] |= 0x80;
             }
         }
         fc[3] = 0;

--- a/src/level/LOONEY.c
+++ b/src/level/LOONEY.c
@@ -270,7 +270,35 @@ INCLUDE_ASM("asm/nonmatchings/level/LOONEY", func_8015B1BC_B346C);
 
 INCLUDE_ASM("asm/nonmatchings/level/LOONEY", func_8015B250_B3500);
 
-INCLUDE_ASM("asm/nonmatchings/level/LOONEY", func_8015B4BC_B376C);
+extern char D_80161DC0_BA070[];
+extern unsigned short D_80078A40[][4];
+extern void func_80017E88();
+extern void func_80016894();
+
+void func_8015B4BC_B376C(Instance* instance) {
+    extern int D_800EB8A0;
+    Object* obj;
+    Model* model;
+    SVECTOR pos;
+    SVECTOR vel;
+    int i;
+
+    obj = ((Object*)OBTABLE_FindObject(D_80161DC0_BA070));
+    if (obj != NULL) {
+        pos.x = instance->position.x;
+        pos.y = instance->position.y;
+        pos.z = instance->position.z + 0x140;
+        model = obj->modelList[0];
+        for (i = 0; i < 20; i++) {
+            unsigned short* entry;
+            entry = D_80078A40[rand() % 244];
+            vel.x = (entry[0] << 16) >> 23;
+            vel.y = (entry[1] << 16) >> 23;
+            vel.z = (entry[2] << 16) >> 23;
+            func_800170E8(model, model->_14, &pos, &vel, 0, D_800EB8A0, func_80017E88, func_80016894, 0xF);
+        }
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/LOONEY", looney_brkblok_OnCollide);
 

--- a/src/level/LOONEY.c
+++ b/src/level/LOONEY.c
@@ -573,7 +573,38 @@ void looney_funplat_OnCollide(Instance* instance, GameTracker* gameTracker) {
     }
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/LOONEY", looney_fxgen_OnCreate);
+extern char D_80161DA8_BA058[];
+
+void looney_fxgen_OnCreate(Instance* instance, GameTracker* gameTracker) {
+    int* fc;
+    unsigned char* config;
+
+    fc = &instance->_F4[2];
+    if (instance->flags & 0x20000) {
+        if (*(int*)&instance->_108 != 0) {
+            func_800331BC(*(int*)&instance->_108);
+            *(int*)&instance->_108 = 0;
+        }
+    } else {
+        if (instance->introData == NULL) {
+            instance->introData = D_80161DA8_BA058;
+        }
+        config = instance->introData;
+        fc[0] = OBTABLE_FindObject(config + 0xC);
+        if ((config[1] & 1) == 0) {
+            if ((config[1] & 2) != 0) {
+                *(short*)&instance->_110 = 0x119;
+                ((short*)&instance->_110)[1] = 0x78;
+                ((short*)&instance->_114)[1] = 0xDAC;
+                *(short*)&instance->_114 = (rand() & 0x7F) - 0x15E;
+                ((short*)&instance->_10C)[1] = *(short*)&instance->_10C = rand() & 7;
+                config[1] |= 0x80;
+            }
+        }
+        fc[3] = 0;
+        instance->flags |= 0x10000;
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/LOONEY", func_80160B20_B8DD0);
 

--- a/src/level/MAP.c
+++ b/src/level/MAP.c
@@ -675,6 +675,141 @@ void map_start_OnCreate(Instance* instance, GameTracker* gameTracker) {
 }
 
 INCLUDE_ASM("asm/nonmatchings/level/MAP", map_start_OnUpdate);
+/* near-match: 309/309 instructions, 11 diff words confined to two scheduler windows:
+   1) prologue: ours orders the _D0[2] load before the camera load and splits the
+      multispline loads around the increment; the target does the reverse (independent
+      -load ordering tie, KMC scheduler).
+   2) the D_800785D0 branch delay slot: KMC fills it with the fc addiu, ours with the
+      li 5 from the next statement (fc's addiu sinks because its first use is late).
+   Everything else verified: intro camera fly-in driver - runs the player intro anim
+   chain (func_800284C4/func_80024A80) while D_800785D0 is clear, resets the remote/
+   collectable tables on D_800785CC, waits for the intro sound handle, advances the
+   two camera multisplines while buttons 0xF0 are held (fast-forward), restarts the
+   attract loop through the level list at D_80161194/D_801611A4 every 0x258 frames,
+   snaps to the end on the map level type, rewinds on button 0x4000, and unhides the
+   player once _D0[2] reaches 0x64.
+extern int D_800785D0;
+extern int D_800785CC[];
+extern int D_800785D4;
+extern int D_8006CF54;
+extern char D_801539C8[];
+extern char* D_80161194_C1BC4[];
+extern char* D_801611A4_C1BD4[];
+extern G2String D_801612C0_C1CF0;
+extern unsigned int D_801612C4_C1CF4;
+
+void map_start_OnUpdate(Instance* instance, GameTracker* gameTracker) {
+    short* data;
+    int** cam;
+    int* ms1;
+    int* ms2;
+    char* fc;
+    char* sel;
+    int frame;
+    int i;
+
+    data = (short*)PlayerInstance->data;
+    cam = (int**)gameTracker->camera;
+    instance->_D0[2] = instance->_D0[2] + 1;
+    ms1 = (int*)cam[0x480/4];
+    ms2 = (int*)cam[0x484/4];
+    if (D_800785D0 == 0) {
+        fc = (char*)&instance->_F4[2];
+        gameTracker->player->_F4[0] = 5;
+        if (fc[0x25] == PlayerInstance->currentAnimFrame) {
+            PlayerInstance->flags2 |= 0x10;
+            data[0x8A/2] = 0x91;
+            sel = D_801539C8;
+            if (!(PlayerInstance->flags & 0x100)) {
+                sel = (char*)gameTracker + 0x18;
+            }
+            func_800284C4(PlayerInstance, gameTracker, data, sel);
+            PlayerInstance->currentAnimFrame = -1;
+        }
+        func_80024A80(PlayerInstance, gameTracker, data);
+        fc[0x25] = *(unsigned short*)&PlayerInstance->currentAnimFrame;
+        frame = *(unsigned short*)&PlayerInstance->currentAnimFrame + 1;
+        PlayerInstance->currentAnimFrame = frame;
+        if (PlayerInstance->object->oflags2 & 8) {
+            func_80050400(PlayerInstance, frame & 0xFF);
+        }
+    }
+    if (D_800785CC[0] != 0) {
+        short* pdata2;
+        pdata2 = (short*)PlayerInstance->data;
+        ((char*)gameTracker)[0x4CA0] = 0;
+        ((int*)gameTracker)[0x4C98/4] = 0;
+        ((int*)gameTracker)[0x4C94/4] = 0;
+        ((int*)gameTracker)[0x4BF4/4] = pdata2[0x1C/2];
+        D_8006CF54 = 0xC;
+        ((int*)gameTracker)[0x4BF8/4] = pdata2[0x1A/2];
+        for (i = 0; i < 0x1F; i++) {
+            ((char*)gameTracker + i)[0x4C6E] = 0;
+            *(short*)((char*)gameTracker8 + i*6 + 0x4CEC) = 0;
+            *(short*)((char*)gameTracker8 + i*6 + 0x4CEA) = 0;
+            *(short*)((char*)gameTracker8 + i*6 + 0x4CE8) = 0;
+        }
+    }
+    if (((int**)gameTracker->camera)[0x480/4] != NULL && ((int**)gameTracker->camera)[0x484/4] != NULL) {
+        if (((char*)instance)[0x120] == 0) {
+            ((char*)instance)[0x120] = 1;
+        } else {
+            if (((char*)instance)[0x120] != 1) {
+                if (((int*)gameTracker8)[0x4C54/4] & 0x7F) {
+                    func_80033334((((int*)gameTracker8)[0x4C54/4] - 1) & 0x7F);
+                }
+                if (((int*)gameTracker8)[0x4C54/4] != 0) {
+                    return;
+                }
+                func_80033354();
+                func_80033334(instance->_D0[1] & 0x7F);
+                ((char*)instance)[0x120] = 1;
+            }
+            if ((((short*)ms1[0])[0x4/2] - 1 == ((short*)ms1)[0x10/2]) && !(ms1[0x10/4] & 0x7FFF)
+                && (PlayerInstance->flags & 0x200)) {
+                if (((int*)gameTracker)[0x40/4] != 0) {
+                    instance->_D0[0] = 0x258;
+                }
+                instance->_D0[0] -= 1;
+                if (instance->_D0[0] < 0) {
+                    ((char*)gameTracker)[0x4CDD] = 1;
+                    func_800396E0(D_80161194_C1BC4[((char*)gameTracker)[0x4CDE]], D_801611A4_C1BD4[((char*)gameTracker)[0x4CDE]], gameTracker);
+                    instance->_D0[0] = 0x258;
+                    ((char*)gameTracker)[0x4CDE] = (((char*)gameTracker)[0x4CDE] + 1) % 4;
+                }
+            }
+            if (((int*)gameTracker)[0x40/4] & 0xF0) {
+                SplineGetNextPoint((Spline*)ms1[0], (SplineDef*)(ms1 + 4));
+                SplineGetNextPoint((Spline*)ms2[0], (SplineDef*)(ms2 + 4));
+                instance->_D0[2] += 1;
+            }
+            if (((G2String*)gameTracker->level->levelType)->raw[0] == D_801612C0_C1CF0.raw[0]
+                && ((G2String*)gameTracker->level->levelType)->raw[1] == D_801612C4_C1CF4) {
+                if (((short*)ms2)[0x10/2] == ((short*)ms2[0])[0x4/2] - 1) {
+                    func_80048DE4(0, ms1 + 4, ms1 + 5, ms1 + 6);
+                    func_80048DE4(0, ms2 + 4, ms2 + 5, ms2 + 6);
+                    instance->_D0[2] = 0;
+                }
+            } else if (((int*)gameTracker)[0x40/4] == 0x4000) {
+                if (D_800785D4 == 0) {
+                    SplineDef* d1;
+                    SplineDef* d2;
+                    d1 = (SplineDef*)(ms1 + 4);
+                    SplineGetLastPoint((Spline*)ms1[0], d1);
+                    d2 = (SplineDef*)(ms2 + 4);
+                    SplineGetLastPoint((Spline*)ms2[0], d2);
+                    SplineGetPreviousPoint((Spline*)ms1[0], d1);
+                    SplineGetPreviousPoint((Spline*)ms2[0], d2);
+                    instance->_D0[2] = 0x64;
+                }
+            }
+        }
+        if (instance->_D0[2] >= 0x64) {
+            gameTracker->player->flags &= ~0x800;
+        }
+    }
+}
+*/
 
 void map_bobbox_OnCreate(Instance* instance, GameTracker* gameTracker)
 {

--- a/src/level/MAP.c
+++ b/src/level/MAP.c
@@ -1003,14 +1003,12 @@ void map_tvmenu_OnCreate(Instance* instance, GameTracker* gameTracker) {
     }
 }
 
-void func_8015B96C_BC39C();
-
 void map_tvmenu_OnUpdate(Instance* instance, GameTracker* gameTracker) {
     int splineOk;
     short i;
     short total;
     signed char* fc;
-    int* config;
+    int* intro;
     int* cam;
     int* sp;
     short* keys;
@@ -1020,7 +1018,7 @@ void map_tvmenu_OnUpdate(Instance* instance, GameTracker* gameTracker) {
 
     splineOk = 0;
     fc = (signed char*)&instance->_F4[2];
-    config = instance->introData;
+    intro = instance->introData;
     cam = (int*)gameTracker->camera;
     if (cam[0x14C/4] == 5 && cam[0x480/4] != 0) {
         splineOk = cam[0x484/4] != 0;
@@ -1061,27 +1059,27 @@ void map_tvmenu_OnUpdate(Instance* instance, GameTracker* gameTracker) {
                     }
                 }
             }
-            if ((instance->flags & 0x200) && config != NULL && ((short*)fc)[3] != 0 && fc[0x13] != 0) {
+            if ((instance->flags & 0x200) && intro != NULL && ((short*)fc)[3] != 0 && fc[0x13] != 0) {
                 if ((((short*)fc)[1] != 0
                      || ((((int*)gameTracker)[0x44/4] & 0x80) && ((short*)fc)[2] == 0))
-                    && config[1] != 0) {
+                    && intro[1] != 0) {
                     ((short*)fc)[1] = 0;
-                    SIGNAL_HandleSignal(PlayerInstance, config[1] + 4, 0);
+                    SIGNAL_HandleSignal(PlayerInstance, intro[1] + 4, 0);
                     if (func_80033268(0x81) == 0) {
                         func_800509E0(0x81, 0x7A, 0x40, 0x64);
                     }
-                } else if ((((int*)gameTracker)[0x44/4] & 0x10) && config[0] != 0) {
-                    SIGNAL_HandleSignal(PlayerInstance, config[0] + 4, 0);
+                } else if ((((int*)gameTracker)[0x44/4] & 0x10) && intro[0] != 0) {
+                    SIGNAL_HandleSignal(PlayerInstance, intro[0] + 4, 0);
                     if (func_80033268(0x81) == 0) {
                         func_800509E0(0x81, 0x7A, 0x40, -0x64);
                     }
-                } else if ((((int*)gameTracker)[0x44/4] & 0x20) && config[2] != 0) {
-                    SIGNAL_HandleSignal(PlayerInstance, config[2] + 4, 0);
+                } else if ((((int*)gameTracker)[0x44/4] & 0x20) && intro[2] != 0) {
+                    SIGNAL_HandleSignal(PlayerInstance, intro[2] + 4, 0);
                     if (func_80033268(0x81) == 0) {
                         func_800509E0(0x81, 0x7A, 0x40, 0);
                     }
-                } else if ((((int*)gameTracker)[0x44/4] & 0x40) && config[3] != 0) {
-                    SIGNAL_HandleSignal(PlayerInstance, config[3] + 4, 0);
+                } else if ((((int*)gameTracker)[0x44/4] & 0x40) && intro[3] != 0) {
+                    SIGNAL_HandleSignal(PlayerInstance, intro[3] + 4, 0);
                     if (func_80033268(0x81) == 0) {
                         func_800509E0(0x81, 0x7A, 0x40, 0);
                     }

--- a/src/level/MAP.c
+++ b/src/level/MAP.c
@@ -868,7 +868,96 @@ void map_tvmenu_OnCreate(Instance* instance, GameTracker* gameTracker) {
     }
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/MAP", map_tvmenu_OnUpdate);
+void func_8015B96C_BC39C();
+
+void map_tvmenu_OnUpdate(Instance* instance, GameTracker* gameTracker) {
+    int splineOk;
+    short i;
+    short total;
+    signed char* fc;
+    int* config;
+    int* cam;
+    int* sp;
+    short* keys;
+    short numk;
+    int frame;
+    int done13;
+
+    splineOk = 0;
+    fc = (signed char*)&instance->_F4[2];
+    config = instance->introData;
+    cam = (int*)gameTracker->camera;
+    if (cam[0x14C/4] == 5 && cam[0x480/4] != 0) {
+        splineOk = cam[0x484/4] != 0;
+    }
+    if (instance->_F4[0] == 3) {
+        func_8015BFE0_BCA10(instance, gameTracker);
+    } else {
+        func_8015C110_BCB40(instance, (short**)gameTracker);
+        if (instance->_F4[0] == 0) {
+            func_8015B96C_BC39C(instance, gameTracker);
+        } else if (instance->_F4[0] == 2) {
+            done13 = fc[0x13];
+            if (done13 == 0) {
+                if (instance->flags & 0x200) {
+                    i = 0;
+                    if (splineOk != 0) {
+                        sp = (int*)*((int**)gameTracker->camera)[0x480/4];
+                        total = 0;
+                        fc[0x13] = 0;
+                        if (sp != 0) {
+                            keys = (short*)sp[0];
+                            if (done13 < ((short*)sp)[0x4/2]) {
+                                numk = ((short*)sp)[0x4/2];
+                                do {
+                                    i++;
+                                    total += *keys;
+                                    keys += 0x20/2;
+                                } while (i < numk);
+                            }
+                        }
+                        if ((SplineGetFrameNumber((Spline*)sp, (SplineDef*)(((int**)gameTracker->camera)[0x480/4] + 0x10/4)) & 0xFFFF) >= total - 1) {
+                            instance->flags |= 0x400;
+                            fc[0x13] = 1;
+                        }
+                    } else {
+                        instance->flags |= 0x400;
+                        fc[0x13] = 1;
+                    }
+                }
+            }
+            if ((instance->flags & 0x200) && config != NULL && ((short*)fc)[3] != 0 && fc[0x13] != 0) {
+                if ((((short*)fc)[1] != 0
+                     || ((((int*)gameTracker)[0x44/4] & 0x80) && ((short*)fc)[2] == 0))
+                    && config[1] != 0) {
+                    ((short*)fc)[1] = 0;
+                    SIGNAL_HandleSignal(PlayerInstance, config[1] + 4, 0);
+                    if (func_80033268(0x81) == 0) {
+                        func_800509E0(0x81, 0x7A, 0x40, 0x64);
+                    }
+                } else if ((((int*)gameTracker)[0x44/4] & 0x10) && config[0] != 0) {
+                    SIGNAL_HandleSignal(PlayerInstance, config[0] + 4, 0);
+                    if (func_80033268(0x81) == 0) {
+                        func_800509E0(0x81, 0x7A, 0x40, -0x64);
+                    }
+                } else if ((((int*)gameTracker)[0x44/4] & 0x20) && config[2] != 0) {
+                    SIGNAL_HandleSignal(PlayerInstance, config[2] + 4, 0);
+                    if (func_80033268(0x81) == 0) {
+                        func_800509E0(0x81, 0x7A, 0x40, 0);
+                    }
+                } else if ((((int*)gameTracker)[0x44/4] & 0x40) && config[3] != 0) {
+                    SIGNAL_HandleSignal(PlayerInstance, config[3] + 4, 0);
+                    if (func_80033268(0x81) == 0) {
+                        func_800509E0(0x81, 0x7A, 0x40, 0);
+                    }
+                }
+            }
+        }
+        if (instance->intro->flags & 0x80) {
+            func_8015BED0_BC900(instance, gameTracker);
+        }
+    }
+}
 
 int func_8015C63C_BD06C(int arg0) {
     int temp_v0;

--- a/src/level/PREHST.c
+++ b/src/level/PREHST.c
@@ -15,11 +15,53 @@ INCLUDE_ASM("asm/nonmatchings/level/PREHST", prehst_ttplat_OnUpdate);
 
 INCLUDE_ASM("asm/nonmatchings/level/PREHST", prehst_ttplat_OnCollide);
 
-INCLUDE_ASM("asm/nonmatchings/level/PREHST", prehst_bug_OnCreate);
+void prehst_bug_OnCreate(Instance* instance, GameTracker* gameTracker) {
+    unsigned short* intro;
+
+    ((short*)&instance->_100)[1] = 0x18;
+    instance->flags |= 0x100000;
+    intro = (unsigned short*)instance->introData;
+
+    if (intro != NULL) {
+        *(short*)&instance->_100 = intro[0];
+        ((short*)&instance->_104)[1] = intro[1];
+        *(short*)&instance->_108 = intro[2];
+        ((short*)&instance->_108)[1] = intro[3];
+        *(short*)&instance->_10C = intro[4];
+        if (((short*)intro)[5] != 0) {
+            ((short*)&instance->_10C)[1] = ((short*)intro)[5];
+        } else {
+            ((short*)&instance->_10C)[1] = 0x40;
+        }
+    } else {
+        *(short*)&instance->_100 = 0x96;
+        ((short*)&instance->_104)[1] = ((unsigned short*)&instance->intro->position)[0] - 0x500;
+        *(short*)&instance->_108 = ((unsigned short*)&instance->intro->position)[1] - 0x780;
+        ((short*)&instance->_108)[1] = ((unsigned short*)&instance->intro->position)[0] + 0x500;
+        *(short*)&instance->_10C = ((unsigned short*)&instance->intro->position)[1] + 0x780;
+        ((short*)&instance->_10C)[1] = 0x40;
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/PREHST", prehst_bug_OnUpdate);
 
-INCLUDE_ASM("asm/nonmatchings/level/PREHST", prehst_bug_OnCollide);
+void prehst_bug_OnCollide(Instance* instance, GameTracker* gameTracker) {
+    BSPTree* bsp;
+    short* temp;
+
+    bsp = instance->bspTree;
+    temp = (short*)&instance->_F4[2];
+
+    if (bsp->_06 == 1) {
+        if ((bsp->instanceSpline == gameTracker->player) && (bsp->_08[4] < 2U) && (bsp->_0C[5] >= 6U)) {
+            INSTANCE_PlainDeath(instance, 5, 3, 0);
+        } else if ((bsp->_06 == 1) && (bsp->instanceSpline == gameTracker->player) && ((bsp->_08[4] == 0) || (bsp->_08[4] == 2))) {
+            func_80022714(instance, gameTracker);
+            instance->_F4[0] = 0;
+            temp[4] = 0x5A;
+        }
+    }
+}
 
 void prehst_bouncer_OnCreate(Instance* instance, GameTracker* gameTracker) {
     short* intro;

--- a/src/level/REZOP.c
+++ b/src/level/REZOP.c
@@ -131,7 +131,12 @@ INCLUDE_ASM("asm/nonmatchings/level/REZOP", rezop_snkplat_OnCreate);
 
 INCLUDE_ASM("asm/nonmatchings/level/REZOP", rezop_snkplat_OnUpdate);
 
-INCLUDE_ASM("asm/nonmatchings/level/REZOP", rezop_snkplat_OnCollide);
+void rezop_snkplat_OnCollide(Instance* instance, GameTracker* gameTracker) {
+    BSPTree* bsp = instance->bspTree;
+    if ((bsp->_06 == 4) && (bsp->instanceSpline == PlayerInstance)) {
+        GenericCollide(instance, gameTracker);
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/REZOP", rezop_rezbull_OnCreate);
 

--- a/src/level/REZOP.c
+++ b/src/level/REZOP.c
@@ -2,6 +2,7 @@
 
 #include "level/REZOP.h"
 #include "types/intro/BTimer.h"
+#include "types/G2String.h"
 
 extern int D_800E5FD8;
 extern int D_80154834;
@@ -273,10 +274,9 @@ void rezop_btimer_OnCreate(Instance* instance, GameTracker* gameTracker) {
     instance->_F4[1] = 0;
 }
 
-// Failing to match due to ro section?
-INCLUDE_ASM("asm/nonmatchings/level/REZOP", rezop_btimer_OnUpdate);
+extern char D_80161590_D9D00[];
 
-/*void rezop_btimer_OnUpdate(Instance* instance, GameTracker* gameTracker) {
+void rezop_btimer_OnUpdate(Instance* instance, GameTracker* gameTracker) {
     char buffer[0x50];
     int timeLeft;
     int minutesLeft;
@@ -319,13 +319,13 @@ INCLUDE_ASM("asm/nonmatchings/level/REZOP", rezop_btimer_OnUpdate);
         if ((((short*)((int**)gameTracker))[0x4C12/2] == 0) && (var_v1 != 0) && (instance->intro->_2C == 0)) {
             ((int*)temp_s2)[0x8/4] -= D_800E5FD8;
         }
-        if ((gameTracker->player->_F4[2] & 0x600000) == 0x600000) && (instance->_F4[1] == 0)) {
+        if (((gameTracker->player->_F4[2] & 0x600000) == 0x600000) && (instance->_F4[1] == 0)) {
             temp_s2[0] = (intro->missionTime - 1);
             if (intro->collectType == EBTIMER_COLLECTTYPE_CUTSCENE) {
                 SIGNAL_HandleSignal(PlayerInstance, intro->b + 4, 0);
             }
             instance->_F4[1] = 1;
-            PlayerInstance->_F4[2] &= ~0x400000;
+            PlayerInstance->_F4[2] &= 0xFFBFFFFF;
         }
         if ((gameTracker->player->_F4[2] & 0x400000) && ((((int**)gameTracker)[0x4C00/4] != 0) || (((int**)gameTracker)[0x4C04/4] != 0))) {
             func_8002C18C(5);
@@ -348,7 +348,7 @@ INCLUDE_ASM("asm/nonmatchings/level/REZOP", rezop_btimer_OnUpdate);
             if ((timeLeft > 300) || ((timeLeft % 15) >= 5)) {
                 Set3DTextPosition(0x2D, 0xC8);
                 if ((timeLeft % 30) >= 15) {
-                    sprintf(buffer, "%d", minutesLeft);
+                    sprintf(buffer, D_80161590_D9D00, minutesLeft);  // "%d" — emitted earlier in this TU by a still-undecompiled function (INCLUDE_RODATA blob); a literal here would duplicate it and shift .rodata
                 } else {
                     sprintf(buffer, "%d.", minutesLeft);
                 }
@@ -377,7 +377,7 @@ INCLUDE_ASM("asm/nonmatchings/level/REZOP", rezop_btimer_OnUpdate);
             }
         }
     }
-}*/
+}
 
 void rezop_markey_OnCreate(Instance* instance, GameTracker* gameTracker) {
 }

--- a/src/level/REZOP.c
+++ b/src/level/REZOP.c
@@ -330,7 +330,7 @@ void rezop_btimer_OnUpdate(Instance* instance, GameTracker* gameTracker) {
                 SIGNAL_HandleSignal(PlayerInstance, intro->b + 4, 0);
             }
             instance->_F4[1] = 1;
-            PlayerInstance->_F4[2] &= 0xFFBFFFFF;
+            PlayerInstance->_F4[2] &= ~0x400000;
         }
         if ((gameTracker->player->_F4[2] & 0x400000) && ((((int**)gameTracker)[0x4C00/4] != 0) || (((int**)gameTracker)[0x4C04/4] != 0))) {
             func_8002C18C(5);

--- a/src/level/SCIFI.c
+++ b/src/level/SCIFI.c
@@ -167,7 +167,77 @@ void scifi_onoff_OnUpdate(Instance* instance, GameTracker* gameTracker) {
     }
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/SCIFI", scifi_onoff_OnCollide);
+extern int D_80164E3C_EAC5C;
+extern int D_80164E40_EAC60;
+
+void scifi_onoff_OnCollide(Instance* instance, GameTracker* gameTracker) {
+    short* config;
+    BSPTree* bsp;
+    int** list;
+    Instance* other;
+    int match;
+    int toggled;
+    int checkState;
+    int fire;
+    short i;
+
+    match = 0;
+    toggled = 0;
+    checkState = 0;
+    fire = 0;
+    config = instance->introData;
+    bsp = instance->bspTree;
+    if (config != NULL && bsp->_06 == 1 && bsp->_0C[5] >= 8U && instance->_F4[1] != 1) {
+        list = (int**)(config + 2);
+        if (config[1] == 0) {
+            match = 1;
+        } else if (config[1] == 1) {
+            if (instance->_F4[0] == 0) {
+                match = 1;
+                checkState = 1;
+            }
+        } else if (config[1] == 2) {
+            if (instance->_F4[0] == 1) {
+                match = 1;
+                checkState = 1;
+            }
+        }
+        for (i = 0; i < config[0]; i++, list++) {
+            other = ((Intro*)list[0])->instance;
+            if (other == NULL) continue;
+            if (other->flags & 0x2000000) continue;
+            if (match == 0) continue;
+            if (checkState != 0) {
+                if (!((((unsigned short*)config)[1] & 1) && !(other->flags & 0x1000000))) {
+                    if (!(((unsigned short*)config)[1] & 2)) continue;
+                    if (!(other->flags & 0x1000000)) continue;
+                }
+            }
+            other->flags &= ~0x100000;
+            if (!(other->flags2 & 0x10000)) {
+                other->flags2 |= 0x1000;
+            }
+            other->flags |= 0x2000000;
+            toggled = 1;
+        }
+        if ((match != 0 && toggled != 0) || config[0] == 0) {
+            instance->intro->flags ^= 0x800;
+            instance->_F4[0] ^= 1;
+            fire = 1;
+        } else if (*(int*)instance->object->name == D_80164E3C_EAC5C
+                   && ((int*)instance->object->name)[1] == D_80164E40_EAC60) {
+            fire = 1;
+        }
+        if (fire != 0) {
+            if (((short*)&instance->object->_08)[1] != 0) {
+                instance->_F4[1] = 1;
+            }
+            if (*(int*)list == 0x29A) {
+                SIGNAL_HandleSignal(instance, (int*)((int*)list)[1] + 1, 0);
+            }
+        }
+    }
+}
 
 void scifi_bub_OnCreate(Instance* instance, GameTracker* gameTracker) {
     short* introData;
@@ -820,7 +890,38 @@ void func_80162154_E7F74(Instance* instance, short arg1) {
     instance->rotation.z = euler.z;
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/SCIFI", func_801621D4_E7FF4);
+void func_801621D4_E7FF4(Instance* instance, SVECTOR offset, short dist, short angle) {
+    MATRIX m1;
+    MATRIX m2;
+    MATRIX m3;
+    SVECTOR result;
+    SVECTOR vec;
+    SVECTOR euler;
+    SVECTOR rot;
+
+    MATH3D_SetUnityMatrix(&m1);
+    MATH3D_SetUnityMatrix(&m2);
+    MATH3D_SetUnityMatrix(&m3);
+    vec.x = 0;
+    vec.y = 0;
+    vec.z = dist;
+    rot.x = instance->rotation.x;
+    rot.y = instance->rotation.y;
+    rot.z = instance->rotation.z;
+    RotMatrixX(angle, &m2);
+    RotMatrix(&rot, &m3);
+    MulMatrix0(&m3, &m2, &m1);
+    result.x = (vec.x * m1.m[0][0] >> 12) + (vec.y * m1.m[0][1] >> 12) + (vec.z * m1.m[0][2] >> 12);
+    result.y = (vec.x * m1.m[1][0] >> 12) + (vec.y * m1.m[1][1] >> 12) + (vec.z * m1.m[1][2] >> 12);
+    result.z = (vec.x * m1.m[2][0] >> 12) + (vec.y * m1.m[2][1] >> 12) + (vec.z * m1.m[2][2] >> 12);
+    instance->position.x = result.x + offset.x;
+    instance->position.y = result.y + offset.y;
+    instance->position.z = result.z + offset.z;
+    func_800157BC(&m1, &euler);
+    instance->rotation.x = euler.x;
+    instance->rotation.y = euler.y;
+    instance->rotation.z = euler.z;
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/SCIFI", scifi_rt_OnUpdate);
 

--- a/src/level/SCIFI.c
+++ b/src/level/SCIFI.c
@@ -1,6 +1,7 @@
 #include "common.h"
 
 #include "level/SCIFI.h"
+#include "types/G2String.h"
 #include "MATRIX.h"
 
 INCLUDE_ASM("asm/nonmatchings/level/SCIFI", func_80159720_DF540);
@@ -167,11 +168,10 @@ void scifi_onoff_OnUpdate(Instance* instance, GameTracker* gameTracker) {
     }
 }
 
-extern int D_80164E3C_EAC5C;
-extern int D_80164E40_EAC60;
+extern char D_80164E3C_EAC5C[];
 
 void scifi_onoff_OnCollide(Instance* instance, GameTracker* gameTracker) {
-    short* config;
+    short* intro;
     BSPTree* bsp;
     int** list;
     Instance* other;
@@ -185,31 +185,31 @@ void scifi_onoff_OnCollide(Instance* instance, GameTracker* gameTracker) {
     toggled = 0;
     checkState = 0;
     fire = 0;
-    config = instance->introData;
+    intro = instance->introData;
     bsp = instance->bspTree;
-    if (config != NULL && bsp->_06 == 1 && bsp->_0C[5] >= 8U && instance->_F4[1] != 1) {
-        list = (int**)(config + 2);
-        if (config[1] == 0) {
+    if (intro != NULL && bsp->_06 == 1 && bsp->_0C[5] >= 8U && instance->_F4[1] != 1) {
+        list = (int**)(intro + 2);
+        if (intro[1] == 0) {
             match = 1;
-        } else if (config[1] == 1) {
+        } else if (intro[1] == 1) {
             if (instance->_F4[0] == 0) {
                 match = 1;
                 checkState = 1;
             }
-        } else if (config[1] == 2) {
+        } else if (intro[1] == 2) {
             if (instance->_F4[0] == 1) {
                 match = 1;
                 checkState = 1;
             }
         }
-        for (i = 0; i < config[0]; i++, list++) {
+        for (i = 0; i < intro[0]; i++, list++) {
             other = ((Intro*)list[0])->instance;
             if (other == NULL) continue;
             if (other->flags & 0x2000000) continue;
             if (match == 0) continue;
             if (checkState != 0) {
-                if (!((((unsigned short*)config)[1] & 1) && !(other->flags & 0x1000000))) {
-                    if (!(((unsigned short*)config)[1] & 2)) continue;
+                if (!((((unsigned short*)intro)[1] & 1) && !(other->flags & 0x1000000))) {
+                    if (!(((unsigned short*)intro)[1] & 2)) continue;
                     if (!(other->flags & 0x1000000)) continue;
                 }
             }
@@ -220,12 +220,11 @@ void scifi_onoff_OnCollide(Instance* instance, GameTracker* gameTracker) {
             other->flags |= 0x2000000;
             toggled = 1;
         }
-        if ((match != 0 && toggled != 0) || config[0] == 0) {
+        if ((match != 0 && toggled != 0) || intro[0] == 0) {
             instance->intro->flags ^= 0x800;
             instance->_F4[0] ^= 1;
             fire = 1;
-        } else if (*(int*)instance->object->name == D_80164E3C_EAC5C
-                   && ((int*)instance->object->name)[1] == D_80164E40_EAC60) {
+        } else if (G2String_Compare_EQ(instance->object->name, D_80164E3C_EAC5C)) {
             fire = 1;
         }
         if (fire != 0) {

--- a/src/level/SPY.c
+++ b/src/level/SPY.c
@@ -220,7 +220,7 @@ void func_80159EEC_EB5BC(Instance* instance, GameTracker* gameTracker) {
     }
 }
 
-extern char D_8015AE00_EC4D0[];
+extern G2String D_8015AE00_EC4D0;
 
 int func_80159F3C_EB60C(Instance* instance, GameTracker* gameTracker) {
     int* sub;
@@ -237,8 +237,7 @@ int func_80159F3C_EB60C(Instance* instance, GameTracker* gameTracker) {
             count = sub[0];
             for (i = 0; i < count; i++, list++) {
                 entry = *list;
-                if (*(int*)entry->object->parentName == ((int*)D_8015AE00_EC4D0)[0]
-                    && ((int*)entry->object->parentName)[1] == ((int*)D_8015AE00_EC4D0)[1]) {
+                if (G2String_Compare_EQ(entry->object->parentName, &D_8015AE00_EC4D0)) {
                     other = entry->instance;
                     if (other != NULL) {
                         if ((other->_F4[0] - 1) < 2U) {
@@ -342,11 +341,10 @@ void spy_onoff_OnUpdate(Instance* instance, GameTracker* gameTracker) {
     }
 }
 
-extern int D_8015AE0C_EC4DC;
-extern int D_8015AE10_EC4E0;
+extern char D_8015AE0C_EC4DC[];
 
 void spy_onoff_OnCollide(Instance* instance, GameTracker* gameTracker) {
-    short* config;
+    short* intro;
     BSPTree* bsp;
     int** list;
     Instance* other;
@@ -360,31 +358,31 @@ void spy_onoff_OnCollide(Instance* instance, GameTracker* gameTracker) {
     toggled = 0;
     checkState = 0;
     fire = 0;
-    config = instance->introData;
+    intro = instance->introData;
     bsp = instance->bspTree;
-    if (config != NULL && bsp->_06 == 1 && bsp->_0C[5] >= 8U && instance->_F4[1] != 1) {
-        list = (int**)(config + 2);
-        if (config[1] == 0) {
+    if (intro != NULL && bsp->_06 == 1 && bsp->_0C[5] >= 8U && instance->_F4[1] != 1) {
+        list = (int**)(intro + 2);
+        if (intro[1] == 0) {
             match = 1;
-        } else if (config[1] == 1) {
+        } else if (intro[1] == 1) {
             if (instance->_F4[0] == 0) {
                 match = 1;
                 checkState = 1;
             }
-        } else if (config[1] == 2) {
+        } else if (intro[1] == 2) {
             if (instance->_F4[0] == 1) {
                 match = 1;
                 checkState = 1;
             }
         }
-        for (i = 0; i < config[0]; i++, list++) {
+        for (i = 0; i < intro[0]; i++, list++) {
             other = ((Intro*)list[0])->instance;
             if (other == NULL) continue;
             if (other->flags & 0x2000000) continue;
             if (match == 0) continue;
             if (checkState != 0) {
-                if (!((((unsigned short*)config)[1] & 1) && !(other->flags & 0x1000000))) {
-                    if (!(((unsigned short*)config)[1] & 2)) continue;
+                if (!((((unsigned short*)intro)[1] & 1) && !(other->flags & 0x1000000))) {
+                    if (!(((unsigned short*)intro)[1] & 2)) continue;
                     if (!(other->flags & 0x1000000)) continue;
                 }
             }
@@ -395,12 +393,11 @@ void spy_onoff_OnCollide(Instance* instance, GameTracker* gameTracker) {
             other->flags |= 0x2000000;
             toggled = 1;
         }
-        if ((match != 0 && toggled != 0) || config[0] == 0) {
+        if ((match != 0 && toggled != 0) || intro[0] == 0) {
             instance->intro->flags ^= 0x800;
             instance->_F4[0] ^= 1;
             fire = 1;
-        } else if (*(int*)instance->object->name == D_8015AE0C_EC4DC
-                   && ((int*)instance->object->name)[1] == D_8015AE10_EC4E0) {
+        } else if (G2String_Compare_EQ(instance->object->name, D_8015AE0C_EC4DC)) {
             fire = 1;
         }
         if (fire != 0) {
@@ -429,19 +426,19 @@ typedef struct {
 } GnRobotKey;
 
 void spy_gnrobot_OnUpdate(Instance* instance, GameTracker* gameTracker) {
-    short* config;
+    short* intro;
     MultiSpline* ms;
     unsigned short frame;
     GnRobotKey* p;
     int i;
     SVECTOR unused; /* dead local needed for the original's 0x28 stack frame */
 
-    config = instance->introData;
+    intro = instance->introData;
     ms = SCRIPT_GetMultiSpline(instance, NULL, NULL);
     frame = SplineGetFrameNumber(ms->positional, &ms->curPositional);
     instance->_F4[2] += 1;
-    p = (GnRobotKey*)config;
-    if (((int*)config)[1] > 0) {
+    p = (GnRobotKey*)intro;
+    if (((int*)intro)[1] > 0) {
         i = 0;
         do {
             if (p[i + 2].frame == frame) {
@@ -449,11 +446,11 @@ void spy_gnrobot_OnUpdate(Instance* instance, GameTracker* gameTracker) {
                 instance->currentAnimFrame = 0;
             }
             i++;
-        } while (i < ((int*)config)[1]);
+        } while (i < ((int*)intro)[1]);
     }
     func_8002DAF8(instance, -1);
     if (instance->currentAnimFrame == ((short*)instance->object->animList[instance->currentModelAnim])[1] - 1) {
-        instance->currentModelAnim = ((unsigned short*)config)[0];
+        instance->currentModelAnim = ((unsigned short*)intro)[0];
     }
 }
 

--- a/src/level/SPY.c
+++ b/src/level/SPY.c
@@ -1,6 +1,8 @@
 #include "common.h"
 
 #include "level/SPY.h"
+#include "SCRIPT.h"
+#include "SPLINE.h"
 #include "types/intro/BTimer.h"
 #include "types/G2String.h"
 
@@ -237,7 +239,39 @@ void spy_gnrobot_OnCreate(Instance* instance, GameTracker* gameTracker) {
     instance->_100 = ((short*)instance->introData)[1];
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/SPY", spy_gnrobot_OnUpdate);
+typedef struct {
+    short frame;
+    unsigned short anim;
+} GnRobotKey;
+
+void spy_gnrobot_OnUpdate(Instance* instance, GameTracker* gameTracker) {
+    short* config;
+    MultiSpline* ms;
+    unsigned short frame;
+    GnRobotKey* p;
+    int i;
+    SVECTOR unused; /* dead local needed for the original's 0x28 stack frame */
+
+    config = instance->introData;
+    ms = SCRIPT_GetMultiSpline(instance, NULL, NULL);
+    frame = SplineGetFrameNumber(ms->positional, &ms->curPositional);
+    instance->_F4[2] += 1;
+    p = (GnRobotKey*)config;
+    if (((int*)config)[1] > 0) {
+        i = 0;
+        do {
+            if (p[i + 2].frame == frame) {
+                instance->currentModelAnim = p[i + 2].anim;
+                instance->currentAnimFrame = 0;
+            }
+            i++;
+        } while (i < ((int*)config)[1]);
+    }
+    func_8002DAF8(instance, -1);
+    if (instance->currentAnimFrame == ((short*)instance->object->animList[instance->currentModelAnim])[1] - 1) {
+        instance->currentModelAnim = ((unsigned short*)config)[0];
+    }
+}
 
 void spy_gnrobot_OnCollide(Instance* instance, GameTracker* gameTracker) {
     BSPTree* bsp;

--- a/src/level/SPY.c
+++ b/src/level/SPY.c
@@ -71,6 +71,9 @@ void spy_launch_OnCreate(Instance* instance, GameTracker* gameTracker) {
 
 INCLUDE_ASM("asm/nonmatchings/level/SPY", spy_launch_OnUpdate);
 
+int func_80159F3C_EB60C(Instance* instance, GameTracker* gameTracker);
+void func_8015A098_EB768(Instance* instance, GameTracker* gameTracker);
+
 void spy_launch_OnCollide(Instance* instance, GameTracker* gameTracker) {
     Instance* temp_a0;
     BSPTree* bsp;
@@ -92,7 +95,7 @@ void spy_launch_OnCollide(Instance* instance, GameTracker* gameTracker) {
     }
 }
 
-void func_80159EEC_EB5BC(Instance* instance) {
+void func_80159EEC_EB5BC(Instance* instance, GameTracker* gameTracker) {
     instance->flags &= ~0x800;
     if (!(instance->_11C & 8)) {
         instance->_F4[2] = instance->_104;
@@ -101,20 +104,77 @@ void func_80159EEC_EB5BC(Instance* instance) {
     }
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/SPY", func_80159F3C_EB60C);
+extern char D_8015AE00_EC4D0[];
+
+int func_80159F3C_EB60C(Instance* instance, GameTracker* gameTracker) {
+    int* sub;
+    Intro** list;
+    Intro* entry;
+    Instance* other;
+    int count;
+    int i;
+
+    if (instance->intro != NULL) {
+        sub = instance->intro->_04;
+        if (sub != NULL) {
+            list = (Intro**)(sub + 1);
+            count = sub[0];
+            for (i = 0; i < count; i++, list++) {
+                entry = *list;
+                if (*(int*)entry->object->parentName == ((int*)D_8015AE00_EC4D0)[0]
+                    && ((int*)entry->object->parentName)[1] == ((int*)D_8015AE00_EC4D0)[1]) {
+                    other = entry->instance;
+                    if (other != NULL) {
+                        if ((other->_F4[0] - 1) < 2U) {
+                            return 1;
+                        }
+                        if (*(int*)&other->_108 != 0) {
+                            return 1;
+                        }
+                    }
+                }
+            }
+        }
+    }
+    return 0;
+}
 
 void func_8015A014_EB6E4(Instance* instance, GameTracker* gameTracker) {
-    register short* pData asm("$18");
+    short* pData;
+
     pData = (short*)gameTracker->player->data;
     instance->flags |= 0x400;
-    func_80159EEC_EB5BC(instance);
+    func_80159EEC_EB5BC(instance, gameTracker);
     instance->_F4[0] = 2;
     PlayerInstance->_E0[1] = pData[4];
     gameTracker->player->_F4[2] |= 0x400;
     func_8004AAA8(instance, 0x18, 0);
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/SPY", func_8015A098_EB768);
+void func_8015A098_EB768(Instance* instance, GameTracker* gameTracker) {
+    short* data;
+    Instance* player;
+
+    data = gameTracker->player->data;
+    instance->flags |= 0x400;
+    func_80159EEC_EB5BC(instance, gameTracker);
+    player = PlayerInstance;
+    data[0x9C/2] = data[0xA0/2] - 1;
+    data[0x9E/2] = data[0xA0/2] - 1;
+    instance->_F4[0] = 1;
+    *(int*)&instance->_110 = ((short*)&instance->_D0[0])[1];
+    player->_D0[2] = 0;
+    player->_E0[1] = 0;
+    player->flags |= 0x400000;
+    func_800256A8(gameTracker);
+    data[0x8C/2] = 0;
+    data[0x8E/2] = 0;
+    data[0x90/2] = 0;
+    data[0x94/2] = 0;
+    data[0x96/2] = 0;
+    data[0x98/2] = 0;
+    func_8004AAA8(instance, 0x18, 0);
+}
 
 void spy_onoff_OnCreate(Instance* instance, GameTracker* gameTracker) {
     if (instance->intro->flags & 0x1000) {

--- a/src/level/SPY.c
+++ b/src/level/SPY.c
@@ -7,7 +7,23 @@
 void spy_qsofa_OnCreate(Instance* instance, GameTracker* gameTracker) {
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/SPY", spy_qsofa_OnUpdate);
+void spy_qsofa_OnUpdate(Instance* instance, GameTracker* gameTracker) {
+    if (instance->_F4[0] == 1) {
+        if (instance->currentAnimFrame == 0) {
+            short* data;
+            data = gameTracker->player->data;
+            data[0x90/2] = 0x180;
+            data[0x98/2] = -0x10;
+            func_800256A8(gameTracker);
+            func_80050508(instance, 0x18, 0, 0x64, 0xFA0);
+        }
+        func_8002DAF8(instance, -1);
+        if (instance->currentAnimFrame == ((short*)instance->object->animList[instance->currentModelAnim])[1] - 1) {
+            instance->_F4[0] = 0;
+            instance->currentAnimFrame = 0;
+        }
+    }
+}
 
 void spy_qsofa_OnCollide(Instance* instance, GameTracker* gameTracker) {
     BSPTree* bsp = instance->bspTree;

--- a/src/level/SPY.c
+++ b/src/level/SPY.c
@@ -72,6 +72,113 @@ void spy_launch_OnCreate(Instance* instance, GameTracker* gameTracker) {
 }
 
 INCLUDE_ASM("asm/nonmatchings/level/SPY", spy_launch_OnUpdate);
+/* near-match (45 diff words from two 1-instruction scheduler windows, all else identical):
+   1) the _110-update block: KMC hoists the lw above the inner beqz and delay-fills the subu;
+      our GCC keeps the lw in the block with an extra nop (speculative-load hoist difference).
+   2) player->_F4[2] & ~0x40 & ~0x400: KMC emits two ands (reusing the ~0x400 reg from
+      instance->flags); our combine always folds the constants into one and (~0x440),
+      even through a shared mask variable.
+extern Object* D_8007684C;
+extern int D_800EB8A0;
+
+int func_80159F3C_EB60C(Instance* instance, GameTracker* gameTracker);
+void func_8015A014_EB6E4(Instance* instance, GameTracker* gameTracker);
+void func_8015A098_EB768(Instance* instance, GameTracker* gameTracker);
+
+void spy_launch_OnUpdate(Instance* instance, GameTracker* gameTracker) {
+    Instance* player;
+    short* pdata;
+    int done;
+    SVECTOR unused;
+
+    player = gameTracker->player;
+    pdata = player->data;
+    if (instance->_F4[0] == 0 && (instance->_11C & 0x30) == 0x30
+        && ((gameTracker->_0014[2] & 0x10) || player->_F4[1] == 0x20 || player->_F4[1] == 0x80)) {
+        if (func_80159F3C_EB60C(instance, gameTracker) == 0) {
+            if (pdata[0x78/2] != 0) {
+                func_8015A014_EB6E4(instance, gameTracker);
+            } else {
+                func_8015A098_EB768(instance, gameTracker);
+            }
+        }
+    }
+    if (instance->_F4[2] > 0) {
+        instance->_F4[2] = instance->_F4[2] - instance->_100;
+        if (instance->_F4[2] <= 0) {
+            if (!(instance->_11C & 2)) {
+                instance->flags |= 0x800;
+            }
+            instance->position = instance->initialPos;
+            instance->_F4[2] = 0;
+        }
+        instance->scale.x = instance->_F4[2] * (*(int*)&instance->_118) / instance->_104 + 0x1000;
+        instance->scale.y = instance->_F4[2] * (*(int*)&instance->_118) / instance->_104 + 0x1000;
+        instance->scale.z = instance->_F4[2] * (*(int*)&instance->_118) / instance->_104 + 0x1000;
+    }
+    if (instance->_F4[0] == 2) {
+        short* d;
+        d = gameTracker->player->data;
+        player->_F4[2] |= 0x40;
+        d[0x144/2] = instance->_120;
+        instance->_F4[1] += 1;
+        d[0x9E/2] = d[0xA0/2] - 1;
+    }
+    done = 0;
+    if (instance->_F4[0] == 1) {
+        int total;
+        int speed;
+        int step;
+        int threshold;
+        int progress;
+        int delta;
+        short chunk;
+
+        speed = *(short*)&instance->_112;
+        total = *(int*)&instance->_10C;
+        step = total / speed;
+        chunk = 0x20;
+        step = step - speed / chunk;
+        progress = *(int*)&instance->_108;
+        threshold = speed * step;
+        if (progress + speed >= total) {
+            delta = total - progress;
+            done = 1;
+        } else {
+            delta = speed;
+        }
+        player->position.z += delta;
+        if (done != 0) {
+            instance->_F4[0] = 3;
+            *(int*)&instance->_108 = 0;
+            player->flags &= ~0x400000;
+        } else {
+            *(int*)&instance->_108 += delta;
+            if (threshold < *(int*)&instance->_108) {
+                if (chunk < *(short*)&instance->_112) {
+                    *(int*)&instance->_110 = ((*(int*)&instance->_110 - chunk) << 16) >> 16;
+                }
+            }
+        }
+    }
+    if (instance->_F4[0] >= 2) {
+        if (instance->_F4[1] >= 5 || instance->_F4[0] != 2) {
+            if (func_800257B4(player) != 0 || (player->_F4[1] & 0x8000)) {
+                instance->flags &= ~0x400;
+                player->_F4[2] = player->_F4[2] & ~0x40 & ~0x400;
+                instance->_F4[0] = 0;
+                instance->_F4[1] = 0;
+            }
+        }
+    }
+    if (instance->_F4[0] > 0) {
+        if (D_8007684C != NULL) {
+            func_800176E8(&player->position, D_8007684C->modelList[0], D_800EB8A0, 0xA);
+        }
+    }
+    instance->_11C &= ~0x20;
+}
+*/
 
 int func_80159F3C_EB60C(Instance* instance, GameTracker* gameTracker);
 void func_8015A098_EB768(Instance* instance, GameTracker* gameTracker);

--- a/src/level/SPY.c
+++ b/src/level/SPY.c
@@ -423,13 +423,13 @@ void spy_gnrobot_OnCreate(Instance* instance, GameTracker* gameTracker) {
 typedef struct {
     short frame;
     unsigned short anim;
-} GnRobotKey;
+} GnRobotKeyframe;
 
 void spy_gnrobot_OnUpdate(Instance* instance, GameTracker* gameTracker) {
     short* intro;
     MultiSpline* ms;
     unsigned short frame;
-    GnRobotKey* p;
+    GnRobotKeyframe* p;
     int i;
     SVECTOR unused; /* dead local needed for the original's 0x28 stack frame */
 
@@ -437,7 +437,7 @@ void spy_gnrobot_OnUpdate(Instance* instance, GameTracker* gameTracker) {
     ms = SCRIPT_GetMultiSpline(instance, NULL, NULL);
     frame = SplineGetFrameNumber(ms->positional, &ms->curPositional);
     instance->_F4[2] += 1;
-    p = (GnRobotKey*)intro;
+    p = (GnRobotKeyframe*)intro;
     if (((int*)intro)[1] > 0) {
         i = 0;
         do {

--- a/src/level/SPY.c
+++ b/src/level/SPY.c
@@ -228,7 +228,77 @@ void spy_onoff_OnUpdate(Instance* instance, GameTracker* gameTracker) {
     }
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/SPY", spy_onoff_OnCollide);
+extern int D_8015AE0C_EC4DC;
+extern int D_8015AE10_EC4E0;
+
+void spy_onoff_OnCollide(Instance* instance, GameTracker* gameTracker) {
+    short* config;
+    BSPTree* bsp;
+    int** list;
+    Instance* other;
+    int match;
+    int toggled;
+    int checkState;
+    int fire;
+    short i;
+
+    match = 0;
+    toggled = 0;
+    checkState = 0;
+    fire = 0;
+    config = instance->introData;
+    bsp = instance->bspTree;
+    if (config != NULL && bsp->_06 == 1 && bsp->_0C[5] >= 8U && instance->_F4[1] != 1) {
+        list = (int**)(config + 2);
+        if (config[1] == 0) {
+            match = 1;
+        } else if (config[1] == 1) {
+            if (instance->_F4[0] == 0) {
+                match = 1;
+                checkState = 1;
+            }
+        } else if (config[1] == 2) {
+            if (instance->_F4[0] == 1) {
+                match = 1;
+                checkState = 1;
+            }
+        }
+        for (i = 0; i < config[0]; i++, list++) {
+            other = ((Intro*)list[0])->instance;
+            if (other == NULL) continue;
+            if (other->flags & 0x2000000) continue;
+            if (match == 0) continue;
+            if (checkState != 0) {
+                if (!((((unsigned short*)config)[1] & 1) && !(other->flags & 0x1000000))) {
+                    if (!(((unsigned short*)config)[1] & 2)) continue;
+                    if (!(other->flags & 0x1000000)) continue;
+                }
+            }
+            other->flags &= ~0x100000;
+            if (!(other->flags2 & 0x10000)) {
+                other->flags2 |= 0x1000;
+            }
+            other->flags |= 0x2000000;
+            toggled = 1;
+        }
+        if ((match != 0 && toggled != 0) || config[0] == 0) {
+            instance->intro->flags ^= 0x800;
+            instance->_F4[0] ^= 1;
+            fire = 1;
+        } else if (*(int*)instance->object->name == D_8015AE0C_EC4DC
+                   && ((int*)instance->object->name)[1] == D_8015AE10_EC4E0) {
+            fire = 1;
+        }
+        if (fire != 0) {
+            if (((short*)&instance->object->_08)[1] != 0) {
+                instance->_F4[1] = 1;
+            }
+            if (*(int*)list == 0x29A) {
+                SIGNAL_HandleSignal(instance, (int*)((int*)list)[1] + 1, 0);
+            }
+        }
+    }
+}
 
 extern short D_8015AD70_EC440[];
 

--- a/src/level/SPY.c
+++ b/src/level/SPY.c
@@ -9,7 +9,12 @@ void spy_qsofa_OnCreate(Instance* instance, GameTracker* gameTracker) {
 
 INCLUDE_ASM("asm/nonmatchings/level/SPY", spy_qsofa_OnUpdate);
 
-INCLUDE_ASM("asm/nonmatchings/level/SPY", spy_qsofa_OnCollide);
+void spy_qsofa_OnCollide(Instance* instance, GameTracker* gameTracker) {
+    BSPTree* bsp = instance->bspTree;
+    if ((bsp->_06 == 4) && (bsp->instanceSpline == PlayerInstance) && (bsp->_04 == 5)) {
+        instance->_F4[0] = 1;
+    }
+}
 
 void spy_launch_OnCreate(Instance* instance, GameTracker* gameTracker) {
     short* objData;
@@ -147,11 +152,32 @@ void spy_onoff_OnUpdate(Instance* instance, GameTracker* gameTracker) {
 
 INCLUDE_ASM("asm/nonmatchings/level/SPY", spy_onoff_OnCollide);
 
-INCLUDE_ASM("asm/nonmatchings/level/SPY", spy_gnrobot_OnCreate);
+extern short D_8015AD70_EC440[];
+
+void spy_gnrobot_OnCreate(Instance* instance, GameTracker* gameTracker) {
+    if (instance->introData == NULL) {
+        instance->introData = D_8015AD70_EC440;
+    }
+    instance->_100 = ((short*)instance->introData)[1];
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/SPY", spy_gnrobot_OnUpdate);
 
-INCLUDE_ASM("asm/nonmatchings/level/SPY", spy_gnrobot_OnCollide);
+void spy_gnrobot_OnCollide(Instance* instance, GameTracker* gameTracker) {
+    BSPTree* bsp;
+    int* fc;
+
+    bsp = instance->bspTree;
+    fc = &instance->_F4[2];
+    if ((bsp->instanceSpline == PlayerInstance) && (bsp->_0C[5] == 8)) {
+        fc[1] -= 1;
+    }
+    if (fc[1] == 0) {
+        INSTANCE_KillInstance(instance);
+    } else {
+        func_80022D54(instance, gameTracker);
+    }
+}
 
 void spy_btimer_OnCreate(Instance* instance, GameTracker* gameTracker) {
     int var_s0;

--- a/src/level/SPY.c
+++ b/src/level/SPY.c
@@ -72,12 +72,15 @@ void spy_launch_OnCreate(Instance* instance, GameTracker* gameTracker) {
 }
 
 INCLUDE_ASM("asm/nonmatchings/level/SPY", spy_launch_OnUpdate);
-/* near-match (45 diff words from two 1-instruction scheduler windows, all else identical):
-   1) the _110-update block: KMC hoists the lw above the inner beqz and delay-fills the subu;
-      our GCC keeps the lw in the block with an extra nop (speculative-load hoist difference).
-   2) player->_F4[2] & ~0x40 & ~0x400: KMC emits two ands (reusing the ~0x400 reg from
-      instance->flags); our combine always folds the constants into one and (~0x440),
-      even through a shared mask variable.
+/* near-match: every instruction matches except ONE scheduler window in the state-1 block.
+   The target emits [slt; lw _110; nop; beqz; subu-in-delay] - KMC's reorg pulls the lw
+   above the branch and delay-fills the subu (a 2-insn thread steal). Our GCC either
+   leaves the lw inside the block (extra nop) or, with the load written before the if,
+   hoists it above the slt as well. All arrangements are +/-1 instruction.
+   Note the mask40/mask400 variables below are REQUIRED and correct: with literal
+   constants the tree folds ~0x40 & ~0x400 into ~0x440 at parse time, while the target
+   has two separate ands sharing the ~0x400 register with the instance->flags clear
+   (KMC combine does not substitute a multi-use constant register).
 extern Object* D_8007684C;
 extern int D_800EB8A0;
 
@@ -164,8 +167,12 @@ void spy_launch_OnUpdate(Instance* instance, GameTracker* gameTracker) {
     if (instance->_F4[0] >= 2) {
         if (instance->_F4[1] >= 5 || instance->_F4[0] != 2) {
             if (func_800257B4(player) != 0 || (player->_F4[1] & 0x8000)) {
-                instance->flags &= ~0x400;
-                player->_F4[2] = player->_F4[2] & ~0x40 & ~0x400;
+                int mask40;
+                int mask400;
+                mask400 = ~0x400;
+                mask40 = ~0x40;
+                instance->flags &= mask400;
+                player->_F4[2] = player->_F4[2] & mask40 & mask400;
                 instance->_F4[0] = 0;
                 instance->_F4[1] = 0;
             }


### PR DESCRIPTION
## Summary

40 newly matched functions, verified with a full clean build (`make clean && make split && make build && make diff` — no differences). The bulk is a cross-level "twin harvest": functions already matched in one level ported to their byte-identical counterparts in other levels, plus SPY/MAP/LOONEY decompilation and two long-standing puzzles solved (`rezop_btimer_OnUpdate`, `COLLIDE_PointAndTerrain`).

## Functions

| Module | Functions |
|---|---|
| SPY | spy_gnrobot_OnCreate/OnUpdate/OnCollide, spy_qsofa_OnUpdate/OnCollide, spy_onoff_OnCollide, func_80159F3C_EB60C, func_8015A098_EB768 |
| MAP | map_tvmenu_OnUpdate |
| LOONEY | looney_fxgen_OnCreate, looney_fallgen_OnCreate, func_8015B4BC_B376C |
| KUNGFU | kungfu_onoff_OnCollide, kungfu_bug_OnCreate/OnCollide, launch trio (func_8015AC6C_A9E8C, func_8015AD44_A9F64, func_8015ADC8_A9FE8), terrain probe/resolver (func_8015D5E8_AC808, func_8015D770_AC990), func_80161944_B0B64 |
| CIRCUIT | circuit_bug_OnCreate/OnCollide, circuit_fxgen_OnCreate, launch trio (func_8015D354_84534, func_8015D42C_8460C, func_8015D4B0_84690) |
| GEXZIL / PREHST | gexzil_bug_OnCreate/OnCollide, prehst_bug_OnCreate/OnCollide |
| SCIFI / HORROR | scifi_onoff_OnCollide, func_801621D4_E7FF4, horror_onoff_OnCollide |
| REZOP | rezop_btimer_OnUpdate, rezop_snkplat_OnCollide |
| Core | COLLIDE_PointAndTerrain (COLLIDE_D), G2Quat_ToEuler (161C0), func_80052F58, func_80052F7C (_532f0) |

Two documented near-matches remain as INCLUDE_ASM with commented attempts: spy_launch_OnUpdate (45/287 words, scheduler-only diffs) and map_start_OnUpdate (11/309 words, same class).

## Notes / techniques

- **rezop_btimer_OnUpdate** resolves the old "Failing to match due to ro section?" comment: the function's `%d` format string is emitted earlier in the TU by a still-undecompiled function (the `D_80161590_D9D00` rodata blob). Writing the literal duplicated the string and shifted `.rodata`; referencing the blob symbol via `extern char D_80161590_D9D00[]` produces identical code and a byte-identical rodata section. When the owning function is eventually decompiled, this extern should flip back to a `"%d"` literal (inline comment documents this).
- **COLLIDE_PointAndTerrain** turned out to be a thin wrapper: `return func_8000F0DC(segmentAddress, newPoint, oldPoint, 1, instance, 0, 0);`
- Twin ports were verified word-by-word against the target assembly and at the ROM level; level-specific constants found this way: KUNGFU launch trio uses sound ID `0x6A` (SPY/CIRCUIT use `0x18`), circuit_fxgen uses `0x46` (LOONEY uses `0x78`).
- `func_8015AC1C_A9E3C` (KUNGFU) and `func_8015D304_844E4` (CIRCUIT) gained the `GameTracker*` parameter to match their SPY twin `func_80159EEC_EB5BC` and their callers.
