### PR TITLE
Decompile 52 small level functions across 9 levels

### DIFF
--- a/src/level/CIRCUIT.c
+++ b/src/level/CIRCUIT.c
@@ -205,7 +205,12 @@ INCLUDE_ASM("asm/nonmatchings/level/CIRCUIT", func_8015BA9C_82C7C);
 
 INCLUDE_ASM("asm/nonmatchings/level/CIRCUIT", circuit_ebridge_OnUpdate);
 
-INCLUDE_ASM("asm/nonmatchings/level/CIRCUIT", circuit_ebridge_OnCollide);
+void circuit_ebridge_OnCollide(Instance* instance, GameTracker* gameTracker) {
+    if (instance->bspTree->instanceSpline == gameTracker->player) {
+        instance->_D0[0] = 10;
+        instance->_120 |= 1;
+    }
+}
 
 void circuit_ebrijac_OnCreate(Instance* instance, GameTracker* gameTracker) {
     int* intro;
@@ -218,7 +223,19 @@ void circuit_ebrijac_OnCreate(Instance* instance, GameTracker* gameTracker) {
     instance->_104 = 0;
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/CIRCUIT", circuit_ebrijac_OnUpdate);
+void circuit_ebrijac_OnUpdate(Instance* instance, GameTracker* gameTracker) {
+    if (instance->_104 != 0) {
+        if (instance->scale.z == 0x1000) {
+            instance->scale.z = 0x800;
+            func_8002E704();
+        }
+    } else {
+        if (instance->scale.z != 0x1000) {
+            instance->scale.z = 0x1000;
+            func_8002E704();
+        }
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/CIRCUIT", circuit_ebrijac_OnCollide);
 
@@ -387,7 +404,13 @@ void func_8015D4B0_84690(Instance* instance, GameTracker* gameTracker) {
     func_8004AAA8(instance, 0x18, 0);
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/CIRCUIT", circuit_follow_OnCreate);
+void circuit_follow_OnCreate(Instance* instance, GameTracker* gameTracker) {
+    if ((instance->intro->flags & 0x80) == 0) {
+        instance->flags |= 0x400;
+    }
+    instance->_100 = 1;
+    instance->flags |= 0x100800;
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/CIRCUIT", circuit_follow_OnUpdate);
 
@@ -420,11 +443,24 @@ INCLUDE_ASM("asm/nonmatchings/level/CIRCUIT", func_8015DB80_84D60);
 
 INCLUDE_ASM("asm/nonmatchings/level/CIRCUIT", circuit_ppath_OnCreate);
 
-INCLUDE_ASM("asm/nonmatchings/level/CIRCUIT", func_8015DD58_84F38);
+void func_8015DD58_84F38(Instance* instance) {
+    if (instance->_F4[0] != 2) {
+        instance->_F4[0] = 2;
+    } else {
+        Model* model;
+
+        model = instance->object->modelList[instance->currentModel];
+        instance->currentTextureAnimFrame = ((int*)model->_20)[2] * ((int*)model->_20)[3] >> 1;
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/CIRCUIT", circuit_ppath_OnUpdate);
 
-INCLUDE_ASM("asm/nonmatchings/level/CIRCUIT", circuit_ppath_OnCollide);
+void circuit_ppath_OnCollide(Instance* instance, GameTracker* gameTracker) {
+    if (instance->object->oflags & 0x400) {
+        GenericCollide(instance, gameTracker);
+    }
+}
 
 extern char D_801635A0_8A780[];
 
@@ -534,7 +570,16 @@ INCLUDE_ASM("asm/nonmatchings/level/CIRCUIT", circuit_reza_OnUpdate);
 
 INCLUDE_ASM("asm/nonmatchings/level/CIRCUIT", circuit_reza_OnCollide);
 
-INCLUDE_ASM("asm/nonmatchings/level/CIRCUIT", func_8015F6B8_86898);
+void func_8015F6B8_86898(Instance* instance, int arg1, int arg2) {
+    instance->_F4[0] = 1;
+    instance->_F4[1] = 2;
+    instance->currentModelAnim = 1;
+    instance->currentAnimFrame = 0;
+    *(short*)&instance->_110 = arg1;
+    ((short*)&instance->_110)[1] = arg2;
+    instance->flags &= ~1;
+    func_8015FC70_86E50(instance);
+}
 
 void func_8015F708_868E8(Instance* instance) {
     instance->_F4[0] = 5;
@@ -563,7 +608,23 @@ void func_8015F75C_8693C(Instance* instance) {
     instance->currentModelAnim = val2;
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/CIRCUIT", func_8015F780_86960);
+/* walks a list of 0x14-byte weighted records, returning the record where
+   the running weight sum first exceeds val (weighted random pick) */
+int* func_8015F780_86960(int* p, int val) {
+    int sum;
+
+    sum = 0;
+    if (val >= 0) {
+        while (1) {
+            sum += p[0];
+            if (val < sum) {
+                break;
+            }
+            p += 0x14 / 4;
+        }
+    }
+    return p;
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/CIRCUIT", circuit_robo_OnCreate);
 
@@ -618,7 +679,14 @@ INCLUDE_ASM("asm/nonmatchings/level/CIRCUIT", circuit_explode_OnCreate);
 
 INCLUDE_ASM("asm/nonmatchings/level/CIRCUIT", circuit_explode_OnUpdate);
 
-INCLUDE_ASM("asm/nonmatchings/level/CIRCUIT", circuit_explode_OnCollide);
+void circuit_explode_OnCollide(Instance* instance, GameTracker* gameTracker) {
+    BSPTree* bsp;
+
+    bsp = instance->bspTree;
+    if (bsp->instanceSpline == gameTracker->player && bsp->_06 == 1) {
+        func_80022714(instance, gameTracker);
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/CIRCUIT", circuit_pulse_OnCreate);
 

--- a/src/level/FINAL.c
+++ b/src/level/FINAL.c
@@ -68,7 +68,15 @@ void final_reztvex_OnCreate(Instance* arg0, GameTracker* gameTracker) {
     arg0->flags |= 0x80;
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/FINAL", final_reztvex_OnUpdate);
+void final_reztvex_OnUpdate(Instance* instance, GameTracker* gameTracker) {
+    instance->currentTextureAnimFrame += 1;
+    *(unsigned short*)&instance->scale.x += 0xEC;
+    *(unsigned short*)&instance->scale.y += 0xEC;
+    *(unsigned short*)&instance->scale.z += 0x9D;
+    if (instance->scale.x >= 0x1000) {
+        func_8002E350(instance);
+    }
+}
 
 void final_reztvex_OnCollide(Instance* instance, GameTracker* gameTracker) {
 }
@@ -94,7 +102,13 @@ void final_rezxpl_OnCollide(Instance* instance, GameTracker* gameTracker) {
 
 INCLUDE_RODATA("asm/nonmatchings/level/FINAL", D_80161588_92728);
 
-INCLUDE_ASM("asm/nonmatchings/level/FINAL", final_rezbomb_OnCreate);
+extern char D_80161588_92728[];
+
+void final_rezbomb_OnCreate(Instance* instance, GameTracker* gameTracker) {
+    *(short*)&instance->_E0[0] = 0;
+    instance->_F4[0] = OBTABLE_FindObject(D_80161588_92728);
+    instance->_F4[1] = OBTABLE_FindObject("rezxpl__");
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/FINAL", func_80159E50_8AFF0);
 
@@ -133,7 +147,12 @@ INCLUDE_ASM("asm/nonmatchings/level/FINAL", func_8015AC70_8BE10);
 
 INCLUDE_ASM("asm/nonmatchings/level/FINAL", func_8015ADC4_8BF64);
 
-INCLUDE_ASM("asm/nonmatchings/level/FINAL", func_8015AE98_8C038);
+extern int D_800785C8;
+
+void func_8015AE98_8C038(void) {
+    PlayerInstance->_F4[0] = D_800785C8;
+    func_80003234(gameTracker8->camera);
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/FINAL", func_8015AED8_8C078);
 
@@ -167,9 +186,43 @@ INCLUDE_ASM("asm/nonmatchings/level/FINAL", func_8015C850_8D9F0);
 
 INCLUDE_ASM("asm/nonmatchings/level/FINAL", func_8015C9D0_8DB70);
 
-INCLUDE_ASM("asm/nonmatchings/level/FINAL", func_8015CAF8_8DC98);
+/* format val as 8 uppercase hex digits into buf */
+void func_8015CAF8_8DC98(char* buf, int val) {
+    int i;
+    char* p;
+    unsigned int d;
 
-INCLUDE_ASM("asm/nonmatchings/level/FINAL", func_8015CB34_8DCD4);
+    i = 7;
+    p = buf + 7;
+    for (; i >= 0; i--) {
+        d = val & 0xF;
+        val >>= 4;
+        if (d < 10) {
+            *p = d + '0';
+        } else {
+            *p = d + 'A' - 10;
+        }
+        p--;
+    }
+    buf[8] = 0;
+}
+
+/* format val as 4 uppercase hex digits into buf */
+void func_8015CB34_8DCD4(char* buf, short val) {
+    int i;
+    char* p;
+    unsigned int d;
+
+    i = 3;
+    p = buf + 3;
+    for (; i >= 0; i--) {
+        d = val & 0xF;
+        val >>= 4;
+        *p = d < 10 ? d + '0' : d + 'A' - 10;
+        p--;
+    }
+    buf[4] = 0;
+}
 
 INCLUDE_RODATA("asm/nonmatchings/level/FINAL", D_801615B8_92758);
 
@@ -211,7 +264,17 @@ INCLUDE_RODATA("asm/nonmatchings/level/FINAL", D_80161670_92810);
 
 INCLUDE_ASM("asm/nonmatchings/level/FINAL", final_popper_OnUpdate);
 
-INCLUDE_ASM("asm/nonmatchings/level/FINAL", final_popper_OnCollide);
+extern int D_80161618_927B8;
+extern int D_8016161C_927BC;
+
+void final_popper_OnCollide(Instance* instance, GameTracker* gameTracker) {
+    const char* name;
+
+    name = instance->bspTree->instanceSpline->object->name;
+    if (((int*)name)[0] == D_80161618_927B8 && ((int*)name)[1] == D_8016161C_927BC) {
+        *(short*)&instance->_F4[2] = 3;
+    }
+}
 
 void final_finaltv_OnCreate(Instance* instance, GameTracker* gameTracker) {
     instance->position.x = 11520;
@@ -240,7 +303,6 @@ INCLUDE_ASM("asm/nonmatchings/level/FINAL", func_8015F480_90620);
 
 INCLUDE_ASM("asm/nonmatchings/level/FINAL", func_8015F818_909B8);
 
-extern char D_80161588_92728[];
 extern char D_8016166C_9280C[];
 extern void func_8015F200_903A0(void); // unknown
 

--- a/src/level/FINAL.c
+++ b/src/level/FINAL.c
@@ -264,14 +264,13 @@ INCLUDE_RODATA("asm/nonmatchings/level/FINAL", D_80161670_92810);
 
 INCLUDE_ASM("asm/nonmatchings/level/FINAL", final_popper_OnUpdate);
 
-extern int D_80161618_927B8;
-extern int D_8016161C_927BC;
+extern char D_80161618_927B8[];
 
 void final_popper_OnCollide(Instance* instance, GameTracker* gameTracker) {
     const char* name;
 
     name = instance->bspTree->instanceSpline->object->name;
-    if (((int*)name)[0] == D_80161618_927B8 && ((int*)name)[1] == D_8016161C_927BC) {
+    if (G2String_Compare_EQ(name, D_80161618_927B8)) {
         *(short*)&instance->_F4[2] = 3;
     }
 }

--- a/src/level/FINAL.c
+++ b/src/level/FINAL.c
@@ -267,10 +267,7 @@ INCLUDE_ASM("asm/nonmatchings/level/FINAL", final_popper_OnUpdate);
 extern char D_80161618_927B8[];
 
 void final_popper_OnCollide(Instance* instance, GameTracker* gameTracker) {
-    const char* name;
-
-    name = instance->bspTree->instanceSpline->object->name;
-    if (G2String_Compare_EQ(name, D_80161618_927B8)) {
+    if (G2String_Compare_EQ(instance->bspTree->instanceSpline->object->name, D_80161618_927B8)) {
         *(short*)&instance->_F4[2] = 3;
     }
 }

--- a/src/level/GEXZIL.c
+++ b/src/level/GEXZIL.c
@@ -99,9 +99,29 @@ INCLUDE_ASM("asm/nonmatchings/level/GEXZIL", func_8015B144_942C4);
 
 INCLUDE_ASM("asm/nonmatchings/level/GEXZIL", func_8015B220_943A0);
 
-INCLUDE_ASM("asm/nonmatchings/level/GEXZIL", func_8015B334_944B4);
+int func_8015B334_944B4(Instance* instance) {
+    int* intro;
+    int result;
+    int flag;
 
-INCLUDE_ASM("asm/nonmatchings/level/GEXZIL", gexzil_mechjet_OnCreate);
+    intro = (int*)instance->introData;
+    if (intro != 0) {
+        result = intro[0xFC / 4] < intro[0x100 / 4];
+    } else {
+        /* with no introData, the intro field slot holds flag bits here */
+        flag = (int)instance->intro & 8;
+        result = flag == 0;
+    }
+    return result;
+}
+
+void gexzil_mechjet_OnCreate(Instance* instance, GameTracker* gameTracker) {
+    if (instance->flags & 0x20000) {
+        ((int*)instance->parent->object->data)[0x94 / 4] = 0;
+    } else {
+        instance->flags |= 0x10400;
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/GEXZIL", gexzil_mechjet_OnUpdate);
 
@@ -307,7 +327,16 @@ INCLUDE_ASM("asm/nonmatchings/level/GEXZIL", gexzil_mecha_OnCollide);
 
 INCLUDE_ASM("asm/nonmatchings/level/GEXZIL", func_80160B70_99CF0);
 
-INCLUDE_ASM("asm/nonmatchings/level/GEXZIL", func_80160BD8_99D58);
+/* p0/p1 are packed short pairs (x in the high half, y in the low half) */
+int func_80160BD8_99D58(int p0, int p1) {
+    int angle;
+
+    angle = (short)ratan2(((short*)&p1)[1] - ((short*)&p0)[1], ((short*)&p1)[0] - ((short*)&p0)[0]);
+    if (angle < 0) {
+        angle += 0x1000;
+    }
+    return angle;
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/GEXZIL", func_80160C28_99DA8);
 
@@ -520,7 +549,14 @@ INCLUDE_ASM("asm/nonmatchings/level/GEXZIL", gexzil_explode_OnCreate);
 
 INCLUDE_ASM("asm/nonmatchings/level/GEXZIL", gexzil_explode_OnUpdate);
 
-INCLUDE_ASM("asm/nonmatchings/level/GEXZIL", gexzil_explode_OnCollide);
+void gexzil_explode_OnCollide(Instance* instance, GameTracker* gameTracker) {
+    BSPTree* bsp;
+
+    bsp = instance->bspTree;
+    if (bsp->instanceSpline == gameTracker->player && bsp->_06 == 1) {
+        func_80022714(instance, gameTracker);
+    }
+}
 
 INCLUDE_RODATA("asm/nonmatchings/level/GEXZIL", D_80162B70_9BCF0);
 

--- a/src/level/GEXZIL.c
+++ b/src/level/GEXZIL.c
@@ -99,17 +99,16 @@ INCLUDE_ASM("asm/nonmatchings/level/GEXZIL", func_8015B144_942C4);
 
 INCLUDE_ASM("asm/nonmatchings/level/GEXZIL", func_8015B220_943A0);
 
-int func_8015B334_944B4(Instance* instance) {
-    int* intro;
+int func_8015B334_944B4(Intro* intro) {
+    Instance* instance;
     int result;
     int flag;
 
-    intro = (int*)instance->introData;
-    if (intro != 0) {
-        result = intro[0xFC / 4] < intro[0x100 / 4];
+    instance = intro->instance;
+    if (instance != 0) {
+        result = instance->_F4[2] < instance->_100;
     } else {
-        /* with no introData, the intro field slot holds flag bits here */
-        flag = (int)instance->intro & 8;
+        flag = intro->flags & 8;
         result = flag == 0;
     }
     return result;

--- a/src/level/HORROR.c
+++ b/src/level/HORROR.c
@@ -12,18 +12,52 @@ extern int D_80154834;
 extern int D_80164C30_A8460;
 
 
-INCLUDE_ASM("asm/nonmatchings/level/HORROR", horror_drawer_OnCreate);
+void horror_drawer_OnCreate(Instance* instance, GameTracker* gameTracker) {
+    int* intro;
+    int v;
+
+    intro = (int*)instance->introData;
+    if (intro != 0) {
+        v = intro[0];
+        instance->_F4[0] = v;
+        if (v == 1) {
+            instance->scale.x = 1;
+            func_8002E704();
+        }
+    } else {
+        instance->_F4[0] = 0;
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/HORROR", horror_drawer_OnUpdate);
 
 void horror_drawer_OnCollide(Instance* instance, GameTracker* gameTracker) {
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/HORROR", horror_chandb_OnCreate);
+void horror_chandb_OnCreate(Instance* instance, GameTracker* gameTracker) {
+    int* intro;
+
+    intro = (int*)instance->introData;
+    instance->_F4[0] = 0;
+    instance->flags |= 0x100000;
+    if (intro[0] == 1) {
+        instance->currentModelAnim = 1;
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/HORROR", horror_chandb_OnUpdate);
 
-INCLUDE_ASM("asm/nonmatchings/level/HORROR", horror_chandb_OnCollide);
+void horror_chandb_OnCollide(Instance* instance, GameTracker* gameTracker) {
+    BSPTree* bsp;
+
+    bsp = instance->bspTree;
+    if (bsp->_04 == 1) {
+        instance->_F4[1] = 2;
+    }
+    if (bsp->_06 == 4) {
+        instance->_F4[1] = 1;
+    }
+}
 
 void horror_chand_OnCreate(Instance* instance, GameTracker* gameTracker) {
     instance->_E0[1] = -8;
@@ -35,7 +69,17 @@ void horror_chand_OnCreate(Instance* instance, GameTracker* gameTracker) {
 
 INCLUDE_ASM("asm/nonmatchings/level/HORROR", horror_chand_OnUpdate);
 
-INCLUDE_ASM("asm/nonmatchings/level/HORROR", horror_chand_OnCollide);
+void horror_chand_OnCollide(Instance* instance, GameTracker* gameTracker) {
+    int on;
+
+    on = 1;    /* materialized early — required for the original register allocation */
+    if (instance->bspTree->_06 == 4) {
+        instance->_F4[1] = on;
+    }
+    if (instance->intro->multiSpline != 0) {
+        GenericCollide(instance, gameTracker);
+    }
+}
 
 void horror_axe_OnCreate(Instance* instance, GameTracker* gameTracker) {
     int v;
@@ -58,13 +102,38 @@ INCLUDE_ASM("asm/nonmatchings/level/HORROR", func_8015A014_9D844);
 
 INCLUDE_ASM("asm/nonmatchings/level/HORROR", horror_axe_OnUpdate);
 
-INCLUDE_ASM("asm/nonmatchings/level/HORROR", horror_axe_OnCollide);
+void horror_axe_OnCollide(Instance* instance, GameTracker* gameTracker) {
+    BSPTree* bsp;
 
-INCLUDE_ASM("asm/nonmatchings/level/HORROR", horror_face_OnCreate);
+    bsp = instance->bspTree;
+    if (bsp->_06 == 1 && bsp->instanceSpline == gameTracker->player && instance->_F4[0] != 0) {
+        func_80022714(instance, gameTracker);
+    }
+}
+
+void horror_face_OnCreate(Instance* instance, GameTracker* gameTracker) {
+    instance->_F4[0] = 1;
+    instance->flags |= 0x100000;
+    if (((short*)instance->introData)[1] != 0) {
+        instance->_F4[0] = 0;
+        instance->flags |= 0x800;
+    }
+    instance->_104 = 0;
+    *(int*)&instance->_108 = 0;
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/HORROR", horror_face_OnUpdate);
 
-INCLUDE_ASM("asm/nonmatchings/level/HORROR", horror_face_OnCollide);
+void horror_face_OnCollide(Instance* instance, GameTracker* gameTracker) {
+    BSPTree* bsp;
+    int state;
+
+    state = instance->_F4[0];
+    bsp = instance->bspTree;
+    if (state == 1 && bsp->_06 == 1 && bsp->instanceSpline == gameTracker->player) {
+        func_80022714(instance, gameTracker);
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/HORROR", horror_zombie_OnCreate);
 
@@ -106,7 +175,16 @@ INCLUDE_ASM("asm/nonmatchings/level/HORROR", func_8015BF7C_9F7AC);
 
 INCLUDE_ASM("asm/nonmatchings/level/HORROR", horror_huckhed_OnCollide);
 
-INCLUDE_ASM("asm/nonmatchings/level/HORROR", horror_gate_OnCreate);
+void horror_gate_OnCreate(Instance* instance, GameTracker* gameTracker) {
+    short* intro;
+
+    intro = (short*)instance->introData;
+    if (intro != 0 && intro[0] == 1) {
+        instance->scale.z = 1;
+        instance->_F4[0] = 2;
+        func_8002E704();
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/HORROR", horror_gate_OnUpdate);
 
@@ -145,7 +223,14 @@ void horror_ldgeact_OnCollide(Instance* instance, GameTracker* gameTracker) {
 void horror_bkshlf_OnCreate(Instance* instance, GameTracker* gameTracker) {
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/HORROR", horror_bkshlf_OnUpdate);
+void horror_bkshlf_OnUpdate(Instance* instance, GameTracker* gameTracker) {
+    if (instance->_F4[1] == 1) {
+        *(unsigned short*)&instance->rotation.z -= 0xC;
+    } else if (instance->_F4[1] == 2) {
+        *(unsigned short*)&instance->rotation.z += 0xC;
+    }
+    instance->_F4[1] = 0;
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/HORROR", horror_bkshlf_OnCollide);
 
@@ -432,7 +517,17 @@ INCLUDE_ASM("asm/nonmatchings/level/HORROR", horror_evileye_OnCollide);
 
 INCLUDE_ASM("asm/nonmatchings/level/HORROR", horror_splitob_OnCreate);
 
-INCLUDE_ASM("asm/nonmatchings/level/HORROR", horror_splitob_OnUpdate);
+void horror_splitob_OnUpdate(Instance* instance, GameTracker* gameTracker) {
+    Instance* player;
+
+    player = PlayerInstance;
+    if (player->position.z < instance->_100 && instance->_100 - 0x100 < player->position.z) {
+        *(int*)&player->_C0[0] = instance->_F4[2];
+        player->_C0[2] = player->position.x;
+        player->_C0[3] = player->position.y;
+        player->_C0[4] = instance->_100;
+    }
+}
 
 void horror_splitob_OnCollide(Instance* instance, GameTracker* gameTracker) {
 }
@@ -444,7 +539,17 @@ void horror_elevpan_OnCreate(Instance* instance, GameTracker* gameTracker) {
     }
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/HORROR", horror_elevpan_OnUpdate);
+extern int D_80078654;
+
+void horror_elevpan_OnUpdate(Instance* instance, GameTracker* gameTracker) {
+    short* intro;
+
+    intro = (short*)instance->introData;
+    if (D_80078654 != 0 && instance->currentTextureAnimFrame != 1) {
+        instance->currentTextureAnimFrame = 1;
+        intro[0] = 1;
+    }
+}
 
 void horror_elevpan_OnCollide(Instance* instance, GameTracker* gameTracker) {
 }

--- a/src/level/KUNGFU.c
+++ b/src/level/KUNGFU.c
@@ -16,7 +16,20 @@ void kungfu_kboat_OnCollide(Instance* instance, GameTracker* gameTracker) {
     GenericCollide(instance, gameTracker);
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", kungfu_kbgen_OnCreate);
+void kungfu_kbgen_OnCreate(Instance* instance, GameTracker* gameTracker) {
+    int* intro;
+
+    intro = (int*)instance->introData;
+    instance->_F4[0] = 0;
+    instance->flags |= 0x100C00;
+    if (intro != 0) {
+        if (intro[3] == 0 || (((unsigned short*)intro)[0xC] & 4)) {
+            instance->_F4[2] = intro[2];
+        } else {
+            instance->_F4[0] = 1;
+        }
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", kungfu_kbgen_OnUpdate);
 
@@ -482,7 +495,16 @@ INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", kungfu_spike_OnCreate);
 
 INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", kungfu_spike_OnUpdate);
 
-INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", kungfu_spike_OnCollide);
+void kungfu_spike_OnCollide(Instance* instance, GameTracker* gameTracker) {
+    int frame;
+    BSPTree* bsp;
+
+    frame = instance->currentAnimFrame;
+    bsp = instance->bspTree;
+    if (frame != 0 && bsp->instanceSpline == gameTracker->player) {
+        func_80022714(instance, gameTracker);
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", func_8015B5A8_AA7C8);
 
@@ -618,7 +640,14 @@ void func_8015DB50_ACD70(Instance* instance, short* arg1) {
     instance->position = instance->initialPos;
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", func_8015DBB0_ACDD0);
+void func_8015DBB0_ACDD0(Instance* instance, short* arg1) {
+    instance->flags2 &= ~0x10;
+    arg1[0x18 / 2] = 1;
+    if (instance->currentModelAnim != 0 && instance->currentModelAnim != 5) {
+        instance->currentModelAnim = arg1[0x10 / 2] != 0 ? 5 : 0;
+        instance->currentAnimFrame = 0;
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", func_8015DC00_ACE20);
 
@@ -741,7 +770,13 @@ INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", func_80160F68_B0188);
 
 INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", kungfu_joyride_OnCreate);
 
-INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", func_8016121C_B043C);
+void func_8016121C_B043C(Instance* instance, GameTracker* gameTracker) {
+    Instance* player;
+
+    player = gameTracker->player;
+    func_8004AEC8(instance, 0, 0, 0x80, (SVECTOR*)((short*)instance->_D0 + 5));
+    player->position = *(SVECTOR*)((short*)instance->_D0 + 5);
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", kungfu_joyride_OnUpdate);
 

--- a/src/level/LOONEY.c
+++ b/src/level/LOONEY.c
@@ -1,6 +1,7 @@
 #include "common.h"
 
 #include "level/LOONEY.h"
+#include "types/G2String.h"
 #include "OBTABLE.h"
 #include "MATRIX.h"
 
@@ -487,8 +488,7 @@ INCLUDE_ASM("asm/nonmatchings/level/LOONEY", looney_trapmuv_OnUpdate);
 void looney_trapmuv_OnCollide(Instance* instance, GameTracker* gameTracker) {
 }
 
-extern int D_80161E00_BA0B0;
-extern int D_80161E04_BA0B4;
+extern char D_80161E00_BA0B0[];
 
 void looney_pusher_OnCreate(Instance* instance, GameTracker* gameTracker) {
     const char* name;
@@ -496,7 +496,7 @@ void looney_pusher_OnCreate(Instance* instance, GameTracker* gameTracker) {
     *(int*)&instance->_108 = 0;
     instance->_100 = 0;
     name = instance->object->name;
-    if (((int*)name)[0] == D_80161E00_BA0B0 && ((int*)name)[1] == D_80161E04_BA0B4) {
+    if (G2String_Compare_EQ(name, D_80161E00_BA0B0)) {
         instance->_104 = 0;
     } else {
         instance->_104 = 0x14;

--- a/src/level/LOONEY.c
+++ b/src/level/LOONEY.c
@@ -491,12 +491,9 @@ void looney_trapmuv_OnCollide(Instance* instance, GameTracker* gameTracker) {
 extern char D_80161E00_BA0B0[];
 
 void looney_pusher_OnCreate(Instance* instance, GameTracker* gameTracker) {
-    const char* name;
-
     *(int*)&instance->_108 = 0;
     instance->_100 = 0;
-    name = instance->object->name;
-    if (G2String_Compare_EQ(name, D_80161E00_BA0B0)) {
+    if (G2String_Compare_EQ(instance->object->name, D_80161E00_BA0B0)) {
         instance->_104 = 0;
     } else {
         instance->_104 = 0x14;

--- a/src/level/LOONEY.c
+++ b/src/level/LOONEY.c
@@ -459,7 +459,19 @@ INCLUDE_ASM("asm/nonmatchings/level/LOONEY", looney_teeter_OnUpdate);
 
 INCLUDE_ASM("asm/nonmatchings/level/LOONEY", looney_teeter_OnCollide);
 
-INCLUDE_ASM("asm/nonmatchings/level/LOONEY", looney_trapsit_OnCreate);
+extern short D_80161CA4_B9F54[];
+
+void looney_trapsit_OnCreate(Instance* instance, GameTracker* gameTracker) {
+    if (instance->introData == 0) {
+        instance->introData = D_80161CA4_B9F54;
+    }
+    instance->_104 = instance->position.z;
+    if (((short*)instance->introData)[0] == 0) {
+        instance->_F4[2] = 2;
+    } else {
+        instance->_F4[2] = 0;
+    }
+}
 
 INCLUDE_RODATA("asm/nonmatchings/level/LOONEY", D_80161DD8_BA088);
 
@@ -475,7 +487,21 @@ INCLUDE_ASM("asm/nonmatchings/level/LOONEY", looney_trapmuv_OnUpdate);
 void looney_trapmuv_OnCollide(Instance* instance, GameTracker* gameTracker) {
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/LOONEY", looney_pusher_OnCreate);
+extern int D_80161E00_BA0B0;
+extern int D_80161E04_BA0B4;
+
+void looney_pusher_OnCreate(Instance* instance, GameTracker* gameTracker) {
+    const char* name;
+
+    *(int*)&instance->_108 = 0;
+    instance->_100 = 0;
+    name = instance->object->name;
+    if (((int*)name)[0] == D_80161E00_BA0B0 && ((int*)name)[1] == D_80161E04_BA0B4) {
+        instance->_104 = 0;
+    } else {
+        instance->_104 = 0x14;
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/LOONEY", looney_pusher_OnUpdate);
 
@@ -520,7 +546,17 @@ INCLUDE_ASM("asm/nonmatchings/level/LOONEY", func_8015FEC8_B8178);
 
 INCLUDE_ASM("asm/nonmatchings/level/LOONEY", looney_daisy_OnCollide);
 
-INCLUDE_ASM("asm/nonmatchings/level/LOONEY", looney_grrfish_OnCreate);
+extern int D_80161D98_BA048[];
+
+void looney_grrfish_OnCreate(Instance* instance, GameTracker* gameTracker) {
+    if (instance->object->data == 0) {
+        instance->object->data = D_80161D98_BA048;
+    }
+    instance->_D0[0] = instance->intro->position.z;
+    if (*(int*)instance->object->data >= 0) {
+        instance->currentModel = 1;
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/LOONEY", func_80160164_B8414);
 

--- a/src/level/MOOSHU.c
+++ b/src/level/MOOSHU.c
@@ -25,7 +25,14 @@ void func_8015A150_C2AD0(Instance* instance, short arg1, short arg2) {
     }
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/MOOSHU", func_8015A18C_C2B0C);
+int func_8015A18C_C2B0C(Instance* instance) {
+    if (instance->flags2 & 0x10) {
+        PlayerInstance->_F4[0] = 2;
+        gameTracker8->player->_F4[2] &= ~0x1000000;
+        return 1;
+    }
+    return 0;
+}
 
 void func_8015A1E0_C2B60(Instance* instance, int arg1, int arg2, short* arg3) {
     short angle;
@@ -87,7 +94,21 @@ void func_8015B5F0_C3F70(Instance* instance, short* arg1) {
     arg1[6] = 1;
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/MOOSHU", func_8015B614_C3F94);
+void func_8015C710_C5090(Instance* instance, GameTracker* gameTracker);
+
+void func_8015B614_C3F94(Instance* instance, short* arg1) {
+    Instance* target;
+
+    instance->currentModelAnim = 4;
+    instance->flags2 &= ~0x10;
+    instance->currentAnimFrame = 0;
+    arg1[0xC / 2] = 2;
+    *(unsigned short*)&arg1[0x4 / 2] &= 0xEFF7;
+    target = ((Instance**)arg1)[0];
+    if (target != 0) {
+        func_8015C710_C5090(target, gameTracker8);
+    }
+}
 
 void func_8015B674_C3FF4(Instance* instance, short* arg1) {
     instance->flags2 &= ~0x10;
@@ -146,7 +167,12 @@ INCLUDE_ASM("asm/nonmatchings/level/MOOSHU", mooshu_moolevr_OnUpdate);
 
 INCLUDE_ASM("asm/nonmatchings/level/MOOSHU", mooshu_moolevr_OnCollide);
 
-INCLUDE_ASM("asm/nonmatchings/level/MOOSHU", func_8015C6D0_C5050);
+int func_8015C6D0_C5050(Instance* instance) {
+    if (instance->rotation.x == 0 || (instance->_F4[0] == 3 && instance->rotation.x < 0x400)) {
+        return 1;
+    }
+    return 0;
+}
 
 void func_8015C708_C5088(Instance* instance, GameTracker* gameTracker)
 {

--- a/src/level/RTA.c
+++ b/src/level/RTA.c
@@ -9,7 +9,25 @@ void rta_zgrate_OnCreate(Instance* instance, GameTracker* gameTracker) {
     instance->_F4[2] = instance->intro->position.z;
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/RTA", rta_zgrate_OnUpdate);
+extern char D_8015EF10_DF580;
+
+void rta_zgrate_OnUpdate(Instance* instance, GameTracker* gameTracker) {
+    SVECTOR unused;          /* dead local — reproduces the 8-byte frame */
+    int z;
+    int zz;
+
+    if (D_8015EF10_DF580 != 0) {
+        z = instance->position.z;
+        zz = z;
+        z = z - instance->_F4[2];
+        if (z < 0x9C4) {
+            instance->position.z = zz + 100;
+        }
+    } else {
+        instance->position.z = instance->_F4[2];
+        instance->_100 = 0;
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/RTA", rta_zshark_OnCreate);
 
@@ -150,7 +168,14 @@ void rta_lavadrp_OnUpdate(Instance* instance, GameTracker* gameTracker) {
 void rta_lavadrp_OnCollide(Instance* instance, GameTracker* gameTracker) {
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/RTA", rta_zturtle_OnCreate);
+void rta_zturtle_OnCreate(Instance* instance, GameTracker* gameTracker) {
+    SCRIPT_InstanceSplineInit(instance, gameTracker);
+    *(int*)&instance->_34[0] = 5;
+    instance->scale.x = instance->scale.y = instance->scale.z = 0xCE4;
+    instance->_F4[2] = 0;
+    *(int*)&instance->_10C = 0;
+    instance->flags |= 0x100000;
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/RTA", rta_zturtle_OnUpdate);
 
@@ -158,7 +183,12 @@ INCLUDE_ASM("asm/nonmatchings/level/RTA", rta_zturtle_OnCollide);
 
 INCLUDE_ASM("asm/nonmatchings/level/RTA", rta_zarchsig_OnCollide);
 
-INCLUDE_ASM("asm/nonmatchings/level/RTA", rta_count_OnCreate);
+void rta_count_OnCreate(Instance* instance, GameTracker* gameTracker) {
+    instance->_F4[2] = 0x20;
+    instance->_100 = 0x15E;
+    instance->flags |= 0x80;
+    instance->currentTextureAnimFrame = ((int*)gameTracker8)[0x4CC8 / 4] + 1;
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/RTA", rta_count_OnUpdate);
 
@@ -174,7 +204,17 @@ INCLUDE_ASM("asm/nonmatchings/level/RTA", func_8015B1D4_DB844);
 
 INCLUDE_ASM("asm/nonmatchings/level/RTA", func_8015B4EC_DBB5C);
 
-INCLUDE_ASM("asm/nonmatchings/level/RTA", rta_zgeyser_OnCreate);
+extern char D_8015EE74_DF4E4[];
+
+void rta_zgeyser_OnCreate(Instance* instance, GameTracker* gameTracker) {
+    instance->_F4[2] = OBTABLE_FindObject(D_8015EE74_DF4E4);
+    instance->scale.x = 0x1000;
+    instance->scale.y = 0x1000;
+    *(short*)&instance->_100 = 0;
+    ((short*)&instance->_100)[1] = 0;
+    *(short*)&instance->_104 = 0;
+    instance->scale.z = 0x180;
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/RTA", rta_zgeyser_OnUpdate);
 
@@ -297,9 +337,30 @@ void rta_qmark_OnCollide(Instance* instance, GameTracker* gameTracker) {
     }
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/RTA", rta_zarrow_OnCreate);
+void rta_zarrow_OnCreate(Instance* instance, GameTracker* gameTracker) {
+    if (instance->flags & 0x20000) {
+        instance->intro->flags &= ~8;
+    } else {
+        instance->flags |= 0x10400;
+        instance->_F4[2] = 0;
+    }
+}
 
-INCLUDE_ASM("asm/nonmatchings/level/RTA", rta_zarrow_OnUpdate);
+extern int D_8015EF14_DF584;
+extern short D_8015ED10_DF380[];
+
+void rta_zarrow_OnUpdate(Instance* instance, GameTracker* gameTracker) {
+    int v;
+
+    v = instance->_F4[2] + 1;
+    instance->_F4[2] = v;
+    if (v >= 0x14) {
+        instance->_F4[2] = 0;
+        if (D_8015EF14_DF584 != 0) {
+            func_8015C8C8_DCF38(&instance->position, 0x206C, D_8015EF14_DF584, D_8015ED10_DF380);
+        }
+    }
+}
 
 void func_8015C8C0_DCF30(Instance* instance, GameTracker* gameTracker) {
 }
@@ -320,7 +381,16 @@ INCLUDE_ASM("asm/nonmatchings/level/RTA", rta_zstmvent_OnUpdate);
 
 INCLUDE_ASM("asm/nonmatchings/level/RTA", func_8015D0B4_DD724);
 
-INCLUDE_ASM("asm/nonmatchings/level/RTA", rta_zstmvent_OnCollide);
+void rta_zstmvent_OnCollide(Instance* instance, GameTracker* gameTracker) {
+    BSPTree* bsp;
+    Instance* player;
+
+    bsp = instance->bspTree;
+    player = gameTracker->player;
+    if (bsp->instanceSpline == player) {
+        func_80022714(bsp->instanceSpline, gameTracker);
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/RTA", func_8015D20C_DD87C);
 
@@ -344,7 +414,16 @@ INCLUDE_RODATA("asm/nonmatchings/level/RTA", D_8015EEB8_DF528);
 
 INCLUDE_RODATA("asm/nonmatchings/level/RTA", D_8015EEBC_DF52C);
 
-INCLUDE_ASM("asm/nonmatchings/level/RTA", func_8015E228_DE898);
+extern int D_8015EF18_DF588;
+
+void func_8015E228_DE898(Instance* instance) {
+    instance->_F4[0] = 6;
+    instance->currentAnimFrame = 0x1A;
+    instance->currentModelAnim = 0x35;
+    instance->_F4[1] = 0;
+    D_8015EF18_DF588 = 0x10;
+    D_8015EF14_DF584 = OBTABLE_FindObject("zbubbl__");
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/RTA", func_8015E27C_DE8EC);
 

--- a/src/level/SCIFI.c
+++ b/src/level/SCIFI.c
@@ -22,9 +22,19 @@ INCLUDE_ASM("asm/nonmatchings/level/SCIFI", func_80159D54_DFB74);
 
 INCLUDE_ASM("asm/nonmatchings/level/SCIFI", func_80159E3C_DFC5C);
 
-INCLUDE_ASM("asm/nonmatchings/level/SCIFI", scifi_dust_OnCreate);
+void scifi_dust_OnCreate(Instance* instance, GameTracker* gameTracker) {
+    instance->_F4[2] = rand() % 10 + 6;
+}
 
-INCLUDE_ASM("asm/nonmatchings/level/SCIFI", scifi_dust_OnUpdate);
+void scifi_dust_OnUpdate(Instance* instance, GameTracker* gameTracker) {
+    unsigned short z;
+
+    z = instance->position.z - instance->_F4[2];
+    instance->position.z = z;
+    if ((short)z < instance->intro->position.z - 0x190) {
+        INSTANCE_KillInstance(instance);
+    }
+}
 
 void scifi_crawler_OnCreate(Instance* instance, GameTracker* gameTracker)
 {
@@ -519,7 +529,13 @@ INCLUDE_ASM("asm/nonmatchings/level/SCIFI", func_8015BFD4_E1DF4);
 
 INCLUDE_ASM("asm/nonmatchings/level/SCIFI", scifi_bldbota_OnCreate);
 
-INCLUDE_ASM("asm/nonmatchings/level/SCIFI", scifi_bldbota_OnUpdate);
+void scifi_bldbota_OnUpdate(Instance* instance, GameTracker* gameTracker) {
+    unsigned short frame;
+
+    frame = instance->currentTextureAnimFrame;
+    instance->currentTextureAnimFrame = frame + 1;
+    func_8015BFD4_E1DF4(instance->_F4[2], (short)frame);
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/SCIFI", scifi_abubble_OnCreate);
 
@@ -540,7 +556,18 @@ void scifi_xa_OnCreate(Instance* instance, GameTracker* gameTracker)
 }
 
 
-INCLUDE_ASM("asm/nonmatchings/level/SCIFI", scifi_xa_OnUpdate);
+void scifi_xa_OnUpdate(Instance* instance, GameTracker* gameTracker) {
+    int w;
+
+    instance->_F4[2] += 1;
+    *(unsigned short*)&instance->scale.x += 0x555;
+    w = instance->_F4[2];
+    *(unsigned short*)&instance->scale.y += 0x555;
+    *(unsigned short*)&instance->scale.z += 0x555;
+    if (w >= 0xD) {
+        func_8002E350(instance);
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/SCIFI", scifi_apod_OnCreate);
 
@@ -1085,7 +1112,10 @@ INCLUDE_ASM("asm/nonmatchings/level/SCIFI", scifi_rt_OnUpdate);
 
 INCLUDE_ASM("asm/nonmatchings/level/SCIFI", scifi_rt_OnCollide);
 
-INCLUDE_ASM("asm/nonmatchings/level/SCIFI", scifi_rtblast_OnCreate);
+void scifi_rtblast_OnCreate(Instance* instance, GameTracker* gameTracker) {
+    instance->initialPos = instance->position;
+    *(ROTATION*)&instance->intro->rotation = instance->rotation;
+}
 
 void scifi_rtblast_OnUpdate(Instance* instance, GameTracker* gameTracker) {
     short dx;


### PR DESCRIPTION
## Summary
Easiest-first sweep of the small level handlers (12-26 instruction tier), sized by a census of the remaining nonmatching functions. Everything verified with full clean builds and ROM diffs.

## Functions (52)
| Level | Count | Functions |
|---|---|---|
| CIRCUIT | 10 | ebridge/ppath/explode OnCollide, ebrijac/follow OnCreate+OnUpdate, weighted-pick walker (func_8015F780), launch setup (func_8015F6B8), texture-frame calc (func_8015DD58) |
| HORROR | 12 | chandb OnCreate/OnCollide, chand OnCollide, drawer/gate/face OnCreate, face/axe OnCollide, elevpan/bkshlf/splitob OnUpdate |
| RTA | 9 | count/zarrow/zgeyser/zturtle OnCreate, zstmvent OnCollide, zgrate/zarrow OnUpdate, zbubble spawner init (func_8015E228) |
| FINAL | 7 | rezbomb/popper handlers, reztvex OnUpdate, 8- and 4-digit hex formatters, func_8015AE98 |
| SCIFI | 6 | dust OnCreate/OnUpdate, bldbota/xa OnUpdate, rtblast OnCreate |
| KUNGFU | 5 | kbgen/spike handlers, anim reset (func_8015DBB0), joyride position writeback (func_8016121C) |
| GEXZIL | 5 | mechjet OnCreate, explode OnCollide, packed-pair ratan2 wrapper (func_80160BD8), func_8015B334 |
| MOOSHU | 3 | func_8015A18C, func_8015B614, func_8015C6D0 |
| LOONEY | 3 | trapsit/pusher/grrfish OnCreate |

## Techniques
- The scale-animation pair (scifi_xa, final_reztvex) are direct compound assignments on unsigned-short-cast fields — the pairwise load interleave and register assignment both follow from that form
- GEXZIL's func_80160BD8 receives two packed short-pairs; taking the parameters' addresses reproduces the home-slot stores
- Two G2String-style two-word name compares (looney_pusher, final_popper) use the explicit two-symbol form
- A few functions needed dead locals to reproduce frame sizes (rta_zgrate) or specific temp materialization for register allocation (horror_chand)
