### PR TITLE
Decompile 34 level functions (43-52 instruction tier)

### DIFF
--- a/src/level/CIRCUIT.c
+++ b/src/level/CIRCUIT.c
@@ -185,7 +185,32 @@ void circuit_chrganm_OnCreate(Instance* instance, GameTracker* gameTracker) {
     func_80027110(instance, 0xA, gameTracker);
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/CIRCUIT", circuit_chrganm_OnUpdate);
+void circuit_chrganm_OnUpdate(Instance* instance, GameTracker* gameTracker) {
+    Instance* player = gameTracker->player;
+    MATRIX* m;
+    int r;
+    int flags;
+
+    r = func_80025798(player);
+    if (r != 0) {
+        m = &player->matrix[10];
+        instance->position.x = m->l[0];
+        instance->position.y = m->l[1];
+        instance->position.z = m->l[2];
+        func_8002DAF8(instance, -1);
+        flags = instance->flags & ~0x800;
+        instance->flags = flags;
+        if (r < 0x3D) {
+            if (((int*)gameTracker)[0xE0 / 4] & 1) {
+                instance->flags = flags | 0x800;
+            }
+        } else if (r < 0x79) {
+            if (((int*)gameTracker)[0xE0 / 4] & 2) {
+                instance->flags = flags | 0x800;
+            }
+        }
+    }
+}
 
 void func_8015B548_82728(Instance* instance) {
     instance->scale.y = instance->work0;
@@ -517,7 +542,24 @@ void circuit_pball_OnCollide(Instance* instance, GameTracker* gameTracker) {
 
 INCLUDE_ASM("asm/nonmatchings/level/CIRCUIT", func_8015DB80_84D60);
 
-INCLUDE_ASM("asm/nonmatchings/level/CIRCUIT", circuit_ppath_OnCreate);
+void circuit_ppath_OnCreate(Instance* instance, GameTracker* gameTracker) {
+    Model* model;
+    void* introData = instance->introData;
+
+    instance->currentTextureAnimFrame = 0;
+    model = instance->object->modelList[instance->currentModel];
+    instance->work1 = ((int*)model->_20)[2] * ((int*)model->_20)[3];
+    if (instance->intro != 0 && instance->intro->_04 != 0) {
+        instance->flags |= 0x80;
+    }
+    if (introData != 0) {
+        if (instance->intro != 0 && instance->intro->_04 != 0 && instance == ((Intro**)instance->intro->_04)[2]->instance) {
+            instance->work2 = 1;
+            WORK_AS(int, instance->work4) = 0;
+            WORK_AS(int, instance->work5) = -1;
+        }
+    }
+}
 
 void func_8015DD58_84F38(Instance* instance) {
     if (instance->currentMainState != 2) {
@@ -667,6 +709,8 @@ void circuit_reza_OnCollide(Instance* instance, GameTracker* gameTracker) {
     }
 }
 
+void func_8015FC70_86E50(Instance* instance);
+
 void func_8015F6B8_86898(Instance* instance, int arg1, int arg2) {
     instance->currentMainState = 1;
     instance->currentSubState = 2;
@@ -749,7 +793,35 @@ int* func_8015FA1C_86BFC(Instance* instance) {
 
 INCLUDE_ASM("asm/nonmatchings/level/CIRCUIT", func_8015FAC4_86CA4);
 
-INCLUDE_ASM("asm/nonmatchings/level/CIRCUIT", func_8015FC70_86E50);
+extern unsigned short D_801635B8_8A798;
+
+void func_8015FC70_86E50(Instance* instance) {
+    Intro* intro = instance->intro;
+    short** list = ((short**)(intro->_04 + 2));
+    short* ea;
+    short* eb;
+    short dx;
+    short dy;
+    short base;
+    int ext;
+
+    eb = list[WORK_AS_IDX(short, instance->work5, 0)];
+    ea = list[WORK_AS_IDX(short, instance->work5, 1)];
+    dx = ea[0x10 / 2] - eb[0x10 / 2];
+    dy = ea[0x12 / 2] - eb[0x12 / 2];
+    base = D_801635B8_8A798 - intro->rotation.z;
+    instance->rotation.z = base;
+    if (dx == 0) {
+        ext = (base << 16) >> 16;
+        if (dy > 0) {
+            instance->rotation.z = ext + 0x400;
+        } else {
+            instance->rotation.z = ext - 0x400;
+        }
+    } else {
+        instance->rotation.z += ratan2(dy, dx);
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/CIRCUIT", circuit_robo_OnUpdate);
 
@@ -790,9 +862,46 @@ INCLUDE_ASM("asm/nonmatchings/level/CIRCUIT", circuit_bomb_OnUpdate);
 void circuit_bomb_OnCollide(Instance* instance, GameTracker* gameTracker) {
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/CIRCUIT", circuit_explode_OnCreate);
+extern char D_8016363C_8A81C[];
 
-INCLUDE_ASM("asm/nonmatchings/level/CIRCUIT", circuit_explode_OnUpdate);
+void circuit_explode_OnCreate(Instance* instance, GameTracker* gameTracker) {
+    Instance* parent;
+    int* p = WORK_AS_PTR(int, instance->work0);
+    LVECTOR dims;
+    int r;
+
+    dims = *(LVECTOR*)((int*)instance->object->modelList[instance->currentModel]->_20 + 1);
+    WORK_AS_IDX(short, instance->work0, 0) = 0;
+    WORK_AS_IDX(short, instance->work0, 1) = (dims.y - 1) * dims.z;
+    instance->currentTextureAnimFrame = 0;
+    parent = instance->parent;
+    if (G2String_Compare_EQ(parent->object->parentName, D_8016363C_8A81C)) {
+        instance->position.x += WORK_AS_IDX(unsigned short, parent->work3, 0);
+        instance->position.z += WORK_AS_IDX(unsigned short, parent->work4, 0);
+    }
+    instance->flags |= 0x100480;
+    r = (rand() & 0x3F) - 0x20;
+    p[2] = r;
+    p[1] = func_80050508(instance, 0x20, (short)r, 0x5C, 0x1D4C);
+}
+
+void circuit_explode_OnUpdate(Instance* instance, GameTracker* gameTracker) {
+    short* p = WORK_AS_PTR(short, instance->work0);
+
+    if (instance->work1 != 0) {
+        if (func_80033200(instance->work1) == 0) {
+            instance->work1 = 0;
+        } else {
+            func_800506B8(instance, instance->work1, WORK_AS_IDX(short, instance->work2, 1), 0x5C, 0x1D4C);
+        }
+    }
+    p[0] += 1;
+    if (p[1] < p[0]) {
+        INSTANCE_KillInstance(instance);
+    } else {
+        instance->currentTextureAnimFrame += 1;
+    }
+}
 
 void circuit_explode_OnCollide(Instance* instance, GameTracker* gameTracker) {
     if (instance->bspTree->instanceSpline == gameTracker->player && instance->bspTree->_06 == 1) {

--- a/src/level/CIRCUIT.c
+++ b/src/level/CIRCUIT.c
@@ -812,7 +812,7 @@ void func_8015FC70_86E50(Instance* instance) {
     base = D_801635B8_8A798 - intro->rotation.z;
     instance->rotation.z = base;
     if (dx == 0) {
-        ext = (base << 16) >> 16;
+        ext = base;
         if (dy > 0) {
             instance->rotation.z = ext + 0x400;
         } else {
@@ -876,8 +876,8 @@ void circuit_explode_OnCreate(Instance* instance, GameTracker* gameTracker) {
     instance->currentTextureAnimFrame = 0;
     parent = instance->parent;
     if (G2String_Compare_EQ(parent->object->parentName, D_8016363C_8A81C)) {
-        instance->position.x += WORK_AS_IDX(unsigned short, parent->work3, 0);
-        instance->position.z += WORK_AS_IDX(unsigned short, parent->work4, 0);
+        instance->position.x += WORK_AS_IDX(short, parent->work3, 0);
+        instance->position.z += WORK_AS_IDX(short, parent->work4, 0);
     }
     instance->flags |= 0x100480;
     r = (rand() & 0x3F) - 0x20;

--- a/src/level/FINAL.c
+++ b/src/level/FINAL.c
@@ -130,7 +130,94 @@ void final_rezbomb_OnCreate(Instance* instance, GameTracker* gameTracker) {
     instance->currentSubState = OBTABLE_FindObject("rezxpl__");
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/FINAL", func_80159E50_8AFF0);
+typedef struct {
+    char _00[8];
+    int* next;
+    unsigned short flags;
+    short _0E;
+    void* callback;
+    void* _14;
+    int _18;
+    short posX;
+    short posY;
+    short posZ;
+    short _22;
+    unsigned short unk24;
+    short _26;
+    unsigned short unk28;
+    short _2A;
+    unsigned short unk2C;
+    short _2E;
+    unsigned short unk30;
+    short _32;
+    unsigned short unk34;
+    short _36;
+    unsigned short unk38;
+    short _3A;
+    unsigned short unk3C;
+    short _3E;
+    unsigned short unk40;
+    short _42;
+    short _44;
+    unsigned short _46;
+    unsigned short _48;
+    short _4A;
+    unsigned short _4C;
+    unsigned short _4E;
+    unsigned short _50;
+    unsigned short _52;
+    unsigned short _54;
+    unsigned short _56;
+    int _58[5];
+    unsigned short frame;
+} VentSprayData;
+
+void func_80159E50_8AFF0(VentSprayData* p, void* callback, char* data, int arg3, unsigned short* def, char* table, int arg6, int arg7, int arg8, int arg9, unsigned short arg10) {
+    SVECTOR c;
+    short* va;
+    short* vb;
+    short* vc;
+    int* nxt;
+    unsigned short t;
+
+    va = (short*)(table + def[0] * 12);
+    vb = (short*)(table + def[1] * 12);
+    vc = (short*)(table + def[2] * 12);
+    c.x = (va[0] + vb[0] + vc[0]) / 3;
+    c.y = (va[1] + vb[1] + vc[1]) / 3;
+    c.z = (va[2] + vb[2] + vc[2]) / 3;
+    p->posX = c.x + ((int*)data)[0x20 / 4];
+    p->posY = c.y + ((int*)data)[0x24 / 4];
+    p->posZ = c.z + ((int*)data)[0x28 / 4];
+    p->unk24 = va[0] - c.x;
+    p->_26 = va[1] - c.y;
+    p->unk28 = va[2] - c.z;
+    p->unk2C = vb[0] - c.x;
+    p->_2E = vb[1] - c.y;
+    p->unk30 = vb[2] - c.z;
+    p->unk34 = vc[0] - c.x;
+    p->_36 = vc[1] - c.y;
+    p->unk38 = vc[2] - c.z;
+    if (((unsigned char*)def)[7] & 2) {
+        p->flags |= 1;
+        nxt = ((int**)def)[2];
+        p->next = nxt;
+        p->_18 = (nxt[3] & 0x3FFFFFF) | 0x24000000;
+    } else {
+        p->flags &= ~1;
+        p->_18 = (((int*)def)[2] & 0x3FFFFFF) | 0x20000000;
+    }
+    p->callback = callback;
+    p->_14 = data;
+    p->_4C = -c.x >> 1;
+    p->_4E = -c.y >> 1;
+    t = c.z;
+    p->_52 = 0;
+    p->_54 = 0;
+    p->_56 = 0;
+    p->_0E = arg10;
+    p->_50 = -((t << 16) >> 17);
+}
 
 void func_8015A0DC_8B27C(short* arg0) {
     func_800162C0(arg0);
@@ -169,7 +256,23 @@ void func_8015A434_8B5D4(Instance* instance, Object* obj, int pos, int rot) {
     }
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/FINAL", func_8015A4C8_8B668);
+extern void func_80016894();
+
+void func_8015A4C8_8B668(int arg0, Object* obj, int arg2) {
+    Model* model;
+    VentSprayData* spray;
+
+    if (obj != 0) {
+        model = obj->modelList[1];
+        spray = ((VentSprayData*)func_800170E8(model, model->_14, arg2, 0, 0, D_800EB8A0, func_80017E88, func_80016894, -1));
+        if (model->_20 != 0 && spray != 0) {
+            spray->flags |= 4;
+            memcpy(spray->_58, spray->next, 0x10);
+            spray->_58[4] = model->_20 + 4;
+            spray->frame = 0;
+        }
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/FINAL", func_8015A590_8B730);
 
@@ -195,9 +298,19 @@ void func_8015AE98_8C038(void) {
 
 INCLUDE_ASM("asm/nonmatchings/level/FINAL", func_8015AED8_8C078);
 
-INCLUDE_ASM("asm/nonmatchings/level/FINAL", func_8015B07C_8C21C);
-
 extern void func_8004ACB0(short* angle, short target, int step);
+
+int func_8015B07C_8C21C(Instance* instance, int arg1, short arg2) {
+    SVECTOR d;
+    int angle;
+
+    d.x = PlayerInstance->position.x - instance->position.x;
+    d.y = PlayerInstance->position.y - instance->position.y;
+    d.z = PlayerInstance->position.z - instance->position.z;
+    angle = (short)ratan2(d.y, d.x) + 0x400;
+    func_8004ACB0(&instance->rotation.z, angle, arg2);
+    return instance->rotation.z == angle;
+}
 
 int func_8015B130_8C2D0(Instance* instance, int arg1, short arg2) {
     SVECTOR d;
@@ -383,6 +496,7 @@ void final_finaltv_OnCreate(Instance* instance, GameTracker* gameTracker) {
 
 INCLUDE_ASM("asm/nonmatchings/level/FINAL", final_finaltv_OnUpdate);
 
+
 void final_finaltv_OnCollide(Instance* instance, GameTracker* gameTracker) {
     if (G2String_Compare_EQ(instance->bspTree->instanceSpline->object->name, D_80161618_927B8)) {
         func_80046978(instance);
@@ -425,13 +539,46 @@ int func_8015F0C8_90268(int arg0, SVector* p1, SVector* p2, unsigned short* t) {
     return CAMERA_LengthSVector(&n) < t[3];
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/FINAL", func_8015F13C_902DC);
+extern int D_80161544_926E4;
+extern SVECTOR D_80161830_929D0;
+extern SVECTOR D_80161838_929D8;
+extern SVECTOR D_80161840_929E0;
+extern SVECTOR D_80161848_929E8;
+
+void func_8015F13C_902DC(SVECTOR* a, SVECTOR* b) {
+    if (D_80161544_926E4 == 0) {
+        D_80161848_929E8.x = a->x;
+        D_80161848_929E8.y = a->y;
+        D_80161848_929E8.z = a->z;
+        D_80161840_929E0.x = b->x;
+        D_80161840_929E0.y = b->y;
+        D_80161840_929E0.z = b->z;
+    } else {
+        D_80161830_929D0.x = a->x;
+        D_80161830_929D0.y = a->y;
+        D_80161830_929D0.z = a->z;
+        D_80161838_929D8.x = b->x;
+        D_80161838_929D8.y = b->y;
+        D_80161838_929D8.z = b->z;
+    }
+    D_80161544_926E4 += 1;
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/FINAL", func_8015F200_903A0);
 
 INCLUDE_ASM("asm/nonmatchings/level/FINAL", func_8015F480_90620);
 
-INCLUDE_ASM("asm/nonmatchings/level/FINAL", func_8015F818_909B8);
+int func_8015F818_909B8(Instance* instance, SVECTOR* target, int arg2, short arg3) {
+    SVECTOR d;
+    int angle;
+
+    d.x = target->x - instance->position.x;
+    d.y = target->y - instance->position.y;
+    d.z = target->z - instance->position.z;
+    angle = (short)ratan2(d.y, d.x) + 0x400;
+    func_8004ACB0(&instance->rotation.z, angle, arg3);
+    return instance->rotation.z == angle;
+}
 
 extern char D_8016166C_9280C[];
 extern void func_8015F200_903A0(void); // unknown

--- a/src/level/FINAL.c
+++ b/src/level/FINAL.c
@@ -170,9 +170,9 @@ typedef struct {
     unsigned short _56;
     int _58[5];
     unsigned short frame;
-} VentSprayData;
+} ParticleData;
 
-void func_80159E50_8AFF0(VentSprayData* p, void* callback, char* data, int arg3, unsigned short* def, char* table, int arg6, int arg7, int arg8, int arg9, unsigned short arg10) {
+void func_80159E50_8AFF0(ParticleData* p, void* callback, char* data, int arg3, unsigned short* def, char* table, int arg6, int arg7, int arg8, int arg9, unsigned short arg10) {
     SVECTOR c;
     short* va;
     short* vb;
@@ -260,11 +260,11 @@ extern void func_80016894();
 
 void func_8015A4C8_8B668(int arg0, Object* obj, int arg2) {
     Model* model;
-    VentSprayData* spray;
+    ParticleData* spray;
 
     if (obj != 0) {
         model = obj->modelList[1];
-        spray = ((VentSprayData*)func_800170E8(model, model->_14, arg2, 0, 0, D_800EB8A0, func_80017E88, func_80016894, -1));
+        spray = ((ParticleData*)func_800170E8(model, model->_14, arg2, 0, 0, D_800EB8A0, func_80017E88, func_80016894, -1));
         if (model->_20 != 0 && spray != 0) {
             spray->flags |= 4;
             memcpy(spray->_58, spray->next, 0x10);

--- a/src/level/GEXZIL.c
+++ b/src/level/GEXZIL.c
@@ -1,6 +1,7 @@
 #include "common.h"
 
 #include "level/GEXZIL.h"
+#include "types/G2String.h"
 
 void gexzil_bug_OnCreate(Instance* instance, GameTracker* gameTracker) {
     unsigned short* intro;
@@ -84,7 +85,17 @@ INCLUDE_ASM("asm/nonmatchings/level/GEXZIL", gexzil_bldg_OnCreate);
 
 INCLUDE_ASM("asm/nonmatchings/level/GEXZIL", gexzil_bldg_OnUpdate);
 
-INCLUDE_ASM("asm/nonmatchings/level/GEXZIL", gexzil_bldg_OnCollide);
+void gexzil_bldg_OnCollide(Instance* instance, GameTracker* gameTracker) {
+    BSPTree* bsp = instance->bspTree;
+    char* data = gameTracker->player->data;
+
+    if (func_80027500(bsp, gameTracker) != 0 && instance->work0 < instance->work1) {
+        func_8015B144_942C4(instance, gameTracker);
+        if (instance->work8 != 0 && ((int*)data)[0x138 / 4] != 0 && bsp->instanceSpline == gameTracker->player) {
+            bsp->instanceSpline->work0 |= 0x800;
+        }
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/GEXZIL", func_8015A7F0_93970);
 
@@ -711,9 +722,46 @@ void gexzil_gas_OnCollide(Instance* instance, GameTracker* gameTracker) {
     }
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/GEXZIL", gexzil_explode_OnCreate);
+extern char D_80162B70_9BCF0[];
 
-INCLUDE_ASM("asm/nonmatchings/level/GEXZIL", gexzil_explode_OnUpdate);
+void gexzil_explode_OnCreate(Instance* instance, GameTracker* gameTracker) {
+    Instance* parent;
+    int* p = WORK_AS_PTR(int, instance->work0);
+    LVECTOR dims;
+    int r;
+
+    dims = *(LVECTOR*)((int*)instance->object->modelList[instance->currentModel]->_20 + 1);
+    WORK_AS_IDX(short, instance->work0, 0) = 0;
+    WORK_AS_IDX(short, instance->work0, 1) = (dims.y - 1) * dims.z;
+    instance->currentTextureAnimFrame = 0;
+    parent = instance->parent;
+    if (G2String_Compare_EQ(parent->object->parentName, D_80162B70_9BCF0)) {
+        instance->position.x += WORK_AS_IDX(unsigned short, parent->work3, 0);
+        instance->position.z += WORK_AS_IDX(unsigned short, parent->work4, 0);
+    }
+    instance->flags |= 0x100480;
+    r = (rand() & 0x3F) - 0x20;
+    p[2] = r;
+    p[1] = func_80050508(instance, 0x20, (short)r, 0x5C, 0x1D4C);
+}
+
+void gexzil_explode_OnUpdate(Instance* instance, GameTracker* gameTracker) {
+    short* p = WORK_AS_PTR(short, instance->work0);
+
+    if (instance->work1 != 0) {
+        if (func_80033200(instance->work1) == 0) {
+            instance->work1 = 0;
+        } else {
+            func_800506B8(instance, instance->work1, WORK_AS_IDX(short, instance->work2, 1), 0x5C, 0x1D4C);
+        }
+    }
+    p[0] += 1;
+    if (p[1] < p[0]) {
+        INSTANCE_KillInstance(instance);
+    } else {
+        instance->currentTextureAnimFrame += 1;
+    }
+}
 
 void gexzil_explode_OnCollide(Instance* instance, GameTracker* gameTracker) {
     if (instance->bspTree->instanceSpline == gameTracker->player && instance->bspTree->_06 == 1) {

--- a/src/level/HORROR.c
+++ b/src/level/HORROR.c
@@ -190,7 +190,41 @@ INCLUDE_ASM("asm/nonmatchings/level/HORROR", horror_zomleg_OnUpdate);
 void horror_zomleg_OnCollide(Instance* instance, GameTracker* gameTracker) {
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/HORROR", horror_huck_OnCreate);
+void func_8015BF7C_9F7AC(Instance* instance, GameTracker* gameTracker);
+
+void horror_huck_OnCreate(Instance* instance, GameTracker* gameTracker) {
+    int* introData = instance->introData;
+    int flags = instance->flags;
+    Instance* linked;
+    int v;
+
+    if (flags & 0x20000) {
+        v = instance->work9;
+        if (v != 0) {
+            v = ~0x400;
+            linked = ((Instance*)instance->work9);
+            instance->flags = flags & v;
+            linked->parent = 0;
+            instance->work9 = 0;
+            if (linked->flags2 & 4) {
+                func_8015BF7C_9F7AC(linked, gameTracker);
+            } else {
+                INSTANCE_PlainDeath(linked, 5, 3, 0);
+            }
+        }
+    } else {
+        instance->currentMainState = 1;
+        instance->currentModelAnim = 0;
+        WORK_AS(int, instance->work3) = 0x19;
+        instance->work7 = 1;
+        if (introData != 0) {
+            instance->work8 = introData[0];
+        } else {
+            instance->work8 = 0;
+        }
+        instance->flags |= 0x10000;
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/HORROR", horror_huck_OnUpdate);
 
@@ -394,7 +428,15 @@ void horror_skelh_OnCreate(Instance* instance, GameTracker* gameTracker) {
 
 INCLUDE_ASM("asm/nonmatchings/level/HORROR", horror_skelh_OnUpdate);
 
-INCLUDE_ASM("asm/nonmatchings/level/HORROR", horror_skelh_OnCollide);
+void horror_skelh_OnCollide(Instance* instance, GameTracker* gameTracker) {
+    BSPTree* bsp = instance->bspTree;
+
+    if (bsp->_06 == 1 && bsp->instanceSpline == gameTracker->player && bsp->_0C[5] >= 6 && bsp->_08[4] == 0) {
+        INSTANCE_PlainDeath(instance, 5, -1, 0);
+    } else if (bsp->_06 == 1 && bsp->instanceSpline == gameTracker->player) {
+        func_80022714(instance, gameTracker);
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/HORROR", horror_fltlamp_OnCollide);
 

--- a/src/level/HORROR.c
+++ b/src/level/HORROR.c
@@ -204,7 +204,7 @@ void horror_huck_OnCreate(Instance* instance, GameTracker* gameTracker) {
             v = ~0x400;
             linked = ((Instance*)instance->work9);
             instance->flags = flags & v;
-            linked->parent = 0;
+            linked->parent = NULL;
             instance->work9 = 0;
             if (linked->flags2 & 4) {
                 func_8015BF7C_9F7AC(linked, gameTracker);

--- a/src/level/KUNGFU.c
+++ b/src/level/KUNGFU.c
@@ -596,7 +596,24 @@ INCLUDE_RODATA("asm/nonmatchings/level/KUNGFU", D_80162700_B1920); // draga___
 
 INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", kungfu_cannon_OnUpdate);
 
-INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", kungfu_canball_OnCreate);
+void kungfu_canball_OnCreate(Instance* instance, GameTracker* gameTracker) {
+    Instance* parent = instance->parent;
+    short* p = WORK_AS_PTR(short, parent->work0);
+
+    if (instance->flags & 0x20000) {
+        if (instance->object->oflags2 & 4) {
+            if (instance->flags2 & 0x2000) {
+                instance->flags2 &= ~0x2000;
+                func_800331BC(*(int*)&instance->_34[4]);
+                *(int*)&instance->_34[4] = 0;
+            }
+        }
+        p[0x18 / 2] -= 1;
+    } else {
+        instance->flags |= 0x10000;
+        WORK_AS_IDX(short, parent->work6, 0) += 1;
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", kungfu_canball_OnUpdate);
 
@@ -909,7 +926,24 @@ void func_8016121C_B043C(Instance* instance, GameTracker* gameTracker) {
 
 INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", kungfu_joyride_OnUpdate);
 
-INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", kungfu_joyride_OnCollide);
+void kungfu_joyride_OnCollide(Instance* instance, GameTracker* gameTracker) {
+    Instance* player = gameTracker->player;
+    BSPTree* bsp = instance->bspTree;
+
+    if (bsp->instanceSpline == player) {
+        ((short*)instance->_D0)[0] |= 1;
+    }
+    if (*(short*)&instance->_D0[2] == 0) {
+        if (bsp->_04 == 1) {
+            func_8004AEC8(instance, 0, 0, 0x80, (SVECTOR*)((short*)instance->_D0 + 5));
+            *(short*)&instance->_D0[2] = 1;
+            gameTracker->gameFlags |= 1;
+        }
+        player->currentMainState = 5;
+    } else if (*(short*)&instance->_D0[2] == 3) {
+        func_80022D54(instance, gameTracker);
+    }
+}
 
 void kungfu_leafgen_OnCreate(Instance* instance, GameTracker* gameTracker) {
     const char name[] = "leaffx__";

--- a/src/level/LOONEY.c
+++ b/src/level/LOONEY.c
@@ -564,7 +564,7 @@ void looney_funguy_OnUpdate(Instance* instance, GameTracker* gameTracker) {
 }
 
 void looney_funguy_OnCollide(Instance* instance, GameTracker* gameTracker) {
-    int fd = ((int*)instance->work0)[1];
+    int fd = WORK_AS(int*, instance->work0)[1];
     BSPTree* bsp = instance->bspTree;
     int* fc = WORK_AS_PTR(int, instance->work0);
     Instance* player;

--- a/src/level/LOONEY.c
+++ b/src/level/LOONEY.c
@@ -270,11 +270,119 @@ void looney_brkblok_OnCreate(Instance* instance, GameTracker* gameTracker) {
     }
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/LOONEY", looney_brkblok_OnUpdate);
+void looney_brkblok_OnUpdate(Instance* instance, GameTracker* gameTracker) {
+    int v;
+
+    if (WORK_AS_IDX(short, instance->work2, 0) != 0) {
+        v = instance->_D0[2] - 10;
+        instance->_D0[2] = v;
+        instance->position.z += v;
+        if (instance->position.z < WORK_AS_IDX(short, instance->work2, 1)) {
+            instance->position.z = WORK_AS_IDX(short, instance->work2, 1);
+            instance->_D0[2] = 0;
+            WORK_AS_IDX(short, instance->work2, 0) = 0;
+        }
+    } else if (WORK_AS_IDX(short, instance->work3, 0) != 0) {
+        WORK_AS_IDX(short, instance->work3, 0) -= 1;
+        if (WORK_AS_IDX(short, instance->work3, 0) == 0) {
+            func_8002E350(instance);
+        }
+    }
+    if (instance->object->oflags & 0x400) {
+        GenericProcess(instance, gameTracker);
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/LOONEY", func_8015ADD8_B3088);
 
-INCLUDE_ASM("asm/nonmatchings/level/LOONEY", func_8015AF30_B31E0);
+typedef struct {
+    char _00[8];
+    void* next;
+    unsigned short flags;
+    short _0E;
+    void* callback;
+    void* _14;
+    int _18;
+    short posX;
+    short posY;
+    short posZ;
+    short _22;
+    unsigned short unk24;
+    short _26;
+    unsigned short unk28;
+    short _2A;
+    unsigned short unk2C;
+    short _2E;
+    unsigned short unk30;
+    short _32;
+    unsigned short unk34;
+    short _36;
+    unsigned short unk38;
+    short _3A;
+    unsigned short unk3C;
+    short _3E;
+    unsigned short unk40;
+    short _42;
+    short _44;
+    unsigned short _46;
+    unsigned short _48;
+    short _4A;
+    unsigned short _4C;
+    unsigned short _4E;
+    unsigned short _50;
+    unsigned short _52;
+    unsigned short _54;
+    unsigned short _56;
+    char _58[0x14];
+    unsigned short frame;
+} VentSprayData;
+
+void func_8015AF30_B31E0(VentSprayData* p, void* callback, char* data, void* arg3, unsigned short* def, char* table, int arg6, int arg7, int arg8, int arg9, unsigned short arg10) {
+    SVECTOR c;
+    short* va;
+    short* vb;
+    short* vc;
+    int* nxt;
+    unsigned short t;
+
+    va = (short*)(table + def[0] * 12);
+    vb = (short*)(table + def[1] * 12);
+    vc = (short*)(table + def[2] * 12);
+    c.x = (va[0] + vb[0] + vc[0]) / 3;
+    c.y = (va[1] + vb[1] + vc[1]) / 3;
+    c.z = (va[2] + vb[2] + vc[2]) / 3;
+    p->posX = c.x + ((int*)data)[0x20 / 4];
+    p->posY = c.y + ((int*)data)[0x24 / 4];
+    p->posZ = c.z + ((int*)data)[0x28 / 4];
+    p->unk24 = va[0] - c.x;
+    p->_26 = va[1] - c.y;
+    p->unk28 = va[2] - c.z;
+    p->unk2C = vb[0] - c.x;
+    p->_2E = vb[1] - c.y;
+    p->unk30 = vb[2] - c.z;
+    p->unk34 = vc[0] - c.x;
+    p->_36 = vc[1] - c.y;
+    p->unk38 = vc[2] - c.z;
+    if (((unsigned char*)def)[7] & 2) {
+        p->flags |= 1;
+        nxt = ((int**)def)[2];
+        p->next = nxt;
+        p->_18 = (nxt[3] & 0x3FFFFFF) | 0x24000000;
+    } else {
+        p->flags &= ~1;
+        p->_18 = (((int*)def)[2] & 0x3FFFFFF) | 0x20000000;
+    }
+    p->callback = callback;
+    p->_14 = data;
+    p->_4C = -c.x >> 1;
+    p->_4E = -c.y >> 1;
+    t = c.z;
+    p->_52 = 0;
+    p->_54 = 0;
+    p->_56 = 0;
+    p->_0E = arg10;
+    p->_50 = -((t << 16) >> 17);
+}
 
 void func_8015B1BC_B346C(short* arg0) {
     func_800162C0(arg0);
@@ -455,7 +563,23 @@ void looney_funguy_OnUpdate(Instance* instance, GameTracker* gameTracker) {
     fc[4] -= 1;
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/LOONEY", looney_funguy_OnCollide);
+void looney_funguy_OnCollide(Instance* instance, GameTracker* gameTracker) {
+    int fd = ((int*)instance->work0)[1];
+    BSPTree* bsp = instance->bspTree;
+    int* fc = WORK_AS_PTR(int, instance->work0);
+    Instance* player;
+
+    if (fd != 0 && (player = bsp->instanceSpline) == gameTracker->player && bsp->_06 == 1 && bsp->_0C[5] == 8 &&
+        WORK_AS(int, instance->work3) != 2 &&
+        ((player->currentSubState == 0x20 && (fd & 2)) || (player->currentSubState != 0x80 && (fd & 1)))) {
+        instance->flags2 = (instance->flags2 | 0x200) & ~0x10;
+        instance->currentAnimFrame = 0;
+        fc[3] = 2;
+        if (fc[5] >= 0) {
+            fc[5] -= 1;
+        }
+    }
+}
 
 typedef struct {
     char _00[8];
@@ -497,13 +621,56 @@ INCLUDE_ASM("asm/nonmatchings/level/LOONEY", looney_fallgen_OnUpdate);
 void looney_fallgen_OnCollide(Instance* instance, GameTracker* gameTracker) {
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/LOONEY", looney_fallobj_OnCreate);
+extern short D_80161C64_B9F14[];
+extern char D_80161DD8_BA088[];
+
+void looney_fallobj_OnCreate(Instance* instance, GameTracker* gameTracker) {
+    short* data = instance->object->data;
+    int* pc = 0;
+
+    if (data == 0) {
+        instance->object->data = D_80161C64_B9F14;
+        data = D_80161C64_B9F14;
+    }
+    instance->object->oflags |= 0x2000000;
+    instance->flags |= 0x40;
+    WORK_AS_IDX(short, instance->work9, 1) = data[0];
+    instance->_D0[2] = data[3];
+    instance->_E0[1] = data[2];
+    WORK_AS(int, instance->work3) = ((int)OBTABLE_FindObject(D_80161DD8_BA088));
+    WORK_AS(int, instance->work4) = 3;
+    instance->shadowPosition.z = -0x8000;
+    if (instance->parent != 0) {
+        pc = WORK_AS_PTR(int, instance->parent->work0);
+    }
+    if (pc != 0) {
+        pc[2] = 0x1E;
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/LOONEY", func_8015CB5C_B4E0C);
 
 INCLUDE_ASM("asm/nonmatchings/level/LOONEY", looney_fallobj_OnUpdate);
 
-INCLUDE_ASM("asm/nonmatchings/level/LOONEY", looney_fallobj_OnCollide);
+void looney_fallobj_OnCollide(Instance* instance, GameTracker* gameTracker) {
+    Instance* parent = instance->parent;
+    BSPTree* bsp = instance->bspTree;
+    int* pc;
+
+    pc = 0;
+    if (parent != 0) {
+        pc = WORK_AS_PTR(int, parent->work0);
+    }
+    if (bsp->instanceSpline == gameTracker->player && instance->work0 == 0 && PlayerInstance->scale.z == 0x1000) {
+        if (pc != 0) {
+            pc[2] = 0x3C;
+        }
+        func_80022810(instance, gameTracker, 0x3C);
+        if (*(int*)&gameTracker->_4BF4[4] > 0) {
+            func_800279AC(PlayerInstance, 0x14, 0x2000, 0xD, 0x2000, 0x78);
+        }
+    }
+}
 
 void looney_teeter_OnCreate(Instance* instance, GameTracker* gameTracker) {
     extern int D_80161C9C_B9F4C;
@@ -517,7 +684,24 @@ void looney_teeter_OnCreate(Instance* instance, GameTracker* gameTracker) {
 
 INCLUDE_ASM("asm/nonmatchings/level/LOONEY", looney_teeter_OnUpdate);
 
-INCLUDE_ASM("asm/nonmatchings/level/LOONEY", looney_teeter_OnCollide);
+void looney_teeter_OnCollide(Instance* instance, GameTracker* gameTracker) {
+    LVECTOR newPosition;
+    MATRIX transformMatrix;
+    BSPTree* bsp = instance->bspTree;
+
+    if (bsp->_06 == 4) {
+        if (bsp->instanceSpline == gameTracker->player) {
+            if (instance->matrix) {
+                func_80041FD0(&transformMatrix, instance->matrix);
+                MATH3D_ApplyMatrixT(&transformMatrix, &bsp->globalOffset, &newPosition);
+                instance->work1 = newPosition.x << 2;
+                WORK_AS(int, instance->work3) = newPosition.x;
+                instance->work2 = ((int)bsp->instanceSpline);
+                GenericCollide(instance, gameTracker);
+            }
+        }
+    }
+}
 
 extern short D_80161CA4_B9F54[];
 
@@ -883,7 +1067,20 @@ void looney_genbrk_OnCollide(Instance* instance, GameTracker* gameTracker) {
     }
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/LOONEY", looney_jimboat_OnCollide);
+void looney_jimboat_OnCollide(Instance* instance, GameTracker* gameTracker) {
+    GenericCollide(instance, gameTracker);
+    if (instance->work0 == 0) {
+        instance->work0 = instance->flags & 0x400;
+        if (instance->work0 != 0) {
+            func_80032B34(-1, 2, 0x20, gameTracker->levelIdToLoad, 0);
+        }
+    } else if (instance->work1 == 0) {
+        instance->work1 = instance->intro->flags & 0x100;
+        if (instance->work1 != 0) {
+            func_80032B34(-1, 1, 2, gameTracker->levelIdToLoad, 0);
+        }
+    }
+}
 
 void looney_colorset_OnCreate(Instance* instance, GameTracker* gameTracker) {
     unsigned short* intro;

--- a/src/level/LOONEY.c
+++ b/src/level/LOONEY.c
@@ -335,9 +335,9 @@ typedef struct {
     unsigned short _56;
     char _58[0x14];
     unsigned short frame;
-} VentSprayData;
+} ParticleData;
 
-void func_8015AF30_B31E0(VentSprayData* p, void* callback, char* data, void* arg3, unsigned short* def, char* table, int arg6, int arg7, int arg8, int arg9, unsigned short arg10) {
+void func_8015AF30_B31E0(ParticleData* p, void* callback, char* data, void* arg3, unsigned short* def, char* table, int arg6, int arg7, int arg8, int arg9, unsigned short arg10) {
     SVECTOR c;
     short* va;
     short* vb;
@@ -637,7 +637,7 @@ void looney_fallobj_OnCreate(Instance* instance, GameTracker* gameTracker) {
     WORK_AS_IDX(short, instance->work9, 1) = data[0];
     instance->_D0[2] = data[3];
     instance->_E0[1] = data[2];
-    WORK_AS(int, instance->work3) = ((int)OBTABLE_FindObject(D_80161DD8_BA088));
+    WORK_AS(Object*, instance->work3) = OBTABLE_FindObject(D_80161DD8_BA088);
     WORK_AS(int, instance->work4) = 3;
     instance->shadowPosition.z = -0x8000;
     if (instance->parent != 0) {
@@ -694,9 +694,9 @@ void looney_teeter_OnCollide(Instance* instance, GameTracker* gameTracker) {
             if (instance->matrix) {
                 func_80041FD0(&transformMatrix, instance->matrix);
                 MATH3D_ApplyMatrixT(&transformMatrix, &bsp->globalOffset, &newPosition);
-                instance->work1 = newPosition.x << 2;
+                instance->work1 = newPosition.x * 4;
                 WORK_AS(int, instance->work3) = newPosition.x;
-                instance->work2 = ((int)bsp->instanceSpline);
+                WORK_AS(Instance*, instance->work2) = bsp->instanceSpline;
                 GenericCollide(instance, gameTracker);
             }
         }

--- a/src/level/MOOSHU.c
+++ b/src/level/MOOSHU.c
@@ -32,7 +32,26 @@ INCLUDE_ASM("asm/nonmatchings/level/MOOSHU", func_80159EC4_C2844);
 void func_8015A07C_C29FC(Instance* instance, GameTracker* gameTracker) {
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/MOOSHU", func_8015A084_C2A04);
+void func_8015B4D4_C3E54(Instance* instance, short* arg1);
+int func_8015B510_C3E90(Instance* instance, short* arg1, int arg2, short arg3);
+void func_8015B5F0_C3F70(Instance* instance, short* arg1);
+
+void func_8015A084_C2A04(Instance* instance, short arg1, short arg2, short* arg3) {
+    Instance* player = gameTracker8->player;
+
+    if (instance->flags2 & 0x10) {
+        if (arg3[0x40 / 2] == 0) {
+            func_8015B39C_C3D1C(instance, arg1, arg2);
+        } else if ((short)func_8004B23C(instance, player) < 0x280) {
+            arg3[0x14 / 2] = 6;
+            if (func_8015B510_C3E90(instance, arg3, 1, 0) != 0) {
+                func_8015B4D4_C3E54(instance, arg3);
+            }
+        } else {
+            func_8015B5F0_C3F70(instance, arg3);
+        }
+    }
+}
 
 void func_8015A150_C2AD0(Instance* instance, short arg1, short arg2) {
     if (instance->flags2 & 0x10) {
@@ -80,7 +99,15 @@ void func_8015A258_C2BD8(SVECTOR* pos, int arg1, GameTracker* gameTracker) {
     c[0x17] = c[6] = c[0x1A];
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/MOOSHU", func_8015A2E0_C2C60);
+void func_8015A2E0_C2C60(Camera* camera, SVECTOR* arg1, SVector* arg2) {
+    camera->cameraCore.position = *arg1;
+    *(SVector*)&camera->cameraCore._08[0x28 / 4] = *arg2;
+    *(SVECTOR*)&camera->cameraCore._08[0x8 / 4] = *arg1;
+    *(SVector*)&camera->cameraCore._08[0x10 / 4] = *arg2;
+    *(SVector*)&camera->cameraCore._08[0] = *arg2;
+    ((short*)camera->cameraCore._08)[0x26 / 2] = arg2->z;
+    CAMERA_SetMode(camera, 8);
+}
 
 void func_8015A398_C2D18()
 {
@@ -145,7 +172,29 @@ void func_8015B4D4_C3E54(Instance* instance, short* arg1) {
     arg1[6] = 6;
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/MOOSHU", func_8015B510_C3E90);
+int func_8015B510_C3E90(Instance* instance, short* arg1, int arg2, short arg3) {
+    short angle;
+    int result = 0;
+
+    if (arg2 != 0) {
+        arg1[0x4 / 2] |= 1;
+    } else {
+        arg1[0x12 / 2] = arg3;
+        arg1[0x4 / 2] &= ~1;
+    }
+    if (func_8015B9D0_C4350(instance, arg1, &angle) != 0) {
+        result = 1;
+        instance->rotation.z = angle + 0x400;
+    } else {
+        instance->flags2 &= ~0x10;
+        if (instance->currentModelAnim != 0) {
+            instance->currentModelAnim = 0;
+            instance->currentAnimFrame = 0;
+        }
+        arg1[0xC / 2] = 9;
+    }
+    return result;
+}
 
 void func_8015B5C0_C3F40(Instance* instance, short* arg1) {
     arg1[5] = (gameTracker8->player->position.y > 0) ? -1 : 1;

--- a/src/level/PREHST.c
+++ b/src/level/PREHST.c
@@ -336,7 +336,7 @@ typedef struct {
     unsigned short frame;
 } VentSprayData;
 
-extern void func_80016894(void*);
+extern void func_80016894();
 INCLUDE_ASM("asm/nonmatchings/level/PREHST", func_8015B47C_C8CFC);
 /* near-match (8 diffs: frame a1/a2, mflo v0/v1, z-check load order — scheduler difference):
 void func_8015B47C_C8CFC(void* arg0) {
@@ -1308,7 +1308,21 @@ void func_80163C4C_D14CC(VentSprayData* p, void* callback, char* data, int arg3,
     p->unk38 += 0x28;
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/PREHST", func_80163EE0_D1760);
+void func_80163EE0_D1760(short* p, int arg1) {
+    if (p[0x20 / 2] + p[0x50 / 2] <= p[0x44 / 2]) {
+        if (p[0x46 / 2] < 3) {
+            p[0x46 / 2] += 1;
+            p[0x48 / 2] = p[0x50 / 2] = p[0x48 / 2] - 0xA;
+        }
+    }
+    p[0x24 / 2] -= 1;
+    p[0x28 / 2] += 3;
+    p[0x2C / 2] -= 1;
+    p[0x30 / 2] -= 1;
+    p[0x34 / 2] += 3;
+    p[0x38 / 2] -= 1;
+    func_80016894(p, arg1);
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/PREHST", func_80163F94_D1814);
 

--- a/src/level/PREHST.c
+++ b/src/level/PREHST.c
@@ -334,19 +334,19 @@ typedef struct {
     unsigned short _56;
     char _58[0x14];
     unsigned short frame;
-} VentSprayData;
+} ParticleData;
 
 extern void func_80016894();
 INCLUDE_ASM("asm/nonmatchings/level/PREHST", func_8015B47C_C8CFC);
 /* near-match (8 diffs: frame a1/a2, mflo v0/v1, z-check load order — scheduler difference):
 void func_8015B47C_C8CFC(void* arg0) {
-    VentSprayData* data;
+    ParticleData* data;
     Instance* player;
     int dz;
     int dx;
     int dy;
 
-    data = ((VentSprayData*)arg0);
+    data = ((ParticleData*)arg0);
     data->unk24 -= 10;
     data->unk28 += 10;
     data->frame++;
@@ -382,7 +382,7 @@ void func_8015B5B0_C8E30(Instance* instance) {
     Model* model;
     SVECTOR rot;
     SVECTOR vel;
-    VentSprayData* spray;
+    ParticleData* spray;
 
     obj = ((Object*)OBTABLE_FindObject("sprysht_"));
     if (instance->_E0[3] == 0) {
@@ -418,7 +418,7 @@ void func_8015B5B0_C8E30(Instance* instance) {
     vel.x = 0;
     vel.y = 0;
     vel.z = 0;
-    spray = ((VentSprayData*)func_800170E8(model, model->_14, &instance->position, &rot, 0, D_800EB8A0, func_80017E88, func_8015B47C_C8CFC, 0x14));
+    spray = ((ParticleData*)func_800170E8(model, model->_14, &instance->position, &rot, 0, D_800EB8A0, func_80017E88, func_8015B47C_C8CFC, 0x14));
     if (spray != NULL) {
         if (*(int*)&instance->_34[2] == 0) {
             *(int*)&instance->_34[2] = func_80050508(instance, 0x112, -0x15E, 0x50, 0xBB8);
@@ -1233,7 +1233,7 @@ void func_80163BC8_D1448(Instance* instance, short target, short step) {
     }
 }
 
-void func_80163C4C_D14CC(VentSprayData* p, void* callback, char* data, int arg3, unsigned short* def, char* table, unsigned short* pos, unsigned short* vel, unsigned short* acc, int arg9, unsigned short arg10) {
+void func_80163C4C_D14CC(ParticleData* p, void* callback, char* data, int arg3, unsigned short* def, char* table, unsigned short* pos, unsigned short* vel, unsigned short* acc, int arg9, unsigned short arg10) {
     short* tail;
     int* nxt;
     int off;

--- a/src/level/RTA.c
+++ b/src/level/RTA.c
@@ -178,7 +178,29 @@ void rta_zturtle_OnCreate(Instance* instance, GameTracker* gameTracker) {
 
 INCLUDE_ASM("asm/nonmatchings/level/RTA", rta_zturtle_OnUpdate);
 
-INCLUDE_ASM("asm/nonmatchings/level/RTA", rta_zturtle_OnCollide);
+extern int D_8015EE24;
+
+void rta_zturtle_OnCollide(Instance* instance, GameTracker* gameTracker) {
+    Instance* player;
+    Instance* collider;
+
+    if (instance->work0 == 0) {
+        player = gameTracker->player;
+        collider = instance->bspTree->instanceSpline;
+        if (collider == player) {
+            instance->work0 = 1;
+            instance->work1 = collider->position.x - instance->position.x;
+            D_8015EF10_DF580 = 1;
+            instance->work2 = collider->position.y - instance->position.y;
+            D_8015EE24 = 0xC8;
+            WORK_AS(int, instance->work3) = collider->position.z - instance->position.z;
+            collider->currentSubState = 5;
+            collider->flags |= 0x100;
+            ((int*)gameTracker->camera)[0x444 / 4] = 0x4B0;
+            func_80050A80(0, 2);
+        }
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/RTA", rta_zarchsig_OnCollide);
 
@@ -189,7 +211,21 @@ void rta_count_OnCreate(Instance* instance, GameTracker* gameTracker) {
     instance->currentTextureAnimFrame = ((int*)gameTracker8)[0x4CC8 / 4] + 1;
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/RTA", rta_count_OnUpdate);
+void rta_count_OnUpdate(Instance* instance, GameTracker* gameTracker) {
+    if (instance->work1 >= 0x7D1) {
+        func_8002E350(instance);
+    } else {
+        instance->rotation.z += instance->work0;
+        if (instance->rotation.z >= 0x1000) {
+            instance->rotation.z -= 0x1000;
+        }
+        instance->position.x = gameTracker->player->position.x;
+        instance->position.y = gameTracker->player->position.y;
+        instance->position.z = gameTracker->player->position.z + instance->work1;
+        instance->work1 += 0x14;
+        instance->work0 += 0x10;
+    }
+}
 
 extern int D_800EB8A0;
 
@@ -208,7 +244,27 @@ void rta_zcargo_OnCollide(Instance* instance, GameTracker* gameTracker) {
 
 INCLUDE_ASM("asm/nonmatchings/level/RTA", rta_zwleak_OnCreate);
 
-INCLUDE_ASM("asm/nonmatchings/level/RTA", rta_zwleak_OnUpdate);
+extern short D_8015ED9C_DF40C;
+
+void rta_zwleak_OnUpdate(Instance* instance, GameTracker* gameTracker) {
+    Instance* player;
+    int dx;
+    int dy;
+    int dz;
+
+    instance->work2 += 1;
+    if (D_8015ED9C_DF40C < instance->work2) {
+        player = gameTracker->player;
+        dx = instance->position.x - player->position.x;
+        dy = instance->position.y - player->position.y;
+        dz = instance->position.z - player->position.z;
+        if (dx * dx + dy * dy + dz * dz <= 0xBAEB8F) {
+            func_8015B1D4_DB844(instance);
+        }
+        instance->work2 = 0;
+    }
+    func_8015A2B0_DA920(instance, 0x9C4);
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/RTA", rta_zwleak_OnCollide);
 

--- a/src/level/RTA.c
+++ b/src/level/RTA.c
@@ -182,20 +182,20 @@ extern int D_8015EE24;
 
 void rta_zturtle_OnCollide(Instance* instance, GameTracker* gameTracker) {
     Instance* player;
-    Instance* collider;
+    Instance* other;
 
     if (instance->work0 == 0) {
         player = gameTracker->player;
-        collider = instance->bspTree->instanceSpline;
-        if (collider == player) {
+        other = instance->bspTree->instanceSpline;
+        if (other == player) {
             instance->work0 = 1;
-            instance->work1 = collider->position.x - instance->position.x;
+            instance->work1 = other->position.x - instance->position.x;
             D_8015EF10_DF580 = 1;
-            instance->work2 = collider->position.y - instance->position.y;
+            instance->work2 = other->position.y - instance->position.y;
             D_8015EE24 = 0xC8;
-            WORK_AS(int, instance->work3) = collider->position.z - instance->position.z;
-            collider->currentSubState = 5;
-            collider->flags |= 0x100;
+            instance->work3 = other->position.z - instance->position.z;
+            other->currentSubState = 5;
+            other->flags |= 0x100;
             ((int*)gameTracker->camera)[0x444 / 4] = 0x4B0;
             func_80050A80(0, 2);
         }
@@ -258,7 +258,7 @@ void rta_zwleak_OnUpdate(Instance* instance, GameTracker* gameTracker) {
         dx = instance->position.x - player->position.x;
         dy = instance->position.y - player->position.y;
         dz = instance->position.z - player->position.z;
-        if (dx * dx + dy * dy + dz * dz <= 0xBAEB8F) {
+        if (dx * dx + dy * dy + dz * dz <= (12250000 - 1)) {
             func_8015B1D4_DB844(instance);
         }
         instance->work2 = 0;

--- a/src/level/RTA.c
+++ b/src/level/RTA.c
@@ -258,7 +258,7 @@ void rta_zwleak_OnUpdate(Instance* instance, GameTracker* gameTracker) {
         dx = instance->position.x - player->position.x;
         dy = instance->position.y - player->position.y;
         dz = instance->position.z - player->position.z;
-        if (dx * dx + dy * dy + dz * dz <= (12250000 - 1)) {
+        if (dx * dx + dy * dy + dz * dz < (3500 * 3500)) {
             func_8015B1D4_DB844(instance);
         }
         instance->work2 = 0;

--- a/src/level/SCIFI.c
+++ b/src/level/SCIFI.c
@@ -2,6 +2,8 @@
 
 #include "level/SCIFI.h"
 #include "types/G2String.h"
+#include "INSTANCE.h"
+#include "OBTABLE.h"
 #include "MATRIX.h"
 
 INCLUDE_ASM("asm/nonmatchings/level/SCIFI", func_80159720_DF540);
@@ -367,7 +369,13 @@ void scifi_stmvent_OnCreate(Instance* instance, GameTracker* gameTracker) {
 }
 
 typedef struct {
-    char _00[0x1C];
+    char _00[8];
+    void* next;
+    unsigned short flags;
+    short _0E;
+    void* callback;
+    void* _14;
+    int _18;
     short posX;
     short posY;
     short posZ;
@@ -389,7 +397,16 @@ typedef struct {
     unsigned short unk40;
     short _42;
     short _44;
-    char _46[0x26];
+    unsigned short _46;
+    unsigned short _48;
+    short _4A;
+    unsigned short _4C;
+    unsigned short _4E;
+    unsigned short _50;
+    unsigned short _52;
+    unsigned short _54;
+    unsigned short _56;
+    char _58[0x14];
     unsigned short frame;
 } VentSprayData;
 
@@ -441,7 +458,7 @@ void func_8015B5F0_E1410(Instance* instance) {
     SVECTOR vel;
     VentSprayData* spray;
 
-    obj = ((Object*)OBTABLE_FindObject("sprysht_"));
+    obj = OBTABLE_FindObject("sprysht_");
     if (instance->_E0[3] == 0) {
         model = obj->modelList[0];
     } else {
@@ -512,7 +529,52 @@ void scifi_stmvent_OnUpdate(Instance* instance, GameTracker* gameTracker) {
     }
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/SCIFI", func_8015B904_E1724);
+void func_8015B904_E1724(VentSprayData* p, void* callback, char* data, int arg3, unsigned short* def, char* table, int arg6, int arg7, int arg8, int arg9, unsigned short arg10) {
+    SVECTOR c;
+    short* va;
+    short* vb;
+    short* vc;
+    int* nxt;
+    unsigned short t;
+
+    va = (short*)(table + def[0] * 12);
+    vb = (short*)(table + def[1] * 12);
+    vc = (short*)(table + def[2] * 12);
+    c.x = (va[0] + vb[0] + vc[0]) / 3;
+    c.y = (va[1] + vb[1] + vc[1]) / 3;
+    c.z = (va[2] + vb[2] + vc[2]) / 3;
+    p->posX = c.x + ((int*)data)[0x20 / 4];
+    p->posY = c.y + ((int*)data)[0x24 / 4];
+    p->posZ = c.z + ((int*)data)[0x28 / 4];
+    p->unk24 = va[0] - c.x;
+    p->_26 = va[1] - c.y;
+    p->unk28 = va[2] - c.z;
+    p->unk2C = vb[0] - c.x;
+    p->_2E = vb[1] - c.y;
+    p->unk30 = vb[2] - c.z;
+    p->unk34 = vc[0] - c.x;
+    p->_36 = vc[1] - c.y;
+    p->unk38 = vc[2] - c.z;
+    if (((unsigned char*)def)[7] & 2) {
+        p->flags |= 1;
+        nxt = ((int**)def)[2];
+        p->next = nxt;
+        p->_18 = (nxt[3] & 0x3FFFFFF) | 0x24000000;
+    } else {
+        p->flags &= ~1;
+        p->_18 = (((int*)def)[2] & 0x3FFFFFF) | 0x20000000;
+    }
+    p->callback = callback;
+    p->_14 = data;
+    p->_4C = -c.x >> 1;
+    p->_4E = -c.y >> 1;
+    t = c.z;
+    p->_52 = 0;
+    p->_54 = 0;
+    p->_56 = 0;
+    p->_0E = arg10;
+    p->_50 = -((t << 16) >> 17);
+}
 
 void func_8015BB90_E19B0(short* arg0) {
     func_800162C0(arg0);
@@ -543,7 +605,19 @@ void scifi_genbrk_OnCollide(Instance* instance, GameTracker* gameTracker) {
     }
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/SCIFI", func_8015BF08_E1D28);
+Instance* func_8015BF08_E1D28(Instance* instance) {
+    Instance* ring = INSTANCE_BirthObject(instance, OBTABLE_FindObject("sring___"));
+
+    ring->flags |= 0x400;
+    ring->work0 = instance->position.z;
+    ring->position.x = instance->position.x;
+    ring->position.y = instance->position.y;
+    ring->position.z = instance->position.z;
+    ring->rotation.x = instance->rotation.x;
+    ring->rotation.y = instance->rotation.y;
+    ring->rotation.z = instance->rotation.z;
+    return ring;
+}
 
 void func_8015BFA8_E1DC8(Instance* instance) {
     instance->flags &= ~0x400;
@@ -559,7 +633,7 @@ void scifi_bldbota_OnCreate(Instance* instance, GameTracker* gameTracker) {
     } else {
         instance->flags |= 0x10080;
         instance->currentTextureAnimFrame = 0;
-        instance->work0 = func_8015BF08_E1D28(instance);
+        instance->work0 = ((int)func_8015BF08_E1D28(instance));
     }
 }
 
@@ -571,7 +645,28 @@ void scifi_bldbota_OnUpdate(Instance* instance, GameTracker* gameTracker) {
     func_8015BFD4_E1DF4(instance->work0, (short)frame);
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/SCIFI", scifi_abubble_OnCreate);
+void scifi_abubble_OnCreate(Instance* instance, GameTracker* gameTracker) {
+    short* intro = instance->introData;
+    short* data = instance->object->data;
+
+    if (intro != 0) {
+        instance->work0 = intro[0];
+        instance->work1 = intro[1];
+    } else if (data != 0) {
+        instance->work0 = data[0];
+        instance->work1 = data[1];
+    }
+    if (WORK_AS_IDX(short, instance->work0, 1) == 0) {
+        instance->work0 = 0x64;
+    }
+    if (WORK_AS_IDX(short, instance->work1, 1) == 0) {
+        instance->work1 = 0x1E;
+    }
+    INSTANCE_InsertInstanceWithFlagsSet(instance, 0x1000);
+    if (instance->parent != 0) {
+        instance->flags |= 0x100000;
+    }
+}
 
 void scifi_abubble_OnUpdate(Instance* instance, GameTracker* gameTracker) {
     SVECTOR unused;    /* dead local — reproduces the 0x20 frame */

--- a/src/level/SCIFI.c
+++ b/src/level/SCIFI.c
@@ -408,19 +408,19 @@ typedef struct {
     unsigned short _56;
     char _58[0x14];
     unsigned short frame;
-} VentSprayData;
+} ParticleData;
 
 extern void func_80016894(void*);
 INCLUDE_ASM("asm/nonmatchings/level/SCIFI", func_8015B4BC_E12DC);
 /* near-match (8 diffs: frame a1/a2, mflo v0/v1, z-check load order — scheduler difference):
 void func_8015B4BC_E12DC(void* arg0) {
-    VentSprayData* data;
+    ParticleData* data;
     Instance* player;
     int dz;
     int dx;
     int dy;
 
-    data = ((VentSprayData*)arg0);
+    data = ((ParticleData*)arg0);
     data->unk24 -= 10;
     data->unk28 += 10;
     data->frame++;
@@ -456,7 +456,7 @@ void func_8015B5F0_E1410(Instance* instance) {
     Model* model;
     SVECTOR rot;
     SVECTOR vel;
-    VentSprayData* spray;
+    ParticleData* spray;
 
     obj = OBTABLE_FindObject("sprysht_");
     if (instance->_E0[3] == 0) {
@@ -492,7 +492,7 @@ void func_8015B5F0_E1410(Instance* instance) {
     vel.x = 0;
     vel.y = 0;
     vel.z = 0;
-    spray = ((VentSprayData*)func_800170E8(model, model->_14, &instance->position, &rot, 0, D_800EB8A0, func_80017E88, func_8015B4BC_E12DC, 0x14));
+    spray = ((ParticleData*)func_800170E8(model, model->_14, &instance->position, &rot, 0, D_800EB8A0, func_80017E88, func_8015B4BC_E12DC, 0x14));
     if (*(int*)&instance->_34[2] == 0) {
         *(int*)&instance->_34[2] = func_80050508(instance, 0x112, -0x15E, 0x50, 0xBB8);
     }
@@ -529,7 +529,7 @@ void scifi_stmvent_OnUpdate(Instance* instance, GameTracker* gameTracker) {
     }
 }
 
-void func_8015B904_E1724(VentSprayData* p, void* callback, char* data, int arg3, unsigned short* def, char* table, int arg6, int arg7, int arg8, int arg9, unsigned short arg10) {
+void func_8015B904_E1724(ParticleData* p, void* callback, char* data, int arg3, unsigned short* def, char* table, int arg6, int arg7, int arg8, int arg9, unsigned short arg10) {
     SVECTOR c;
     short* va;
     short* vb;
@@ -633,7 +633,7 @@ void scifi_bldbota_OnCreate(Instance* instance, GameTracker* gameTracker) {
     } else {
         instance->flags |= 0x10080;
         instance->currentTextureAnimFrame = 0;
-        instance->work0 = ((int)func_8015BF08_E1D28(instance));
+        WORK_AS(Instance*, instance->work0) = func_8015BF08_E1D28(instance);
     }
 }
 

--- a/src/level/SPY.c
+++ b/src/level/SPY.c
@@ -136,7 +136,7 @@ void spy_launch_OnUpdate(Instance* instance, GameTracker* gameTracker) {
         int delta;
         short chunk;
 
-        speed = *(short*)&instance->_112;
+        speed = WORK_AS_IDX(short, instance->work5, 1);
         total = WORK_AS(int, instance->work4);
         step = total / speed;
         chunk = 0x20;
@@ -157,7 +157,7 @@ void spy_launch_OnUpdate(Instance* instance, GameTracker* gameTracker) {
         } else {
             WORK_AS(int, instance->work3) += delta;
             if (threshold < WORK_AS(int, instance->work3)) {
-                if (chunk < *(short*)&instance->_112) {
+                if (chunk < WORK_AS_IDX(short, instance->work5, 1)) {
                     WORK_AS(int, instance->work5) = ((WORK_AS(int, instance->work5) - chunk) << 16) >> 16;
                 }
             }


### PR DESCRIPTION
## Summary

34 more level functions decompiled to byte-identical matches (43-52 instruction tier), continuing the easiest-first sweep. Includes the 163-instruction mesh-particle init triple — three byte-identical leaf twins matched from one source. Full clean `make clean && make split && make build && make diff` passes on current master (includes #111; the two new ratan2 sites use the `(short)ratan2(...)` spelling from that cleanup).

## Functions

| Module | Functions |
|--------|-----------|
| LOONEY | `func_8015AF30_B31E0` (mesh-particle init), `looney_jimboat_OnCollide`, `looney_teeter_OnCollide`, `looney_fallobj_OnCollide`, `looney_fallobj_OnCreate`, `looney_brkblok_OnUpdate`, `looney_funguy_OnCollide` |
| FINAL | `func_80159E50_8AFF0` (mesh-particle init), `func_8015B07C_8C21C`, `func_8015F818_909B8`, `func_8015F13C_902DC`, `func_8015CD54_8DEF4`, `func_8015A4C8_8B668` |
| CIRCUIT | `circuit_explode_OnCreate`, `circuit_explode_OnUpdate`, `func_8015FC70_86E50`, `circuit_ppath_OnCreate`, `circuit_chrganm_OnUpdate` |
| SCIFI | `func_8015B904_E1724` (mesh-particle init), `func_8015BF08_E1D28`, `scifi_abubble_OnCreate` |
| RTA | `rta_zturtle_OnCollide`, `rta_zwleak_OnUpdate`, `rta_count_OnUpdate` |
| GEXZIL | `gexzil_explode_OnCreate`, `gexzil_explode_OnUpdate`, `gexzil_bldg_OnCollide` |
| MOOSHU | `func_8015B510_C3E90`, `func_8015A2E0_C2C60`, `func_8015A084_C2A04` |
| HORROR | `horror_skelh_OnCollide`, `horror_huck_OnCreate` |
| KUNGFU | `kungfu_canball_OnCreate`, `kungfu_joyride_OnCollide` |
| PREHST | `func_80163EE0_D1760` |

## Techniques worth noting

- The mesh-particle triple (`func_80159E50`/`func_8015AF30`/`func_8015B904`) reuses PREHST `func_80163C4C`'s VentSprayData conventions; LOONEY/FINAL got the struct typedef and SCIFI's opaque `char[]` head/tail was filled in with the named fields (layout unchanged).
- `func_8015A4C8`'s 16-byte copy showed that memcpy alignment comes from field types: with `int* next` / `int _58[5]` in the struct, a bare `memcpy(spray->_58, spray->next, 0x10)` emits the aligned 4+4 block move — casts at the call site produce lwl/lwr instead.
- `func_80163EE0` and several spray-family functions pass a zero-cost second argument through to `func_80016894(p, arg1)` — the a1 liveness is what pushes the struct pointer's copy into a2 (PREHST's old `(void*)` extern was relaxed to unprototyped to allow it).
- `horror_huck` decodes a `[test-load; branch; delay-slot li; fresh reload]` shape: the original reassigns the test variable with the next mask constant (`v = instance->_120; if (v) { v = ~0x400; ... }`), which both fills the delay slot and forces the pointer reload.
- `func_8015CD54`'s inner counter is `i * 8 + 0x14` — strength reduction recreates the running register, and the induction-variable init landing after the loop-invariant hoists is the tell.
- MOOSHU `func_8015A084` looked like it had a dead `player` load; it's actually a hoisted argument to `func_8004B23C(instance, player)` that only one call path consumes.

Near-miss stubs left as plain INCLUDE_ASM per policy.