### PR TITLE
Decompile 31 level functions (39-43 instruction tier)

### DIFF
--- a/src/level/CIRCUIT.c
+++ b/src/level/CIRCUIT.c
@@ -14,7 +14,22 @@ INCLUDE_ASM("asm/nonmatchings/level/CIRCUIT", circuit_plat_OnCreate);
 
 INCLUDE_ASM("asm/nonmatchings/level/CIRCUIT", circuit_plat_OnUpdate);
 
-INCLUDE_ASM("asm/nonmatchings/level/CIRCUIT", circuit_plat_OnCollide);
+void circuit_plat_OnCollide(Instance* instance, GameTracker* gameTracker) {
+    BSPTree* bsp;
+
+    bsp = instance->bspTree;
+    if (((int*)instance->introData)[1] & 0x20) {
+        if (func_80025798(PlayerInstance) == 0) {
+            return;
+        }
+    }
+    if (bsp->_06 == 4) {
+        if (instance->_F4[0] == 1 && instance->_120 != 2) {
+            instance->_F4[0] = 0;
+        }
+        instance->_F4[1] = 1;
+    }
+}
 
 void circuit_bug_OnCreate(Instance* instance, GameTracker* gameTracker) {
     unsigned short* intro;
@@ -233,13 +248,46 @@ void circuit_ebrijac_OnUpdate(Instance* instance, GameTracker* gameTracker) {
 
 INCLUDE_ASM("asm/nonmatchings/level/CIRCUIT", circuit_ebrijac_OnCollide);
 
-INCLUDE_ASM("asm/nonmatchings/level/CIRCUIT", func_8015C18C_8336C);
+extern G2String D_801635CC_8A7AC;
+
+/* set _104 on every instance in the intro group whose object parentName matches */
+void func_8015C18C_8336C(Instance* instance, int val) {
+    char unused[1];    /* dead local — reproduces the 8-byte frame */
+    int i;
+    int* list;
+    int count;
+    int* p;
+    Intro* e;
+
+    list = (int*)instance->intro->_04;
+    count = list[0];
+    p = list + 1;
+    for (i = 0; i < count; i++, p++) {
+        e = *(Intro**)p;
+        if (e->instance != 0 && G2String_Compare_EQ(e->instance->object->parentName, &D_801635CC_8A7AC)) {
+            e->instance->_104 = val;
+        }
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/CIRCUIT", circuit_orbplat_OnCreate);
 
 INCLUDE_ASM("asm/nonmatchings/level/CIRCUIT", circuit_orbplat_OnUpdate);
 
-INCLUDE_ASM("asm/nonmatchings/level/CIRCUIT", circuit_orbplat_OnCollide);
+void circuit_orbplat_OnCollide(Instance* instance, GameTracker* gameTracker) {
+    BSPTree* bsp;
+
+    bsp = instance->bspTree;
+    if (bsp->_06 == 4) {
+        instance->_F4[1] = 1;
+    }
+    if (bsp->_06 == 3 && instance->_120 <= 0 && instance->_D0[0] <= 0 && instance->_F4[0] == 2) {
+        instance->_120 = 4;
+        *(int*)&instance->_110 = -1;
+        instance->_F4[2] = (instance->_F4[2] + 0x800) & 0xFFF;
+        func_8004AAA8(instance, 0x1A, 0);
+    }
+}
 
 void circuit_orbpole_OnCreate(Instance* instance, GameTracker* gameTracker) {
     int* intro;
@@ -418,7 +466,25 @@ void circuit_follow_OnCreate(Instance* instance, GameTracker* gameTracker) {
 
 INCLUDE_ASM("asm/nonmatchings/level/CIRCUIT", circuit_follow_OnUpdate);
 
-INCLUDE_ASM("asm/nonmatchings/level/CIRCUIT", circuit_follow_OnCollide);
+void circuit_follow_OnCollide(Instance* instance, GameTracker* gameTracker) {
+    Instance* player;
+    Spline* spline;
+    int* data;
+
+    if (instance->_F4[2] == 0) {
+        instance->_F4[2] = 0x1E;
+        if (instance->intro->multiSpline != 0) {
+            player = PlayerInstance;
+            data = (int*)player->data;
+            if (!(player->_F4[2] & 1)) {
+                data[0xE0 / 4] = (int)instance;
+                spline = instance->intro->multiSpline->positional;
+                *(int*)&instance->_10C = spline->key[spline->numkeys - 1].point.y;
+                player->_F4[2] |= 2;
+            }
+        }
+    }
+}
 
 void func_8015D780_84960(Instance* instance, GameTracker* gameTracker) {
     if (instance->introData != 0) {
@@ -578,7 +644,28 @@ INCLUDE_ASM("asm/nonmatchings/level/CIRCUIT", circuit_reza_OnCreate);
 
 INCLUDE_ASM("asm/nonmatchings/level/CIRCUIT", circuit_reza_OnUpdate);
 
-INCLUDE_ASM("asm/nonmatchings/level/CIRCUIT", circuit_reza_OnCollide);
+void circuit_reza_OnCollide(Instance* instance, GameTracker* gameTracker) {
+    SVECTOR unused;    /* dead local — reproduces the 0x20 frame */
+    BSPTree* bsp;
+    int f;
+    int g;
+
+    bsp = instance->bspTree;
+    if (bsp->instanceSpline == gameTracker->player && bsp->_06 == 1 && instance->currentModelAnim != 5) {
+        /* the in-place mask keeps the original byte alive in g (register scheduling) */
+        f = ((char*)&instance->_118)[3];
+        g = f;
+        f &= 0x80;
+        if (f == 0) {
+            if (g & 2) {
+                ((char*)&instance->_118)[3] = g | 0x80;
+                func_8004A7B8(instance, 2, 0);
+            } else {
+                func_80022714(instance, gameTracker);
+            }
+        }
+    }
+}
 
 void func_8015F6B8_86898(Instance* instance, int arg1, int arg2) {
     instance->_F4[0] = 1;
@@ -640,7 +727,25 @@ INCLUDE_ASM("asm/nonmatchings/level/CIRCUIT", circuit_robo_OnCreate);
 
 INCLUDE_ASM("asm/nonmatchings/level/CIRCUIT", func_8015F930_86B10);
 
-INCLUDE_ASM("asm/nonmatchings/level/CIRCUIT", func_8015FA1C_86BFC);
+int func_8015F930_86B10(Instance* instance, int* arg1, short arg2);
+
+int* func_8015FA1C_86BFC(Instance* instance) {
+    int* intro = (int*)instance->introData + 1;
+    int* p;
+    int* q;
+
+    p = func_8015F780_86960(intro, *(short*)&instance->_110);
+    q = func_8015F780_86960(intro, ((short*)&instance->_110)[1]);
+    if (*(short*)&instance->_114 < q[2]) {
+        return p;
+    }
+    p = q;
+    *(short*)&instance->_114 = *(short*)&instance->_114 - q[2];
+    *(short*)&instance->_110 = ((short*)&instance->_110)[1];
+    *(short*)&instance->_118 = p[1];
+    *(short*)&instance->_112 = func_8015F930_86B10(instance, p, ((short*)&instance->_110)[1]);
+    return p;
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/CIRCUIT", func_8015FAC4_86CA4);
 

--- a/src/level/FINAL.c
+++ b/src/level/FINAL.c
@@ -148,7 +148,26 @@ INCLUDE_ASM("asm/nonmatchings/level/FINAL", func_8015A170_8B310);
 
 INCLUDE_ASM("asm/nonmatchings/level/FINAL", func_8015A3DC_8B57C);
 
-INCLUDE_ASM("asm/nonmatchings/level/FINAL", func_8015A434_8B5D4);
+extern int D_800EB8A0;
+extern void func_80017E88();
+extern int func_8015A3DC_8B57C();
+
+void func_8015A434_8B5D4(Instance* instance, Object* obj, int pos, int rot) {
+    SVECTOR vel;
+    short* spray;
+    Model* model;
+
+    if (obj != 0) {
+        model = obj->modelList[2];
+        vel.z = -4;
+        vel.y = 0;
+        vel.x = 0;
+        spray = (short*)func_800170E8(model, model->_14, pos, rot, &vel, D_800EB8A0, func_80017E88, func_8015A3DC_8B57C, 0x3C);
+        if (spray != 0) {
+            spray[0x44 / 2] = instance->position.z;
+        }
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/FINAL", func_8015A4C8_8B668);
 
@@ -178,11 +197,48 @@ INCLUDE_ASM("asm/nonmatchings/level/FINAL", func_8015AED8_8C078);
 
 INCLUDE_ASM("asm/nonmatchings/level/FINAL", func_8015B07C_8C21C);
 
-INCLUDE_ASM("asm/nonmatchings/level/FINAL", func_8015B130_8C2D0);
+extern void func_8004ACB0(short* angle, short target, int step);
 
-INCLUDE_ASM("asm/nonmatchings/level/FINAL", func_8015B1D8_8C378);
+int func_8015B130_8C2D0(Instance* instance, int arg1, short arg2) {
+    SVECTOR d;
+    int angle;
 
-INCLUDE_ASM("asm/nonmatchings/level/FINAL", func_8015B268_8C408);
+    d.x = 0x2D00 - instance->position.x;
+    d.y = 0x267A - instance->position.y;
+    d.z = -instance->position.z;
+    angle = ((ratan2(d.y, d.x) << 16) >> 16) + 0x400;
+    func_8004ACB0(&instance->rotation.z, angle, arg2);
+    return instance->rotation.z == angle;
+}
+
+/* swing the camera focus toward the player at 0x40 per tick */
+void func_8015B1D8_8C378(Instance* instance, GameTracker* gameTracker) {
+    SVECTOR d;
+
+    d.x = PlayerInstance->position.x - instance->position.x;
+    d.y = PlayerInstance->position.y - instance->position.y;
+    d.z = PlayerInstance->position.z - instance->position.z;
+    func_8004ACB0(&gameTracker->camera->focusRotationX, ((ratan2(d.y, d.x) << 16) + 0x4000000) >> 16, 0x40);
+}
+
+void func_8015B268_8C408(Instance* instance, GameTracker* gameTracker) {
+    SVECTOR d;
+    SVECTOR a;
+    Camera* camera = gameTracker->camera;
+
+    a.x = instance->position.x;
+    a.y = instance->position.y;
+    a.z = instance->position.z + 0x200;
+    func_80005438(&camera->_data7[4], &a, camera);
+    d.x = a.x - camera->cameraCore.position.x;
+    d.y = a.y - camera->cameraCore.position.y;
+    d.z = a.z - camera->cameraCore.position.z;
+    camera->cameraCore._08[0x13] = CAMERA_LengthSVector(&d) >> 3;
+    *(short*)&camera->_data7[7] = 0;
+    *(short*)&camera->_data7[9] = 0;
+    camera->_data8[3] = 0;
+    camera->_data8[2] = 0;
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/FINAL", func_8015B30C_8C4AC);
 
@@ -256,7 +312,21 @@ INCLUDE_RODATA("asm/nonmatchings/level/FINAL", D_801615D8_92778); // Z %s
 
 INCLUDE_ASM("asm/nonmatchings/level/FINAL", func_8015CC64_8DE04);
 
-INCLUDE_ASM("asm/nonmatchings/level/FINAL", func_8015CD54_8DEF4);
+extern int D_800BDEE0[5];
+
+void func_8015CD54_8DEF4(int arg0, int arg1, int count) {
+    char buf[16];
+    int i;
+
+    if (count >= 0x29) {
+        for (i = 0; i < 8; i++) {
+            D_800BDEE0[0] = 0x14;
+            D_800BDEE0[1] = i * 8 + 0x14;
+            func_8015CAF8_8DC98(buf, (rand() << 16) | rand());
+            osSyncPrintf("%s", buf);
+        }
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/FINAL", func_8015CDF0_8DF90);
 
@@ -313,12 +383,14 @@ void final_finaltv_OnCreate(Instance* instance, GameTracker* gameTracker) {
 
 INCLUDE_ASM("asm/nonmatchings/level/FINAL", final_finaltv_OnUpdate);
 
-INCLUDE_ASM("asm/nonmatchings/level/FINAL", final_finaltv_OnCollide);
+void final_finaltv_OnCollide(Instance* instance, GameTracker* gameTracker) {
+    if (G2String_Compare_EQ(instance->bspTree->instanceSpline->object->name, D_80161618_927B8)) {
+        func_80046978(instance);
+        func_800509E0(0x10, 0x78, 0x80, 0);
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/FINAL", func_8015EEF4_90094);
-
-extern int D_800EB8A0;
-extern void func_80017E88();
 
 void func_8015F05C_901FC(int arg0, Object* obj, SVECTOR* pos) {
     Model* model;

--- a/src/level/GEXZIL.c
+++ b/src/level/GEXZIL.c
@@ -402,8 +402,6 @@ INCLUDE_ASM("asm/nonmatchings/level/GEXZIL", func_8015FFDC_9915C);
 
 INCLUDE_ASM("asm/nonmatchings/level/GEXZIL", func_8016014C_992CC);
 
-
-
 INCLUDE_ASM("asm/nonmatchings/level/GEXZIL", func_801601D8_99358);
 
 void func_80160344_994C4(void) {

--- a/src/level/GEXZIL.c
+++ b/src/level/GEXZIL.c
@@ -119,7 +119,21 @@ void gexzil_mechjet_OnCreate(Instance* instance, GameTracker* gameTracker) {
     }
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/GEXZIL", gexzil_mechjet_OnUpdate);
+void gexzil_mechjet_OnUpdate(Instance* instance, GameTracker* gameTracker) {
+    if (instance->_F4[0] == 0) {
+        func_8002DAF8(instance, -1);
+        if (instance->flags2 & 0x10) {
+            instance->_F4[0] = 1;
+            instance->currentAnimFrame = ((unsigned short*)instance->object->animList[0])[1] - 1;
+            instance->flags2 &= ~0x10;
+        }
+    } else if (instance->_F4[0] != 1) {
+        func_8002DAF8(instance, -0x3E9);
+        if (instance->flags2 & 0x10) {
+            func_8002E350(instance);
+        }
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/GEXZIL", func_8015B460_945E0);
 
@@ -189,7 +203,21 @@ INCLUDE_ASM("asm/nonmatchings/level/GEXZIL", func_8015C504_95684);
 
 INCLUDE_ASM("asm/nonmatchings/level/GEXZIL", func_8015C704_95884);
 
-INCLUDE_ASM("asm/nonmatchings/level/GEXZIL", func_8015CADC_95C5C);
+void func_8015CADC_95C5C(Instance* instance, short* arg1) {
+    int f;
+
+    f = instance->flags2;
+    if (f & 0x10) {
+        if (arg1[0x26] <= 0) {
+            gameTracker8->player->flags2 |= 0x10;
+            PlayerInstance->_F4[0] = 2;
+            gameTracker8->player->_F4[2] &= ~0x1000000;
+            arg1[0x13] = 0x29;
+        } else {
+            instance->flags2 = f & ~0x10;
+        }
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/GEXZIL", func_8015CB68_95CE8);
 
@@ -296,9 +324,50 @@ void func_8015F588_98708(Instance* instance, short* arg1) {
 
 INCLUDE_ASM("asm/nonmatchings/level/GEXZIL", func_8015F5D4_98754);
 
-INCLUDE_ASM("asm/nonmatchings/level/GEXZIL", func_8015F680_98800);
 
-INCLUDE_ASM("asm/nonmatchings/level/GEXZIL", func_8015F708_98888);
+void func_8015F680_98800(Instance* instance) {
+    short* d;
+
+    d = (short*)instance->object->data;
+    d[8] = -1;
+    d[0x13] = 7;
+    instance->currentModelAnim = 2;
+    instance->currentAnimFrame = 0;
+    d[0xA] = 0;
+    instance->flags2 &= ~0x10;
+    d[9] = 0;
+    instance->currentAnimFrame = 5;
+    instance->_B8 = 0;
+    d[0x1C] = d[0x1D];
+    if (((int*)d)[0x90 / 4] != 0) {
+        func_8002E350(((int*)d)[0x90 / 4]);
+        ((int*)d)[0x90 / 4] = 0;
+    }
+}
+
+int func_8015F708_98888(Instance* instance, Instance* arg1) {
+    char* data = arg1->object->data;
+    int** list;
+    int result;
+    int i;
+
+    result = 0;
+    list = ((int**)((int*)data)[0xA4 / 4]);
+    if (list != 0) {
+        i = 0;
+        if (((short*)data)[0x44 / 2] > i) {
+            do {
+                if (func_8015AC68_93DE8(list[0], instance) != 0) {
+                    result = 1;
+                    break;
+                }
+                i += 1;
+                list += 1;
+            } while (((short*)data)[0x44 / 2] > i);
+        }
+    }
+    return result;
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/GEXZIL", func_8015F7B4_98934);
 
@@ -332,6 +401,8 @@ void func_8015FF80_99100(Instance* instance, short* arg1) {
 INCLUDE_ASM("asm/nonmatchings/level/GEXZIL", func_8015FFDC_9915C);
 
 INCLUDE_ASM("asm/nonmatchings/level/GEXZIL", func_8016014C_992CC);
+
+
 
 INCLUDE_ASM("asm/nonmatchings/level/GEXZIL", func_801601D8_99358);
 
@@ -367,7 +438,29 @@ INCLUDE_ASM("asm/nonmatchings/level/GEXZIL", func_80160C28_99DA8);
 
 INCLUDE_ASM("asm/nonmatchings/level/GEXZIL", func_80160DF8_99F78);
 
-INCLUDE_ASM("asm/nonmatchings/level/GEXZIL", func_801614B0_9A630);
+extern char* D_80078288;
+
+/* find the type-2 entry with the smallest coordinate sum in the 0x1C-stride table */
+char* func_801614B0_9A630(void) {
+    unsigned int unused[1];    /* dead local — reproduces the 0x10 frame */
+    int best;
+    char* result;
+    char* e;
+    int sum;
+
+    best = 0x40000000;
+    result = 0;
+    for (e = D_80078288; e[7] != 0; e += 0x1C) {
+        if (e[7] == 2) {
+            sum = *(short*)(e + 0xA) + *(short*)(e + 0xC);
+            if (sum < best) {
+                best = sum;
+                result = e;
+            }
+        }
+    }
+    return result;
+}
 
 extern int gGlobalMessageBuffer[];
 extern int D_800BF1B8[];

--- a/src/level/HORROR.c
+++ b/src/level/HORROR.c
@@ -5,6 +5,7 @@
 #include "types/intro/QMark.h"
 #include "types/intro/BTimer.h"
 #include "types/G2String.h"
+#include "level/COMMON.h"
 
 #include "types/Vector.h"
 extern int D_800E5FD8;
@@ -199,7 +200,18 @@ INCLUDE_ASM("asm/nonmatchings/level/HORROR", horror_huckhed_OnCreate);
 
 INCLUDE_ASM("asm/nonmatchings/level/HORROR", horror_huckhed_OnUpdate);
 
-INCLUDE_ASM("asm/nonmatchings/level/HORROR", func_8015BF7C_9F7AC);
+extern G2String D_80164C58_A8488;
+
+void func_8015BF7C_9F7AC(Instance* instance, GameTracker* gameTracker) {
+    Instance* e;
+
+    for (e = gameTracker->instanceList->first; e != 0; e = e->next) {
+        if (e != gameTracker->player && G2String_Compare_EQ(e->object->name, &D_80164C58_A8488) && e->_100 == ((int)instance)) {
+            common_icecube_OnCollide(e, gameTracker);
+            break;
+        }
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/HORROR", horror_huckhed_OnCollide);
 
@@ -318,7 +330,7 @@ INCLUDE_RODATA("asm/nonmatchings/level/HORROR", D_80164C4C_A847C);
 
 INCLUDE_RODATA("asm/nonmatchings/level/HORROR", D_80164C50_A8480);
 
-INCLUDE_RODATA("asm/nonmatchings/level/HORROR", D_80164C58_A8488);
+INCLUDE_RODATA("asm/nonmatchings/level/HORROR", D_80164C58_A8488); // icecube_
 
 INCLUDE_RODATA("asm/nonmatchings/level/HORROR", D_80164C64_A8494);
 
@@ -597,7 +609,18 @@ void horror_evileye_OnCreate(Instance* instance, GameTracker* gameTracker) {
 
 INCLUDE_ASM("asm/nonmatchings/level/HORROR", horror_evileye_OnUpdate);
 
-INCLUDE_ASM("asm/nonmatchings/level/HORROR", horror_evileye_OnCollide);
+void horror_evileye_OnCollide(Instance* instance, GameTracker* gameTracker) {
+    int* intro;
+
+    intro = (int*)instance->introData;
+    if (instance->bspTree->instanceSpline == PlayerInstance
+        && instance->bspTree->instanceSpline->_F4[1] == 0x1000
+        && (unsigned int)(instance->_F4[0] - 1) >= 2 && intro[0] == 0) {
+        instance->_F4[0] = 1;
+        instance->_F4[2] = 0;
+        func_80050508(instance, 0x1D0, 0, 0x64, 0xFA0);
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/HORROR", horror_splitob_OnCreate);
 
@@ -1004,7 +1027,28 @@ INCLUDE_ASM("asm/nonmatchings/level/HORROR", horror_reza_OnCreate);
 
 INCLUDE_ASM("asm/nonmatchings/level/HORROR", horror_reza_OnUpdate);
 
-INCLUDE_ASM("asm/nonmatchings/level/HORROR", horror_reza_OnCollide);
+void horror_reza_OnCollide(Instance* instance, GameTracker* gameTracker) {
+    SVECTOR unused;    /* dead local — reproduces the 0x20 frame */
+    BSPTree* bsp;
+    int f;
+    int g;
+
+    bsp = instance->bspTree;
+    if (bsp->instanceSpline == gameTracker->player && bsp->_06 == 1 && instance->currentModelAnim != 5) {
+        /* the in-place mask keeps the original byte alive in g (register scheduling) */
+        f = ((char*)&instance->_118)[3];
+        g = f;
+        f &= 0x80;
+        if (f == 0) {
+            if (g & 2) {
+                ((char*)&instance->_118)[3] = g | 0x80;
+                func_8004A7B8(instance, 2, 0);
+            } else {
+                func_80022714(instance, gameTracker);
+            }
+        }
+    }
+}
 
 void horror_btimer_OnCreate(Instance* instance, GameTracker* gameTracker) {
     int var_s0;

--- a/src/level/KUNGFU.c
+++ b/src/level/KUNGFU.c
@@ -749,17 +749,19 @@ void kungfu_boat_OnCreate(Instance* instance, GameTracker* gameTracker) {
     }
 }
 
+SVECTOR* func_800517E4(Spline* spline, short frame, SplineDef* def);
+
 void kungfu_boat_OnUpdate(Instance* instance, GameTracker* gameTracker) {
     MultiSpline* ms;
-    short* r;
+    SVECTOR* point;
 
     ms = instance->intro->multiSpline;
     if (ms != 0) {
-        r = (short*)func_800517E4(*(int*)ms, ((short*)&instance->_F4[2])[1], (char*)ms + 0x10);
-        if (r != 0) {
-            instance->position.x = r[0];
-            instance->position.y = r[1];
-            instance->position.z = r[2];
+        point = func_800517E4(ms->positional, ((short*)&instance->_F4[2])[1], &ms->curPositional);
+        if (point != 0) {
+            instance->position.x = point->x;
+            instance->position.y = point->y;
+            instance->position.z = point->z;
         }
     }
 }
@@ -911,18 +913,18 @@ INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", kungfu_joyride_OnCollide);
 
 void kungfu_leafgen_OnCreate(Instance* instance, GameTracker* gameTracker) {
     char name[] = "leaffx__";
-    char* n = instance->introData;
+    char* targetObjectName = instance->introData;
     char* d = instance->object->data;
     int* p = &instance->_F4[2];
-    if (n == 0) {
+    if (targetObjectName == 0) {
         if (d != 0) {
-            n = d;
+            targetObjectName = d;
         } else {
             instance->introData = name;
-            n = name;
+            targetObjectName = name;
         }
     }
-    p[0] = ((int)OBTABLE_FindObject(n));
+    p[0] = ((int)OBTABLE_FindObject(targetObjectName));
     p[7] = (rand() & 0xF) + 1;
 }
 

--- a/src/level/KUNGFU.c
+++ b/src/level/KUNGFU.c
@@ -912,7 +912,7 @@ INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", kungfu_joyride_OnUpdate);
 INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", kungfu_joyride_OnCollide);
 
 void kungfu_leafgen_OnCreate(Instance* instance, GameTracker* gameTracker) {
-    char name[] = "leaffx__";
+    const char name[] = "leaffx__";
     char* targetObjectName = instance->introData;
     char* d = instance->object->data;
     int* p = &instance->_F4[2];
@@ -920,8 +920,8 @@ void kungfu_leafgen_OnCreate(Instance* instance, GameTracker* gameTracker) {
         if (d != 0) {
             targetObjectName = d;
         } else {
-            instance->introData = name;
-            targetObjectName = name;
+            instance->introData = (char*)name;
+            targetObjectName = (char*)name;
         }
     }
     p[0] = ((int)OBTABLE_FindObject(targetObjectName));

--- a/src/level/KUNGFU.c
+++ b/src/level/KUNGFU.c
@@ -3,12 +3,24 @@
 #include "level/KUNGFU.h"
 #include "types/intro/BTimer.h"
 #include "types/G2String.h"
+#include "SPLINE.h"
+#include "OBTABLE.h"
 
 
 extern int D_800E5FD8;
 extern int D_80154834;
 
-INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", kungfu_kboat_OnCreate);
+void kungfu_kboat_OnCreate(Instance* instance, GameTracker* gameTracker) {
+    SVECTOR a;
+    SVECTOR b;
+
+    instance->flags |= 0x400;
+    a.x = b.x = instance->position.x;
+    a.y = b.y = instance->position.y;
+    a.z = instance->position.z - 0x100;
+    b.z = instance->position.z + 0x200;
+    COLLIDE_PointAndTerrain(gameTracker8->level->segmentAddress, &a, &b, instance);
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", kungfu_kboat_OnUpdate);
 
@@ -480,7 +492,31 @@ void kungfu_onoff_OnCollide(Instance* instance, GameTracker* gameTracker) {
     }
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", kungfu_spike_OnCreate);
+void kungfu_spike_OnCreate(Instance* instance, GameTracker* gameTracker) {
+    short* p = ((short*)&instance->_F4[2]);
+    int v;
+    int t;
+
+    p[0] = 0;
+    p[2] = 0x1E;
+    p[3] = 0x1E;
+    if (instance->introData != 0) {
+        *(SVector*)&instance->_F4[2] = *((SVector*)instance->introData);
+    }
+    t = p[0];
+    instance->_F4[0] = t;
+    if (t == 1) {
+        v = ((unsigned short*)instance->object->animList[0])[1] - 1;
+    } else {
+        v = 0;
+    }
+    instance->currentAnimFrame = v;
+    v = p[1];
+    if (v == 0) {
+        v = p[2];
+    }
+    *(int*)&p[4] = v;
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", kungfu_spike_OnUpdate);
 
@@ -517,9 +553,42 @@ void kungfu_dragbod_OnCreate(Instance* instance, GameTracker* gameTracker) {
     instance->flags |= 0x100400;
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", kungfu_dragbod_OnCollide);
+void func_8015C884_ABAA4(Instance* instance, Instance* arg1, GameTracker* gameTracker);
 
-INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", kungfu_dragon_OnCollide);
+extern G2String D_80162700_B1920;
+
+void kungfu_dragbod_OnCollide(Instance* instance, GameTracker* gameTracker) {
+    Intro** p = ((Intro**)instance->intro->_04);
+    int count = ((int*)p)[0];
+    int i;
+    Intro* entry;
+
+    p += 1;
+    for (i = 0; i < count; i++) {
+        entry = p[0];
+        if (G2String_Compare_EQ(entry->object->name, &D_80162700_B1920)) {
+            func_8015C884_ABAA4(instance, entry->instance, gameTracker);
+            break;
+        }
+        p += 1;
+    }
+}
+
+void kungfu_dragon_OnCollide(Instance* instance, GameTracker* gameTracker) {
+    BSPTree* bsp = instance->bspTree;
+    char c = -1;
+    short* p = (short*)&instance->_E0[2];
+    if (bsp->_04 == 1) {
+        c = bsp->_08[4];
+    } else if (bsp->_04 == 5) {
+        c = bsp->_08[2];
+    }
+    if (c == 1) {
+        p[0] |= 1;
+    } else {
+        func_8015C884_ABAA4(instance, instance, gameTracker);
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", kungfu_cannon_OnCreate);
 
@@ -636,7 +705,23 @@ void func_8015DBB0_ACDD0(Instance* instance, short* arg1) {
     }
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", func_8015DC00_ACE20);
+void func_8015DC00_ACE20(Instance* instance, short* arg1) {
+    Intro* intro;
+    int dx;
+    int dy;
+
+    instance->flags2 &= ~0x10;
+    arg1[0x18 / 2] = 7;
+    if (instance->currentModelAnim != 0 && instance->currentModelAnim != 5) {
+        instance->currentModelAnim = (arg1[0x10 / 2] != 0) ? 5 : 0;
+        instance->currentAnimFrame = 0;
+    }
+    intro = instance->intro;
+    dx = intro->position.x - instance->position.x;
+    dy = intro->position.y - instance->position.y;
+    ((int*)arg1)[0x14 / 4] = (short)ratan2(dy, dx);
+    arg1[0x1A / 2] = 0;
+}
 
 void func_8015DC9C_ACEBC(Instance* instance, GameTracker* gameTracker)
 {
@@ -648,9 +733,36 @@ INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", kungfu_samuri_OnUpdate);
 
 INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", kungfu_samuri_OnCollide);
 
-INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", kungfu_boat_OnCreate);
+void kungfu_boat_OnCreate(Instance* instance, GameTracker* gameTracker) {
+    MultiSpline* spline = instance->intro->multiSpline;
+    short* p;
 
-INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", kungfu_boat_OnUpdate);
+    instance->flags |= 0x100000;
+    p = ((short*)&instance->_F4[2]);
+    if (instance->introData != 0) {
+        ((short*)&instance->_F4[2])[1] = ((unsigned short*)instance->introData)[1];
+    } else {
+        ((short*)&instance->_F4[2])[1] = 0x19;
+    }
+    if (p[1] < 0 && spline != 0) {
+        instance->position = *SplineGetLastPoint(spline->positional, &spline->curPositional);
+    }
+}
+
+void kungfu_boat_OnUpdate(Instance* instance, GameTracker* gameTracker) {
+    MultiSpline* ms;
+    short* r;
+
+    ms = instance->intro->multiSpline;
+    if (ms != 0) {
+        r = (short*)func_800517E4(*(int*)ms, ((short*)&instance->_F4[2])[1], (char*)ms + 0x10);
+        if (r != 0) {
+            instance->position.x = r[0];
+            instance->position.y = r[1];
+            instance->position.z = r[2];
+        }
+    }
+}
 
 void kungfu_boat_OnCollide(Instance* instance, GameTracker* gameTracker) {
 }
@@ -727,7 +839,17 @@ void func_8015F5F4_AE814(Instance* instance, short* arg1) {
     arg1[8] = 0xB;
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", func_8015F61C_AE83C);
+void func_8015F61C_AE83C(Instance* instance) {
+    if ((instance->flags2 & 0x10) || (unsigned int)(instance->currentModelAnim - 7) >= 2) {
+        instance->flags2 &= ~0x10;
+        if (rand() % 100 < 0x14) {
+            instance->currentModelAnim = 7;
+        } else {
+            instance->currentModelAnim = 8;
+        }
+        instance->currentAnimFrame = 0;
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", kungfu_ninja_OnUpdate);
 
@@ -741,7 +863,25 @@ void kungfu_swing_OnCollide(Instance* instance, GameTracker* gameTracker) {
     func_80022D54(instance, gameTracker);
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", kungfu_oneway_OnCreate);
+void kungfu_oneway_OnCreate(Instance* instance, GameTracker* gameTracker) {
+    short* d = ((short*)instance->object->data);
+    int r;
+    short m;
+
+    ((short*)instance->_D0)[0] = 1;
+    instance->flags |= 0x100000;
+    r = func_8004A3B4(instance);
+    m = 0xA;
+    ((short*)instance->_D0)[2] = 0x3C;
+    if (d != 0) {
+        ((short*)instance->_D0)[2] = d[0];
+        m = d[1];
+    }
+    if (r >= 0) {
+        ((short*)instance->_D0)[1] = r * m;
+    }
+    SCRIPT_InstanceSplineInit(instance, gameTracker);
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", kungfu_oneway_OnUpdate);
 
@@ -769,7 +909,22 @@ INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", kungfu_joyride_OnUpdate);
 
 INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", kungfu_joyride_OnCollide);
 
-INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", kungfu_leafgen_OnCreate);
+void kungfu_leafgen_OnCreate(Instance* instance, GameTracker* gameTracker) {
+    char name[] = "leaffx__";
+    char* n = instance->introData;
+    char* d = instance->object->data;
+    int* p = &instance->_F4[2];
+    if (n == 0) {
+        if (d != 0) {
+            n = d;
+        } else {
+            instance->introData = name;
+            n = name;
+        }
+    }
+    p[0] = ((int)OBTABLE_FindObject(n));
+    p[7] = (rand() & 0xF) + 1;
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", func_801616D4_B08F4);
 
@@ -780,7 +935,19 @@ void func_80161944_B0B64(short* arg0) {
     RotMatrixZ(((short*)arg0)[0x48/2], (char*)((int*)arg0)[5] + 0xC);
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", func_801619A4_B0BC4);
+extern int D_80078244;
+extern int D_800EB8A0;
+extern void func_801616D4_B08F4();
+
+void func_801619A4_B0BC4(Instance* instance, int arg1, int arg2) {
+    Model* model;
+
+    if (instance->_F4[2] != 0) {
+        model = ((Object*)instance->_F4[2])->modelList[0];
+        D_80078244 = (rand() & 3) + 2;
+        func_800170E8(model, model->_14 + 0xC, arg2, 0, 0, D_800EB8A0, func_801616D4_B08F4, func_80161944_B0B64, 0x28);
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", kungfu_leafgen_OnUpdate);
 

--- a/src/level/LOONEY.c
+++ b/src/level/LOONEY.c
@@ -375,7 +375,7 @@ INCLUDE_RODATA("asm/nonmatchings/level/LOONEY", D_80161DA8_BA058);
 INCLUDE_RODATA("asm/nonmatchings/level/LOONEY", D_80161DC0_BA070);
 
 void looney_leafgen_OnCreate(Instance* instance, GameTracker* gameTracker) {
-    char name[] = "leaffx__";
+    const char name[] = "leaffx__";
     char* targetObjectName = instance->introData;
     char* d = instance->object->data;
     int* p = &instance->_F4[2];
@@ -383,8 +383,8 @@ void looney_leafgen_OnCreate(Instance* instance, GameTracker* gameTracker) {
         if (d != 0) {
             targetObjectName = d;
         } else {
-            instance->introData = name;
-            targetObjectName = name;
+            instance->introData = (char*)name;
+            targetObjectName = (char*)name;
         }
     }
     p[0] = ((int)OBTABLE_FindObject(targetObjectName));

--- a/src/level/LOONEY.c
+++ b/src/level/LOONEY.c
@@ -206,7 +206,6 @@ void looney_doeboy_OnCreate(Instance* instance, GameTracker* gameTracker) {
 
 void looney_doeboy_OnUpdate(Instance* instance, GameTracker* gameTracker) {
     Intro* intro;
-    int angle;
     short* temp_v1;
 
     if (instance->_F4[0] == 0) {
@@ -377,18 +376,18 @@ INCLUDE_RODATA("asm/nonmatchings/level/LOONEY", D_80161DC0_BA070);
 
 void looney_leafgen_OnCreate(Instance* instance, GameTracker* gameTracker) {
     char name[] = "leaffx__";
-    char* n = instance->introData;
+    char* targetObjectName = instance->introData;
     char* d = instance->object->data;
     int* p = &instance->_F4[2];
-    if (n == 0) {
+    if (targetObjectName == 0) {
         if (d != 0) {
-            n = d;
+            targetObjectName = d;
         } else {
             instance->introData = name;
-            n = name;
+            targetObjectName = name;
         }
     }
-    p[0] = ((int)OBTABLE_FindObject(n));
+    p[0] = ((int)OBTABLE_FindObject(targetObjectName));
     p[7] = (rand() & 0xF) + 1;
 }
 

--- a/src/level/LOONEY.c
+++ b/src/level/LOONEY.c
@@ -206,6 +206,7 @@ void looney_doeboy_OnCreate(Instance* instance, GameTracker* gameTracker) {
 
 void looney_doeboy_OnUpdate(Instance* instance, GameTracker* gameTracker) {
     Intro* intro;
+    int angle;
     short* temp_v1;
 
     if (instance->_F4[0] == 0) {
@@ -374,7 +375,22 @@ INCLUDE_RODATA("asm/nonmatchings/level/LOONEY", D_80161DA8_BA058);
 
 INCLUDE_RODATA("asm/nonmatchings/level/LOONEY", D_80161DC0_BA070);
 
-INCLUDE_ASM("asm/nonmatchings/level/LOONEY", looney_leafgen_OnCreate);
+void looney_leafgen_OnCreate(Instance* instance, GameTracker* gameTracker) {
+    char name[] = "leaffx__";
+    char* n = instance->introData;
+    char* d = instance->object->data;
+    int* p = &instance->_F4[2];
+    if (n == 0) {
+        if (d != 0) {
+            n = d;
+        } else {
+            instance->introData = name;
+            n = name;
+        }
+    }
+    p[0] = ((int)OBTABLE_FindObject(n));
+    p[7] = (rand() & 0xF) + 1;
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/LOONEY", func_8015B934_B3BE4);
 
@@ -385,7 +401,19 @@ void func_8015BBA4_B3E54(short* arg0) {
     RotMatrixZ(((short*)arg0)[0x48/2], (char*)((int*)arg0)[5] + 0xC);
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/LOONEY", func_8015BC04_B3EB4);
+extern int D_80078244;
+extern int D_800EB8A0;
+extern void func_8015B934_B3BE4();
+
+void func_8015BC04_B3EB4(Instance* instance, int arg1, int arg2) {
+    Model* model;
+
+    if (instance->_F4[2] != 0) {
+        model = ((Object*)instance->_F4[2])->modelList[0];
+        D_80078244 = (rand() & 3) + 2;
+        func_800170E8(model, model->_14 + 0xC, arg2, 0, 0, D_800EB8A0, func_8015B934_B3BE4, func_8015BBA4_B3E54, 0x28);
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/LOONEY", looney_leafgen_OnUpdate);
 
@@ -393,15 +421,42 @@ INCLUDE_ASM("asm/nonmatchings/level/LOONEY", looney_leafgen_OnCollide);
 
 INCLUDE_ASM("asm/nonmatchings/level/LOONEY", looney_funguy_OnCreate);
 
+
 INCLUDE_ASM("asm/nonmatchings/level/LOONEY", func_8015BFCC_B427C);
 
 INCLUDE_ASM("asm/nonmatchings/level/LOONEY", func_8015C158_B4408);
 
-INCLUDE_ASM("asm/nonmatchings/level/LOONEY", func_8015C230_B44E0);
+void func_8015C230_B44E0(Instance* instance, short* arg1) {
+    LVECTOR out;
+    MATRIX* m = &instance->matrix[arg1[0xA / 2]];
+    Instance* fx;
+
+    MATH3D_ApplyMatrix(m, (SVECTOR*)&arg1[2], &out);
+    fx = ((Instance*)func_8000B778(instance, out.x, out.y, out.z, 0, 0, -5, 0x64, 0x64, 0x64));
+    fx->position.x = m->l[0];
+    fx->position.y = m->l[1];
+    fx->position.z = m->l[2];
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/LOONEY", func_8015C2D8_B4588);
 
-INCLUDE_ASM("asm/nonmatchings/level/LOONEY", looney_funguy_OnUpdate);
+void looney_funguy_OnUpdate(Instance* instance, GameTracker* gameTracker) {
+    int* fc;
+
+    fc = &instance->_F4[2];
+    switch (*(int*)&instance->_108) {
+    case 0:
+        func_8015BFCC_B427C(instance, gameTracker);
+        break;
+    case 1:
+        func_8015C158_B4408(instance, gameTracker);
+        break;
+    case 2:
+        func_8015C2D8_B4588(instance, gameTracker);
+        break;
+    }
+    fc[4] -= 1;
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/LOONEY", looney_funguy_OnCollide);
 
@@ -510,7 +565,23 @@ INCLUDE_ASM("asm/nonmatchings/level/LOONEY", looney_pusher_OnUpdate);
 void looney_pusher_OnCollide(Instance* instance, GameTracker* gameTracker) {
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/LOONEY", looney_bullet_OnCreate);
+void looney_bullet_OnCreate(Instance* instance, GameTracker* gameTracker) {
+    SVECTOR d;
+    Intro* intro;
+    int angle;
+
+    instance->_F4[2] = 0x5A;
+    instance->_100 = 0;
+    d.x = PlayerInstance->position.x - instance->position.x;
+    d.y = PlayerInstance->position.y - instance->position.y;
+    d.z = PlayerInstance->position.z - instance->position.z;
+    angle = ratan2(d.y, d.x) << 16;
+    intro = instance->intro;
+    instance->rotation.z = (angle >> 16) - 0x400;
+    intro->rotation.z = 0;
+    intro->rotation.y = 0;
+    intro->rotation.x = 0;
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/LOONEY", looney_bullet_OnUpdate);
 
@@ -522,9 +593,36 @@ INCLUDE_RODATA("asm/nonmatchings/level/LOONEY", D_80161E10_BA0C0);
 
 INCLUDE_ASM("asm/nonmatchings/level/LOONEY", looney_hunter_OnCreate);
 
-INCLUDE_ASM("asm/nonmatchings/level/LOONEY", func_8015E1E4_B6494);
+int func_8015E1E4_B6494(Instance* instance, int arg1, int arg2) {
+    LVECTOR d;
+    short* intro = instance->introData;
+    unsigned int sum;
+    unsigned int rr;
 
-INCLUDE_ASM("asm/nonmatchings/level/LOONEY", func_8015E290_B6540);
+    d.x = instance->position.x - PlayerInstance->position.x;
+    d.y = instance->position.y - PlayerInstance->position.y;
+    d.z = instance->position.z - PlayerInstance->position.z;
+    sum = d.x * d.x + d.y * d.y + d.z * d.z;
+    rr = intro[1] * intro[1];
+    if (sum < rr) {
+        ((short*)instance->_D0)[0] = arg2;
+        ((short*)instance->_D0)[1] = 1;
+        return 1;
+    }
+    return 0;
+}
+
+extern void func_8004ACB0(short* angle, short target, int step);
+
+/* turn toward the player at 0x80 per tick */
+void func_8015E290_B6540(Instance* instance) {
+    SVECTOR d;
+
+    d.x = PlayerInstance->position.x - instance->position.x;
+    d.y = PlayerInstance->position.y - instance->position.y;
+    d.z = PlayerInstance->position.z - instance->position.z;
+    func_8004ACB0(&instance->rotation.z, ((ratan2(d.y, d.x) << 16) + 0x4000000) >> 16, 0x80);
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/LOONEY", func_8015E31C_B65CC);
 
@@ -532,7 +630,22 @@ INCLUDE_ASM("asm/nonmatchings/level/LOONEY", func_8015E4C4_B6774);
 
 INCLUDE_ASM("asm/nonmatchings/level/LOONEY", looney_hunter_OnUpdate);
 
-INCLUDE_ASM("asm/nonmatchings/level/LOONEY", looney_hunter_OnCollide);
+void looney_hunter_OnCollide(Instance* instance, GameTracker* gameTracker) {
+    BSPTree* bsp = instance->bspTree;
+    char unused[1];
+
+    if (bsp->instanceSpline == gameTracker->player && bsp->_06 == 1 && bsp->_0C[5] == 8 &&
+        ((short*)instance->_D0)[0] != 8 && ((short*)instance->_D0)[0] != 0xC &&
+        (unsigned short)(((short*)instance->_D0)[0] - 9) >= 2) {
+        if (PlayerInstance->_F4[1] != 0x20) {
+            ((short*)instance->_D0)[0] = 0xC;
+        } else {
+            ((short*)instance->_D0)[0] = 8;
+        }
+        ((short*)instance->_D0)[1] = 1;
+        ((short*)instance->_D0)[3] -= 1;
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/LOONEY", func_8015F308_B75B8);
 
@@ -562,7 +675,15 @@ INCLUDE_ASM("asm/nonmatchings/level/LOONEY", func_80160318_B85C8);
 
 INCLUDE_ASM("asm/nonmatchings/level/LOONEY", looney_grrfish_OnUpdate);
 
-INCLUDE_ASM("asm/nonmatchings/level/LOONEY", looney_grrfish_OnCollide);
+void looney_grrfish_OnCollide(Instance* instance, GameTracker* gameTracker) {
+    BSPTree* bsp = instance->bspTree;
+
+    if (bsp->_06 == 1 && bsp->instanceSpline == gameTracker->player && bsp->_0C[5] >= 6) {
+        INSTANCE_PlainDeath(instance, 5, 3, 0);
+    } else if (bsp->_06 == 1 && bsp->instanceSpline == gameTracker->player) {
+        func_80022714(instance, gameTracker);
+    }
+}
 
 extern int D_80161DA4_BA054[];
 void looney_funplat_OnCreate(Instance* instance, GameTracker* gameTracker) {

--- a/src/level/MOOSHU.c
+++ b/src/level/MOOSHU.c
@@ -113,7 +113,27 @@ void mooshu_moobar_OnCollide(Instance* instance, GameTracker* gameTracker) {
 
 INCLUDE_ASM("asm/nonmatchings/level/MOOSHU", mooshu_moo_OnCollide);
 
-INCLUDE_ASM("asm/nonmatchings/level/MOOSHU", func_8015B2FC_C3C7C);
+void func_8015B2FC_C3C7C(Instance* instance, int arg1, int arg2) {
+    SVECTOR vec;
+
+    if (instance->currentModelAnim == 0) {
+        if (instance->currentAnimFrame == 6) {
+            int* m = ((int*)instance->oldMatrix);
+
+            vec.x = m[0x54 / 4];
+            vec.y = m[0x58 / 4];
+            vec.z = m[0x5C / 4];
+            func_8015D544_C5EC4(&vec, 8, 0x1E, arg2);
+        } else if (instance->currentAnimFrame == 0x11) {
+            int* m = ((int*)instance->oldMatrix);
+
+            vec.x = m[0xD4 / 4];
+            vec.y = m[0xD8 / 4];
+            vec.z = m[0xDC / 4];
+            func_8015D544_C5EC4(&vec, 8, 0x1E, arg2);
+        }
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/MOOSHU", func_8015B39C_C3D1C);
 
@@ -233,7 +253,21 @@ void func_8015C710_C5090(Instance* instance, GameTracker* gameTracker) {
     }
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/MOOSHU", func_8015C780_C5100);
+void func_8015C780_C5100(Instance* instance) {
+    if (instance->_F4[2] == 0) {
+        instance->_F4[1] = 0;
+        instance->_104 = 0;
+        if (instance->_F4[0] == 1) {
+            instance->_F4[2] = 0x14;
+            instance->_F4[0] = 3;
+            func_80050508(instance, 0x126, (short)((rand() & 0x1F) - 0xF), 0xC8, 0x2710);
+        } else if (instance->_F4[0] == 0) {
+            instance->_F4[2] = 0x14;
+            instance->_F4[0] = 2;
+            instance->_100 = 0x40;
+        }
+    }
+}
 
 void mooshu_moosprk_OnCreate(Instance* instance, GameTracker* gameTracker)
 {

--- a/src/level/MOOSHU.c
+++ b/src/level/MOOSHU.c
@@ -118,18 +118,18 @@ void func_8015B2FC_C3C7C(Instance* instance, int arg1, int arg2) {
 
     if (instance->currentModelAnim == 0) {
         if (instance->currentAnimFrame == 6) {
-            int* m = ((int*)instance->oldMatrix);
+            MATRIX* m = &instance->oldMatrix[2];
 
-            vec.x = m[0x54 / 4];
-            vec.y = m[0x58 / 4];
-            vec.z = m[0x5C / 4];
+            vec.x = m->l[0];
+            vec.y = m->l[1];
+            vec.z = m->l[2];
             func_8015D544_C5EC4(&vec, 8, 0x1E, arg2);
         } else if (instance->currentAnimFrame == 0x11) {
-            int* m = ((int*)instance->oldMatrix);
+            MATRIX* m = &instance->oldMatrix[6];
 
-            vec.x = m[0xD4 / 4];
-            vec.y = m[0xD8 / 4];
-            vec.z = m[0xDC / 4];
+            vec.x = m->l[0];
+            vec.y = m->l[1];
+            vec.z = m->l[2];
             func_8015D544_C5EC4(&vec, 8, 0x1E, arg2);
         }
     }

--- a/src/level/PREHST.c
+++ b/src/level/PREHST.c
@@ -536,7 +536,18 @@ INCLUDE_ASM("asm/nonmatchings/level/PREHST", prehst_cavegex_OnUpdate);
 
 INCLUDE_ASM("asm/nonmatchings/level/PREHST", prehst_cavegex_OnCollide);
 
-INCLUDE_ASM("asm/nonmatchings/level/PREHST", prehst_cavetl_OnCreate);
+void prehst_cavetl_OnCreate(Instance* instance, GameTracker* gameTracker) {
+    int* state = instance->_D0;
+
+    instance->_F4[0] = 4;
+    state[2] = 0x14;
+    state[5] = -2;
+    state[0] = -(((func_8003A6AC(instance->rotation.z - 0x400) << 16) >> 16) * 40) >> 12;
+    state[1] = -(((func_8003A4E0(instance->rotation.z - 0x400) << 16) >> 16) * 40) >> 12;
+    state[6] = 0x28;
+    state[7] = 0x28;
+    state[8] = 0x1E;
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/PREHST", prehst_cavetl_OnUpdate);
 
@@ -1006,37 +1017,6 @@ INCLUDE_ASM("asm/nonmatchings/level/PREHST", prehst_ptera_OnUpdate);
 
 INCLUDE_ASM("asm/nonmatchings/level/PREHST", func_801630A0_D0920);
 
-/* near-match kept for reference: matches only with `register int result __asm__("$2")` to pin the
-   return register; leader prefers no asm constructs, so it stays commented until properly matched.
-int func_801630A0_D0920(Instance* instance) {
-    MATRIX mat;
-    unsigned short out[3];
-    unsigned short out2[3];
-    register int result __asm__("$2");
-    unsigned short x;
-    unsigned short y;
-    unsigned short z;
-
-    MATH3D_SetUnityMatrix(&mat);
-    RotMatrixX(instance->rotation.x, &mat);
-    RotMatrixY(instance->rotation.y + 0x800, &mat);
-    RotMatrixZ(instance->rotation.z, &mat);
-    func_800157BC(&mat, out);
-    result = 0;
-    x = out[0];
-    y = out[1];
-    z = out[2];
-    out2[0] = x;
-    x &= 0xFFF;
-    out2[1] = y;
-    y &= 0xFFF;
-    out2[2] = z;
-    out2[0] = x;
-    out2[1] = y;
-    if (x == 0) result = (y < 1);
-    return result;
-}
-*/
 
 int func_80163138_D09B8(Instance* instance) {
     instance->rotation.x &= 0xFFF;

--- a/src/level/RTA.c
+++ b/src/level/RTA.c
@@ -494,7 +494,7 @@ void func_8015E538_DEBA8(short* rot, short dist, LVECTOR* out) {
     SVector v;
     MATRIX m;
 
-    memset(&v, 0, 8);
+    memset(&v, 0, sizeof(SVector));
     v.x = 0;
     v.y = dist;
     v.z = 0;

--- a/src/level/RTA.c
+++ b/src/level/RTA.c
@@ -191,7 +191,20 @@ void rta_count_OnCreate(Instance* instance, GameTracker* gameTracker) {
 
 INCLUDE_ASM("asm/nonmatchings/level/RTA", rta_count_OnUpdate);
 
-INCLUDE_ASM("asm/nonmatchings/level/RTA", rta_zcargo_OnCollide);
+extern int D_800EB8A0;
+
+void rta_zcargo_OnCollide(Instance* instance, GameTracker* gameTracker) {
+    int* data = ((int*)instance->object->data);
+    int val = 3;
+
+    if (data != 0) {
+        val = data[0];
+    }
+    if (instance->bspTree->instanceSpline == gameTracker->player) {
+        func_80018B60(PlayerInstance, D_800EB8A0, instance->position.x, instance->position.y, instance->position.z);
+        INSTANCE_PlainDeath(instance, 5, val, 0);
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/RTA", rta_zwleak_OnCreate);
 
@@ -269,7 +282,21 @@ int func_8015C344_DC9B4(Instance* instance) {
 
 INCLUDE_RODATA("asm/nonmatchings/level/RTA", D_8015EE74_DF4E4); // geysfx__
 
-INCLUDE_ASM("asm/nonmatchings/level/RTA", rta_zbubgen_OnCreate);
+void rta_zbubgen_OnCreate(Instance* instance, GameTracker* gameTracker) {
+    int* p = &instance->_F4[2];
+
+    if (instance->flags & 0x20000) {
+        instance->intro->flags &= ~8;
+    } else {
+        instance->flags |= 0x10400;
+        if (instance->intro->flags & 0x1000) {
+            instance->intro->flags &= ~0x800;
+        } else {
+            memset(p, 0, 0x28);
+            instance->_F4[2] = ((int)OBTABLE_FindObject("zbubblb_"));
+        }
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/RTA", rta_zbubgen_OnUpdate);
 
@@ -387,7 +414,26 @@ INCLUDE_ASM("asm/nonmatchings/level/RTA", rta_fxgen_OnUpdate);
 
 INCLUDE_ASM("asm/nonmatchings/level/RTA", func_8015CE34_DD4A4);
 
-INCLUDE_ASM("asm/nonmatchings/level/RTA", rta_zstmvent_OnCreate);
+void rta_zstmvent_OnCreate(Instance* instance, GameTracker* gameTracker) {
+    int r;
+    int z;
+
+    instance->scale.x = 0x2000;
+    instance->scale.y = 0x2000;
+    instance->scale.z = 0x1000;
+    memset(&instance->_F4[2], 0, 0x28);
+    instance->_F4[2] = ((int)OBTABLE_FindObject("zstmbub_"));
+    r = rand();
+    z = instance->position.z;
+    *(int*)&instance->_108 = z;
+    instance->_118 = z + 0x15E0;
+    *(int*)&instance->_10C = *(int*)&instance->_108 - 0x514;
+    *(int*)&instance->_110 = *(int*)&instance->_108;
+    *(int*)&instance->_114 = instance->_118;
+    instance->position.z = *(int*)&instance->_10C;
+    instance->_100 = r & 0x3F;
+    instance->_104 = 0;
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/RTA", rta_zstmvent_OnUpdate);
 
@@ -444,7 +490,20 @@ INCLUDE_ASM("asm/nonmatchings/level/RTA", func_8015E27C_DE8EC);
 
 INCLUDE_ASM("asm/nonmatchings/level/RTA", func_8015E3AC_DEA1C);
 
-INCLUDE_ASM("asm/nonmatchings/level/RTA", func_8015E538_DEBA8);
+void func_8015E538_DEBA8(short* rot, short dist, LVECTOR* out) {
+    SVector v;
+    MATRIX m;
+
+    memset(&v, 0, 8);
+    v.x = 0;
+    v.y = dist;
+    v.z = 0;
+    MATH3D_SetUnityMatrix(&m);
+    RotMatrixX(rot[0], &m);
+    RotMatrixY(rot[1], &m);
+    RotMatrixZ(rot[2], &m);
+    MATH3D_ApplyMatrix(&m, (SVECTOR*)&v, out);
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/RTA", func_8015E5E0_DEC50);
 

--- a/src/level/SCIFI.c
+++ b/src/level/SCIFI.c
@@ -27,7 +27,20 @@ INCLUDE_RODATA("asm/nonmatchings/level/SCIFI", D_80164DF0_EAC10);
 
 INCLUDE_RODATA("asm/nonmatchings/level/SCIFI", D_80164E14_EAC34);
 
-INCLUDE_ASM("asm/nonmatchings/level/SCIFI", func_80159A84_DF8A4);
+void func_80159A84_DF8A4(Instance* arg0) {
+    int* data = ((int*)PlayerInstance->data);
+
+    if (arg0 != 0) {
+        INSTANCE_KillInstance(arg0);
+    }
+    memcpy(data + 0x4C / 4, "helmet__", 9);
+    data[0x48 / 4] = 0x14;
+    func_800240C8();
+    if (D_8007681C != 0 && D_8007681C[7] != 0) {
+        ((short*)D_8007681C[7])[0x20 / 2] = 0x12C;
+    }
+}
+
 
 INCLUDE_ASM("asm/nonmatchings/level/SCIFI", func_80159B10_DF930);
 


### PR DESCRIPTION
## Summary

31 more level functions decompiled to byte-identical matches, continuing the easiest-first sweep (39-43 instruction tier). Full clean `make clean && make split && make build && make diff` passes on top of current master (includes the #109 cleanup — new code follows the declaration-initializer style from that pass).

## Functions

| Module | Functions |
|--------|-----------|
| KUNGFU | `kungfu_dragon_OnCollide`, `kungfu_dragbod_OnCollide`, `kungfu_spike_OnCreate`, `kungfu_boat_OnCreate`, `kungfu_oneway_OnCreate`, `kungfu_leafgen_OnCreate`, `func_8015DC00_ACE20`, `func_801619A4_B0BC4`, `func_8015F61C_AE83C` |
| LOONEY | `looney_bullet_OnCreate`, `looney_leafgen_OnCreate`, `looney_grrfish_OnCollide`, `looney_hunter_OnCollide`, `func_8015BC04_B3EB4`, `func_8015C230_B44E0`, `func_8015E1E4_B6494` |
| RTA | `rta_zcargo_OnCollide`, `rta_zstmvent_OnCreate`, `rta_zbubgen_OnCreate`, `func_8015E538_DEBA8` |
| FINAL | `func_8015B130_8C2D0`, `func_8015B268_8C408`, `func_8015CD54_8DEF4` |
| GEXZIL | `gexzil_mechjet_OnUpdate`, `func_8015F708_98888` |
| MOOSHU | `func_8015B2FC_C3C7C`, `func_8015C780_C5100` |
| CIRCUIT | `func_8015FA1C_86BFC` |
| PREHST | `prehst_cavetl_OnCreate` |
| SCIFI | `func_80159A84_DF8A4` |
| HORROR | `func_8015BF7C_9F7AC` |

## Techniques worth noting

- `func_80159A84` (the SCIFI "helmet__" copier) needed `memcpy(data + 0x4C / 4, "helmet__", 9)` through an `int*`-typed local — the pointer variable's alignment is what makes GCC expand the copy as aligned `lw/lw/lb` instead of `lwl/lwr`.
- The two `leafgen_OnCreate` twins are a local `char name[] = "leaffx__"` array initializer (that's where the lwl/lwr stack copy at function entry comes from), with a select-then-reassign if/else for the introData fallback.
- `func_8015CD54`'s inner counter is `i * 8 + 0x14` in source — GCC's strength reduction turns it into the running +8 register, and the giv's init landing *after* the loop-invariant hoists is the tell.
- `func_8015F708`'s loop needed the do-while + nested-guard spelling: the entry test compares against `result`'s zero register via CSE, and `i = 0` sinks into the second guard's branch delay.
- `func_8015F5D4` (GEXZIL) is left as a stub: everything matches except the target hoists the `0x80000` compare constant into the mult shadow while ours rematerializes it at the compare — same length, register-placement tie.

The parked near-match stubs stay bare per policy.