### PR TITLE
Decompile 36 level functions (35-62 instruction tier)

### DIFF
--- a/src/level/CIRCUIT.c
+++ b/src/level/CIRCUIT.c
@@ -179,7 +179,20 @@ INCLUDE_ASM("asm/nonmatchings/level/CIRCUIT", circuit_charger_OnCreate);
 
 INCLUDE_ASM("asm/nonmatchings/level/CIRCUIT", circuit_charger_OnUpdate);
 
-INCLUDE_ASM("asm/nonmatchings/level/CIRCUIT", circuit_charger_OnCollide);
+extern char D_80078240;
+
+void circuit_charger_OnCollide(Instance* instance, GameTracker* gameTracker) {
+    if (instance->bspTree->instanceSpline == gameTracker->player && instance->work0 == 0 && func_80025798(PlayerInstance) == 0) {
+        instance->work0 = instance->work2;
+    }
+    if (func_80025798(PlayerInstance) == 0) {
+        INSTANCE_BirthCachedObject(instance, 0xC);
+        D_80078240 += 1;
+    }
+    func_80025764(PlayerInstance, gameTracker, WORK_AS_IDX(short, instance->work3, 1));
+    func_80050A80(0, 2);
+    instance->work7 = 1;
+}
 
 void circuit_chrganm_OnCreate(Instance* instance, GameTracker* gameTracker) {
     func_80027110(instance, 0xA, gameTracker);
@@ -769,9 +782,38 @@ int* func_8015F780_86960(int* p, int val) {
 
 INCLUDE_ASM("asm/nonmatchings/level/CIRCUIT", circuit_robo_OnCreate);
 
-INCLUDE_ASM("asm/nonmatchings/level/CIRCUIT", func_8015F930_86B10);
+short func_8015F930_86B10(Instance* instance, int* arg1, int frame) {
+    short* fc = WORK_AS_PTR(short, instance->work0);
 
-int func_8015F930_86B10(Instance* instance, int* arg1, short arg2);
+    if (arg1[1] & 8) {
+        frame = arg1[3];
+    } else {
+        if (arg1[1] & 4) {
+            if (instance->currentSubState == 2) {
+                instance->currentSubState = 3;
+            } else {
+                instance->currentSubState = 2;
+            }
+        } else if (frame == WORK_AS_IDX(short, instance->work4, 1) - 1) {
+            func_8015F708_868E8(instance);
+            return frame;
+        }
+        if (instance->currentSubState == 3) {
+            if (frame > 0) {
+                frame -= 1;
+            } else {
+                instance->currentSubState = 2;
+                frame = 1;
+            }
+        } else if (frame < fc[9] - 1) {
+            frame += 1;
+        } else {
+            instance->currentSubState = 3;
+            frame = fc[9] - 2;
+        }
+    }
+    return frame;
+}
 
 int* func_8015FA1C_86BFC(Instance* instance) {
     int* intro = (int*)instance->introData + 1;

--- a/src/level/FINAL.c
+++ b/src/level/FINAL.c
@@ -287,7 +287,32 @@ INCLUDE_ASM("asm/nonmatchings/level/FINAL", func_8015A9F0_8BB90);
 
 INCLUDE_ASM("asm/nonmatchings/level/FINAL", func_8015AC70_8BE10);
 
-INCLUDE_ASM("asm/nonmatchings/level/FINAL", func_8015ADC4_8BF64);
+void func_8015ADC4_8BF64(Instance* instance) {
+    Camera* cam;
+    unsigned short* c;
+    SVECTOR mid;
+    SVECTOR rot;
+    int px;
+    int py;
+
+    cam = gameTracker8->camera;
+    c = (unsigned short*)cam;
+    mid.x = (instance->position.x + 0x2D00) / 2;
+    mid.y = (instance->position.y + 0x267A) / 2;
+    mid.z = instance->position.z + 0x200;
+    py = instance->position.y;
+    rot.x = (py - 0x267A) << 2;
+    px = instance->position.x;
+    rot.y = (-px + 0x2D00) << 2;
+    rot.z = 0;
+    func_80005438(&cam->cameraCore._08[4], &mid, cam);
+    c[0x18] = c[0xC];
+    c[0x19] = c[0xD];
+    c[0x1A] = c[0xE];
+    c[4] = c[0xC];
+    c[5] = c[0xD];
+    c[0x17] = c[6] = c[0xE];
+}
 
 extern int D_800785C8;
 
@@ -363,7 +388,28 @@ INCLUDE_ASM("asm/nonmatchings/level/FINAL", func_8015BB78_8CD18);
 
 INCLUDE_ASM("asm/nonmatchings/level/FINAL", func_8015BD84_8CF24);
 
-INCLUDE_ASM("asm/nonmatchings/level/FINAL", func_8015BFB8_8D158);
+typedef struct {
+    char _00[0x3C];
+    SVECTOR position;  // 0x3C
+    char _42[0x12];
+    Model* model;      // 0x54
+} RezSprayerData;
+
+void func_8015BFB8_8D158(Instance* instance) {
+    RezSprayerData* d = ((RezSprayerData*)instance->work0);
+    ParticleData* spray;
+
+    if (d->model != 0) {
+        d->position.z += 10;
+        spray = ((ParticleData*)func_800170E8(d->model, d->model->_14, &d->position, 0, 0, D_800EB8A0, func_80017E88, 0, -1));
+        if (d->model->_20 != 0 && spray != 0) {
+            spray->flags |= 4;
+            memcpy(spray->_58, spray->next, 0x10);
+            spray->_58[4] = d->model->_20 + 4;
+            spray->frame = 0;
+        }
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/FINAL", func_8015C0A0_8D240);
 

--- a/src/level/GEXZIL.c
+++ b/src/level/GEXZIL.c
@@ -85,6 +85,8 @@ INCLUDE_ASM("asm/nonmatchings/level/GEXZIL", gexzil_bldg_OnCreate);
 
 INCLUDE_ASM("asm/nonmatchings/level/GEXZIL", gexzil_bldg_OnUpdate);
 
+void func_8015B144_942C4(Instance* instance, GameTracker* gameTracker);
+
 void gexzil_bldg_OnCollide(Instance* instance, GameTracker* gameTracker) {
     BSPTree* bsp = instance->bspTree;
     char* data = gameTracker->player->data;
@@ -103,7 +105,25 @@ INCLUDE_ASM("asm/nonmatchings/level/GEXZIL", func_8015AC68_93DE8);
 
 INCLUDE_ASM("asm/nonmatchings/level/GEXZIL", func_8015AE68_93FE8);
 
-INCLUDE_ASM("asm/nonmatchings/level/GEXZIL", func_8015B144_942C4);
+void func_8015B144_942C4(Instance* instance, GameTracker* gameTracker) {
+    int one = 1;
+
+    if (instance->currentSubState != one || instance->currentAnimFrame >= 0x12) {
+        if (instance->work0 < instance->work1) {
+            instance->currentAnimFrame = 0;
+            instance->flags2 &= ~0x10;
+            CAMERA_SetShake(gameTracker->camera, 0x14, 0x190);
+            instance->currentSubState = one;
+            instance->work0 += 1;
+            if (instance->work0 >= instance->work1) {
+                instance->flags |= 0x400;
+            }
+            if (instance->intro->data != 0) {
+                *(int*)instance->intro->data = instance->work0;
+            }
+        }
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/GEXZIL", func_8015B220_943A0);
 
@@ -153,7 +173,23 @@ void gexzil_mechjet_OnCollide(Instance* instance, GameTracker* gameTracker) {
 
 INCLUDE_ASM("asm/nonmatchings/level/GEXZIL", gexzil_mecha_OnCreate);
 
-INCLUDE_ASM("asm/nonmatchings/level/GEXZIL", func_8015B964_94AE4);
+void func_8015B964_94AE4(SVECTOR* from, SVECTOR* to, short* outYaw, short* outPitch) {
+    SVECTOR d;
+    int r;
+    int len;
+
+    d.x = to->x - from->x;
+    d.y = to->y - from->y;
+    d.z = to->z - from->z;
+    *outYaw = ratan2(d.y, d.x);
+    r = d.x * d.x + d.y * d.y;
+    if (0x80000 < r) {
+        len = (MATH3D_FastSqrt2(r << 4, 4) + 8) >> 4;
+    } else {
+        len = MATH3D_FastSqrt(r << 12) >> 12;
+    }
+    *outPitch = ratan2(d.z, len);
+}
 
 INCLUDE_RODATA("asm/nonmatchings/level/GEXZIL", D_80162AB8_9BC38);
 
@@ -411,7 +447,32 @@ void func_8015FF80_99100(Instance* instance, short* arg1) {
 
 INCLUDE_ASM("asm/nonmatchings/level/GEXZIL", func_8015FFDC_9915C);
 
-INCLUDE_ASM("asm/nonmatchings/level/GEXZIL", func_8016014C_992CC);
+typedef struct {
+    char _00[0x26];
+    short state;         // 0x26
+    char _28[2];
+    unsigned short _2A;
+    short _2C;
+    char _2E[0xE];
+    short _3C;
+    char _3E[0x56];
+    int _94;
+} MechaData;
+
+int func_8016014C_992CC(Instance* instance, MechaData* d) {
+    int result;
+    short state;
+    int unused[1];
+
+    result = 0;
+    if (d->_2C == -1 && d->_3C == 0) {
+        state = d->state;
+        if (state != 5 && d->_94 == 0 && (unsigned short)(state - 2) >= 2 && d->_2A - 2 >= 2U && state != 7) {
+            result = state != 0x1E;
+        }
+    }
+    return result;
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/GEXZIL", func_801601D8_99358);
 
@@ -527,7 +588,39 @@ char* func_801615A8_9A728(char* p) {
 
 INCLUDE_ASM("asm/nonmatchings/level/GEXZIL", func_80161624_9A7A4);
 
-INCLUDE_ASM("asm/nonmatchings/level/GEXZIL", func_80161938_9AAB8);
+typedef struct {
+    int minX;
+    int minY;
+    int maxX;
+    int maxY;
+} BoundsRect;
+
+BoundsRect func_80161938_9AAB8(short* box) {
+    BoundsRect r;
+    short x;
+
+    x = box[0];
+    if (box[2] < box[0]) {
+        x = box[2];
+    }
+    r.minX = x;
+    x = box[0];
+    if (box[0] < box[2]) {
+        x = box[2];
+    }
+    r.maxX = x;
+    x = box[1];
+    if (box[3] < box[1]) {
+        x = box[3];
+    }
+    r.minY = x;
+    x = box[1];
+    if (box[1] < box[3]) {
+        x = box[3];
+    }
+    r.maxY = x;
+    return r;
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/GEXZIL", func_80161A18_9AB98);
 

--- a/src/level/GEXZIL.c
+++ b/src/level/GEXZIL.c
@@ -106,14 +106,12 @@ INCLUDE_ASM("asm/nonmatchings/level/GEXZIL", func_8015AC68_93DE8);
 INCLUDE_ASM("asm/nonmatchings/level/GEXZIL", func_8015AE68_93FE8);
 
 void func_8015B144_942C4(Instance* instance, GameTracker* gameTracker) {
-    int one = 1;
-
-    if (instance->currentSubState != one || instance->currentAnimFrame >= 0x12) {
+    if (instance->currentSubState != 1 || instance->currentAnimFrame >= 0x12) {
         if (instance->work0 < instance->work1) {
             instance->currentAnimFrame = 0;
             instance->flags2 &= ~0x10;
             CAMERA_SetShake(gameTracker->camera, 0x14, 0x190);
-            instance->currentSubState = one;
+            instance->currentSubState = 1;
             instance->work0 += 1;
             if (instance->work0 >= instance->work1) {
                 instance->flags |= 0x400;
@@ -183,7 +181,7 @@ void func_8015B964_94AE4(SVECTOR* from, SVECTOR* to, short* outYaw, short* outPi
     d.z = to->z - from->z;
     *outYaw = ratan2(d.y, d.x);
     r = d.x * d.x + d.y * d.y;
-    if (0x80000 < r) {
+    if (r > 0x80000) {
         len = (MATH3D_FastSqrt2(r << 4, 4) + 8) >> 4;
     } else {
         len = MATH3D_FastSqrt(r << 12) >> 12;
@@ -231,7 +229,44 @@ void gexzil_mekblst_OnCreate(Instance* instance, GameTracker* gameTracker) {
     instance->flags |= 0x100000;
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/GEXZIL", gexzil_mekblst_OnUpdate);
+void gexzil_mekblst_OnUpdate(Instance* instance, GameTracker* gameTracker) {
+    int sx = instance->scale.x;
+    int sy = instance->scale.y;
+    int sz = instance->scale.z;
+    int done = 0;
+
+    if (sx < 0x7FFB) {
+        sx += instance->_D0[0];
+        if (sx >= 0x7FFB) {
+            done = 1;
+            sx = 0x7FFB;
+        }
+    }
+    if (sy < 0x7FFB) {
+        sy += instance->_D0[1];
+        if (sy >= 0x7FFB) {
+            done = 1;
+            sy = 0x7FFB;
+        }
+    }
+    if (instance->_D0[2] != 0) {
+        if (sz < 0x7FFB) {
+            sz += instance->_D0[2];
+            if (sz >= 0x7FFB) {
+                done = 1;
+                sz = 0x7FFB;
+            }
+        }
+        instance->_D0[2] /= 2;
+    }
+    instance->scale.x = sx;
+    instance->scale.y = sy;
+    instance->scale.z = sz;
+    if (done != 0) {
+        instance->flags = (instance->flags | 0x10) & ~0x400;
+        func_8002CD3C(gameTracker8->instanceList, instance);
+    }
+}
 
 void func_8015EAB8_97C38(Instance* instance, int* arg1);
 
@@ -462,7 +497,7 @@ typedef struct {
 int func_8016014C_992CC(Instance* instance, MechaData* d) {
     int result;
     short state;
-    int unused[1];
+    int unused[1]; /* dead local -- reproduces the 8-byte frame */
 
     result = 0;
     if (d->_2C == -1 && d->_3C == 0) {

--- a/src/level/GEXZIL.c
+++ b/src/level/GEXZIL.c
@@ -497,7 +497,6 @@ typedef struct {
 int func_8016014C_992CC(Instance* instance, MechaData* d) {
     int result;
     short state;
-    int unused[1]; /* dead local -- reproduces the 8-byte frame */
 
     result = 0;
     if (d->_2C == -1 && d->_3C == 0) {

--- a/src/level/HORROR.c
+++ b/src/level/HORROR.c
@@ -97,7 +97,32 @@ void horror_axe_OnCreate(Instance* instance, GameTracker* gameTracker) {
 
 INCLUDE_ASM("asm/nonmatchings/level/HORROR", func_80159D8C_9D5BC);
 
-INCLUDE_ASM("asm/nonmatchings/level/HORROR", func_8015A014_9D844);
+extern void func_80016894();
+
+void func_8015A014_9D844(short* p, int arg1) {
+    short t;
+
+    if (p[0x20 / 2] + p[0x50 / 2] <= p[0x44 / 2]) {
+        t = p[0x46 / 2];
+        if (t == 0) {
+            p[0x46 / 2] = t + 1;
+            p[0x48 / 2] = p[0x50 / 2] = p[0x48 / 2] - 0xF;
+        } else if (t == 1) {
+            p[0x46 / 2] = t + 1;
+            p[0x48 / 2] = p[0x50 / 2] = p[0x48 / 2] - 0xF;
+        } else if (t == 2) {
+            p[0x46 / 2] = t + 1;
+            p[0x48 / 2] = p[0x50 / 2] = p[0x48 / 2] - 0xA;
+        }
+    }
+    p[0x24 / 2] -= 1;
+    p[0x28 / 2] += 3;
+    p[0x2C / 2] -= 1;
+    p[0x30 / 2] -= 1;
+    p[0x34 / 2] += 3;
+    p[0x38 / 2] -= 1;
+    func_80016894(p, arg1);
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/HORROR", horror_axe_OnUpdate);
 
@@ -185,7 +210,20 @@ void horror_zomleg_OnCreate(Instance* instance, GameTracker* gameTracker) {
     instance->work0 = 0x3C;
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/HORROR", horror_zomleg_OnUpdate);
+void horror_zomleg_OnUpdate(Instance* instance, GameTracker* gameTracker) {
+    if (instance->currentMainState == 1) {
+        if (instance->rotation.y < 0x400) {
+            instance->rotation.y += 0x80;
+        } else {
+            instance->currentMainState = 0;
+        }
+    }
+    if (instance->work0 > 0) {
+        instance->position.x -= instance->work0 * ((short)func_8003A6AC(instance->rotation.z - 0x400)) >> 12;
+        instance->position.y -= instance->work0 * ((short)func_8003A4E0(instance->rotation.z - 0x400)) >> 12;
+        instance->work0 -= 4;
+    }
+}
 
 void horror_zomleg_OnCollide(Instance* instance, GameTracker* gameTracker) {
 }
@@ -230,7 +268,31 @@ INCLUDE_ASM("asm/nonmatchings/level/HORROR", horror_huck_OnUpdate);
 
 INCLUDE_ASM("asm/nonmatchings/level/HORROR", horror_huck_OnCollide);
 
-INCLUDE_ASM("asm/nonmatchings/level/HORROR", horror_huckhed_OnCreate);
+void horror_huckhed_OnCreate(Instance* instance, GameTracker* gameTracker) {
+    if (instance->flags & 0x20000) {
+        if (instance->parent != 0) {
+            instance->parent->work9 = 0;
+            if (instance->parent->flags2 & 4) {
+                func_8015BF7C_9F7AC(instance->parent, gameTracker);
+                instance->parent = 0;
+            } else {
+                INSTANCE_PlainDeath(instance->parent, 5, 3, 0);
+                instance->parent = 0;
+            }
+        }
+    } else {
+        instance->object->oflags |= 0x2000000;
+        WORK_AS_IDX(short, instance->work9, 1) = 0x60;
+        WORK_AS_IDX(short, instance->work9, 0) = 0x3E8;
+        instance->currentModelAnim = 1;
+        instance->_E0[1] = -0x10;
+        instance->_D0[3] = -4;
+        instance->currentMainState = 0;
+        instance->_D0[2] = 0;
+        instance->_D0[0] = 0x60;
+        instance->flags |= 0x10400;
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/HORROR", horror_huckhed_OnUpdate);
 
@@ -322,7 +384,27 @@ void horror_ledge_OnCollide(Instance* instance, GameTracker* gameTracker) {
 void horror_ldgeact_OnCreate(Instance* instance, GameTracker* gameTracker) {
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/HORROR", horror_ldgeact_OnUpdate);
+void horror_ldgeact_OnUpdate(Instance* instance, GameTracker* gameTracker) {
+    Intro* intro = instance->intro;
+    int* introData;
+    int* sig;
+
+    if (intro->_2C != 0 && *(int*)intro->_2C == 1) {
+        introData = instance->introData;
+        if (*(int*)((Intro**)intro->_04)[1]->data == 0) {
+            if (introData[0] != 0) {
+                ((Intro**)intro->_04)[1]->instance->currentMainState = 1;
+                ((Intro**)instance->intro->_04)[2]->instance->currentMainState = 1;
+                instance->currentMainState = 1;
+                sig = ((int*)introData[0]);
+                if (sig != 0) {
+                    COLLIDE_HandleSignal(gameTracker->player, sig + 1, sig[0], 0);
+                }
+                introData[0] = 0;
+            }
+        }
+    }
+}
 
 void horror_ldgeact_OnCollide(Instance* instance, GameTracker* gameTracker) {
 }
@@ -468,7 +550,6 @@ typedef struct {
     unsigned short frame;
 } SprayData;
 
-extern void func_80016894(void*);
 INCLUDE_ASM("asm/nonmatchings/level/HORROR", func_8015F620_A2E50);
 /* near-match (18 diffs: frame a1/a2, mflo v0/v1, z-check v0/v1 swap — scheduler difference):
 void func_8015F620_A2E50(void* arg0) {
@@ -664,7 +745,23 @@ void horror_evileye_OnCollide(Instance* instance, GameTracker* gameTracker) {
     }
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/HORROR", horror_splitob_OnCreate);
+void horror_splitob_OnCreate(Instance* instance, GameTracker* gameTracker) {
+    SVector a;
+    SVector b;
+    int table;
+
+    a.x = b.x = instance->position.x;
+    a.y = b.y = instance->position.y;
+    a.z = instance->position.z - 0x80;
+    b.z = instance->position.z + 0x80;
+    COLLIDE_PointAndTerrain(gameTracker8->level->segmentAddress, (SVECTOR*)&a, (SVECTOR*)&b, instance);
+    if (*(int*)&instance->_C4[0] != 0) {
+        instance->work0 = *(int*)&instance->_C4[0];
+        table = ((int*)gameTracker8->level->segmentAddress)[0x24 / 4];
+        instance->work1 = *(short*)((**(unsigned short**)&instance->_C4[0] << 4) + table + 4);
+    }
+    instance->flags |= 0x400;
+}
 
 void horror_splitob_OnUpdate(Instance* instance, GameTracker* gameTracker) {
     Instance* player;
@@ -930,7 +1027,28 @@ void horror_funplat_OnCollide(Instance* instance, GameTracker* gameTracker) {
 
 INCLUDE_ASM("asm/nonmatchings/level/HORROR", horror_door_OnCreate);
 
-INCLUDE_ASM("asm/nonmatchings/level/HORROR", func_80161F4C_A577C);
+void func_80161F4C_A577C(Instance* instance, SVECTOR offset) {
+    MATRIX m;
+    SVECTOR vec;
+    SVECTOR res;
+
+    MATH3D_SetUnityMatrix(&m);
+    if (instance->rotation.z >= -0x3FF) {
+        instance->rotation.z -= 0x20;
+        RotMatrixZ(instance->rotation.z + instance->intro->rotation.z, &m);
+        vec.y = 0x40;
+        vec.x = 0;
+        vec.z = 0;
+        res.x = (vec.x * m.m[0][0] >> 12) + (vec.y * m.m[0][1] >> 12) + (vec.z * m.m[0][2] >> 12);
+        res.y = (vec.x * m.m[1][0] >> 12) + (vec.y * m.m[1][1] >> 12) + (vec.z * m.m[1][2] >> 12);
+        res.z = (vec.x * m.m[2][0] >> 12) + (vec.y * m.m[2][1] >> 12) + (vec.z * m.m[2][2] >> 12);
+        instance->position.x = res.x + offset.x;
+        instance->position.y = res.y + offset.y;
+        instance->position.z = res.z + offset.z;
+    } else {
+        WORK_AS_IDX(char, instance->work8, 2) = 4;
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/HORROR", func_80162024_A5854);
 

--- a/src/level/HORROR.c
+++ b/src/level/HORROR.c
@@ -389,7 +389,7 @@ void horror_ldgeact_OnUpdate(Instance* instance, GameTracker* gameTracker) {
     int* introData;
     int* sig;
 
-    if (intro->_2C != 0 && *(int*)intro->_2C == 1) {
+    if (intro->_2C != 0 && *intro->_2C == 1) {
         introData = instance->introData;
         if (*(int*)((Intro**)intro->_04)[1]->data == 0) {
             if (introData[0] != 0) {
@@ -746,15 +746,15 @@ void horror_evileye_OnCollide(Instance* instance, GameTracker* gameTracker) {
 }
 
 void horror_splitob_OnCreate(Instance* instance, GameTracker* gameTracker) {
-    SVector a;
-    SVector b;
+    SVECTOR a;
+    SVECTOR b;
     int table;
 
     a.x = b.x = instance->position.x;
     a.y = b.y = instance->position.y;
     a.z = instance->position.z - 0x80;
     b.z = instance->position.z + 0x80;
-    COLLIDE_PointAndTerrain(gameTracker8->level->segmentAddress, (SVECTOR*)&a, (SVECTOR*)&b, instance);
+    COLLIDE_PointAndTerrain(gameTracker8->level->segmentAddress, &a, &b, instance);
     if (*(int*)&instance->_C4[0] != 0) {
         instance->work0 = *(int*)&instance->_C4[0];
         table = ((int*)gameTracker8->level->segmentAddress)[0x24 / 4];

--- a/src/level/KUNGFU.c
+++ b/src/level/KUNGFU.c
@@ -615,7 +615,28 @@ void kungfu_canball_OnCreate(Instance* instance, GameTracker* gameTracker) {
     }
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", kungfu_canball_OnUpdate);
+void kungfu_canball_OnUpdate(Instance* instance, GameTracker* gameTracker) {
+    MATRIX m;
+    SVECTOR out;
+    int spin;
+
+    instance->position.x += instance->_D0[0];
+    instance->position.y += instance->_D0[1];
+    instance->position.z += instance->_D0[2];
+    instance->_D0[2] += instance->_E0[1];
+    spin = WORK_AS(int, instance->work3);
+    if (spin != 0) {
+        instance->work2 += spin;
+        MATH3D_SetUnityMatrix(&m);
+        RotMatrixX(instance->work0, &m);
+        RotMatrixY(instance->work1, &m);
+        RotMatrixZ(instance->work2, &m);
+        func_800157BC(&m, &out);
+        instance->rotation.x = out.x;
+        instance->rotation.y = out.y;
+        instance->rotation.z = out.z;
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", kungfu_canball_OnCollide);
 

--- a/src/level/LOONEY.c
+++ b/src/level/LOONEY.c
@@ -2,6 +2,7 @@
 
 #include "level/LOONEY.h"
 #include "types/G2String.h"
+#include "INSTANCE.h"
 #include "OBTABLE.h"
 #include "MATRIX.h"
 
@@ -531,7 +532,16 @@ INCLUDE_ASM("asm/nonmatchings/level/LOONEY", looney_funguy_OnCreate);
 
 INCLUDE_ASM("asm/nonmatchings/level/LOONEY", func_8015BFCC_B427C);
 
-INCLUDE_ASM("asm/nonmatchings/level/LOONEY", func_8015C158_B4408);
+void func_8015C158_B4408(Instance* instance, GameTracker* gameTracker) {
+    instance->currentModelAnim = ((int*)((int*)instance->work0)[5])[instance->work2];
+    func_8002DAF8(instance, -1);
+    if (instance->currentAnimFrame == ((short*)instance->object->animList[instance->currentModelAnim])[1] - 1) {
+        instance->currentAnimFrame = 0;
+        WORK_AS(int, instance->work3) = 0;
+        instance->flags2 &= ~0x10;
+        WORK_AS(int, instance->work4) = ((int*)instance->work0)[9] + rand() % (((int*)instance->work0)[10] - ((int*)instance->work0)[9]);
+    }
+}
 
 void func_8015C230_B44E0(Instance* instance, short* arg1) {
     LVECTOR out;
@@ -807,7 +817,21 @@ void func_8015E290_B6540(Instance* instance) {
 
 INCLUDE_ASM("asm/nonmatchings/level/LOONEY", func_8015E31C_B65CC);
 
-INCLUDE_ASM("asm/nonmatchings/level/LOONEY", func_8015E4C4_B6774);
+void func_8015E4C4_B6774(Instance* instance, int arg1) {
+    int* intro;
+    Instance* spawn;
+
+    if (arg1 != 0) {
+        intro = ((int*)instance->introData);
+        spawn = INSTANCE_BirthObject(instance, ((Object*)instance->_E0[0]));
+        spawn->position.x = instance->matrix[7].l[0];
+        spawn->position.y = instance->matrix[7].l[1];
+        spawn->position.z = instance->matrix[7].l[2];
+        spawn->position.x -= -((short)func_8003A4E0(instance->rotation.z) * 0xC0) >> 12;
+        spawn->position.y -= -((short)func_8003A6AC(instance->rotation.z) * 0xC0) >> 12;
+        spawn->work0 = intro[1];
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/LOONEY", looney_hunter_OnUpdate);
 
@@ -834,7 +858,37 @@ INCLUDE_ASM("asm/nonmatchings/level/LOONEY", looney_daisy_OnCreate);
 
 INCLUDE_ASM("asm/nonmatchings/level/LOONEY", looney_daisy_OnUpdate);
 
-INCLUDE_ASM("asm/nonmatchings/level/LOONEY", func_8015FEC8_B8178);
+extern G2String D_80161E88_BA138;
+
+void func_8015FEC8_B8178(Instance* instance) {
+    int* list = instance->intro->_04;
+    Intro** p;
+    char* end;
+    Intro* e;
+    Instance* inst;
+
+    if (list != 0) {
+        p = ((Intro**)(list + 1));
+        end = (char*)list + (list[0] * 4 + 4);
+        if ((char*)p < end) {
+            do {
+                e = p[0];
+                if (e != 0) {
+                    inst = e->instance;
+                    if (inst != 0) {
+                        if (G2String_Compare_EQ(inst->object->parentName, &D_80161E88_BA138)) {
+                            if (inst->_D0[0] == 0 || (unsigned int)(inst->_D0[0] - 4) < 2) {
+                                inst->_D0[0] = 1;
+                                inst->_D0[1] = 1;
+                            }
+                        }
+                    }
+                }
+                p += 1;
+            } while ((char*)p < end);
+        }
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/LOONEY", looney_daisy_OnCollide);
 

--- a/src/level/LOONEY.c
+++ b/src/level/LOONEY.c
@@ -877,7 +877,7 @@ void func_8015FEC8_B8178(Instance* instance) {
                     inst = e->instance;
                     if (inst != 0) {
                         if (G2String_Compare_EQ(inst->object->parentName, &D_80161E88_BA138)) {
-                            if (inst->_D0[0] == 0 || (unsigned int)(inst->_D0[0] - 4) < 2) {
+                            if (inst->_D0[0] == 0 || (inst->_D0[0] - 4) < 2U) {
                                 inst->_D0[0] = 1;
                                 inst->_D0[1] = 1;
                             }

--- a/src/level/MOOSHU.c
+++ b/src/level/MOOSHU.c
@@ -35,6 +35,7 @@ void func_8015A07C_C29FC(Instance* instance, GameTracker* gameTracker) {
 void func_8015B4D4_C3E54(Instance* instance, short* arg1);
 int func_8015B510_C3E90(Instance* instance, short* arg1, int arg2, short arg3);
 void func_8015B5F0_C3F70(Instance* instance, short* arg1);
+void func_8015BB44_C44C4(Instance* instance, short* arg1);
 
 void func_8015A084_C2A04(Instance* instance, short arg1, short arg2, short* arg3) {
     Instance* player = gameTracker8->player;
@@ -262,13 +263,58 @@ INCLUDE_ASM("asm/nonmatchings/level/MOOSHU", func_8015B8B0_C4230);
 
 INCLUDE_ASM("asm/nonmatchings/level/MOOSHU", func_8015B9D0_C4350);
 
-INCLUDE_ASM("asm/nonmatchings/level/MOOSHU", func_8015BB44_C44C4);
+void func_8015BB44_C44C4(Instance* instance, short* arg1) {
+    unsigned short raw = arg1[0x14 / 2];
+    short state = raw - 1;
+
+    switch (state) {
+        case 1:
+            func_8015B614_C3F94(instance, arg1);
+            break;
+        case 0:
+            func_8015B5F0_C3F70(instance, arg1);
+            break;
+        case 6:
+            func_8015B674_C3FF4(instance, arg1);
+            break;
+        case 7:
+            func_8015B6D4_C4054(instance, arg1);
+            break;
+        case 5:
+            func_8015B4D4_C3E54(instance, arg1);
+            break;
+        case 10:
+            func_8015B734_C40B4(instance, arg1);
+            break;
+        case 8:
+            func_8015B510_C3E90(instance, arg1, 1, 0);
+            break;
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/MOOSHU", func_8015BC00_C4580);
 
 INCLUDE_ASM("asm/nonmatchings/level/MOOSHU", func_8015BDB4_C4734);
 
-INCLUDE_ASM("asm/nonmatchings/level/MOOSHU", func_8015C2E0_C4C60);
+void func_8015C2E0_C4C60(SVECTOR* arg0, short* arg1, short* arg2, int arg3) {
+    SVECTOR bounds[4];
+    SVECTOR pts[3];
+
+    pts[0] = *arg0;
+    bounds[0].x = -0xB40;
+    bounds[1].x = 0x8C0;
+    bounds[0].y = -0x280;
+    bounds[1].y = 0x280;
+    bounds[2].x = -0x1040;
+    bounds[3].x = 0xDC0;
+    bounds[2].y = -0x780;
+    bounds[3].y = 0x780;
+    func_8015BDB4_C4734(bounds, arg3);
+    pts[2].z = arg0->z + 0xB4;
+    pts[1].z = arg0->z + 0xB4;
+    func_8015BC00_C4580(arg1, &pts[1], &pts[2], 0x200);
+    func_8015BC00_C4580(arg2, &pts[2], &pts[1], 0x200);
+}
 
 void mooshu_moolevr_OnCreate(Instance* instance, GameTracker* gameTracker)
 {
@@ -325,7 +371,19 @@ void mooshu_moosprk_OnCreate(Instance* instance, GameTracker* gameTracker)
 
 INCLUDE_ASM("asm/nonmatchings/level/MOOSHU", mooshu_moosprk_OnUpdate);
 
-INCLUDE_ASM("asm/nonmatchings/level/MOOSHU", mooshu_moosprk_OnCollide);
+void mooshu_moosprk_OnCollide(Instance* instance, GameTracker* gameTracker) {
+    BSPTree* bsp = instance->bspTree;
+
+    if (bsp->_06 == 1 && bsp->instanceSpline == gameTracker->player && bsp->_0C[5] < 6) {
+        instance->work2 = 0x5A;
+        func_80022714(instance, gameTracker);
+    } else if (bsp->_06 == 2 || bsp->_06 == 5 || bsp->_06 == 3 || bsp->_06 == 1) {
+        instance->position.x += bsp->localOffset.x;
+        instance->position.y += bsp->localOffset.y;
+        instance->position.z += bsp->localOffset.z;
+        COLLIDE_UpdateAllTransforms(instance, &bsp->localOffset);
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/MOOSHU", mooshu_jacob_OnCreate);
 

--- a/src/level/PREHST.c
+++ b/src/level/PREHST.c
@@ -958,7 +958,30 @@ void prehst_boulder_OnCreate(Instance* instance, GameTracker* gameTracker) {
 
 INCLUDE_ASM("asm/nonmatchings/level/PREHST", func_8015F9A4_CD224);
 
-INCLUDE_ASM("asm/nonmatchings/level/PREHST", func_8015FC2C_CD4AC);
+void func_8015FC2C_CD4AC(short* p, int arg1) {
+    short t;
+
+    if (p[0x20 / 2] + p[0x50 / 2] <= p[0x44 / 2]) {
+        t = p[0x46 / 2];
+        if (t == 0) {
+            p[0x46 / 2] = t + 1;
+            p[0x48 / 2] = p[0x50 / 2] = p[0x48 / 2] - 0xF;
+        } else if (t == 1) {
+            p[0x46 / 2] = t + 1;
+            p[0x48 / 2] = p[0x50 / 2] = p[0x48 / 2] - 0xF;
+        } else if (t == 2) {
+            p[0x46 / 2] = t + 1;
+            p[0x48 / 2] = p[0x50 / 2] = p[0x48 / 2] - 0xA;
+        }
+    }
+    p[0x24 / 2] -= 1;
+    p[0x28 / 2] += 3;
+    p[0x2C / 2] -= 1;
+    p[0x30 / 2] -= 1;
+    p[0x34 / 2] += 3;
+    p[0x38 / 2] -= 1;
+    func_80016894(p, arg1);
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/PREHST", prehst_boulder_OnUpdate);
 
@@ -1326,7 +1349,38 @@ void func_80163EE0_D1760(short* p, int arg1) {
 
 INCLUDE_ASM("asm/nonmatchings/level/PREHST", func_80163F94_D1814);
 
-INCLUDE_ASM("asm/nonmatchings/level/PREHST", prehst_lavadrp_OnCreate);
+typedef struct {
+    short _00;
+    short _02;
+    short _04;
+    short _06;
+    short _08;
+    short _0A;
+    short _0C;
+    short _0E;
+} LavaDropData;
+
+void prehst_lavadrp_OnCreate(Instance* instance, GameTracker* gameTracker) {
+    char* data = instance->data;
+    unsigned short va;
+    unsigned short vb;
+    unsigned short vc;
+
+    instance->flags |= 0x100400;
+    func_80048DE4(instance, &instance->work4, &instance->work5, &instance->work6);
+    va = WORK_AS_IDX(unsigned short, instance->work6, 1);
+    vb = WORK_AS_IDX(unsigned short, instance->work5, 1);
+    vc = WORK_AS_IDX(unsigned short, instance->work4, 1);
+    va = (va & 0x8000) | 1;
+    vb = (vb & 0x8000) | 1;
+    vc = (vc & 0x8000) | 1;
+    WORK_AS_IDX(unsigned short, instance->work6, 1) = va;
+    WORK_AS_IDX(unsigned short, instance->work5, 1) = vb;
+    WORK_AS_IDX(unsigned short, instance->work4, 1) = vc;
+    func_80047DD4(instance, 0, 0);
+    WORK_AS_IDX(short, instance->work7, 0) = 0;
+    WORK_AS_IDX(LavaDropData, instance->work0, 0) = *(LavaDropData*)data;
+}
 
 typedef struct {
     short _00;

--- a/src/level/REZOP.c
+++ b/src/level/REZOP.c
@@ -177,7 +177,44 @@ INCLUDE_ASM("asm/nonmatchings/level/REZOP", rezop_tbplat_OnUpdate);
 void rezop_tbplat_OnCollide(Instance* instance, GameTracker* gameTracker) {
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/REZOP", rezop_rezfan_OnCreate);
+void rezop_rezfan_OnCreate(Instance* instance, GameTracker* gameTracker) {
+    short* intro = ((short*)instance->introData);
+    int f;
+
+    instance->currentMainState = 0;
+    instance->flags |= 0x100000;
+    if (intro[0] != 0) {
+        instance->currentMainState = 1;
+    } else {
+        instance->work0 = intro[1];
+    }
+    instance->work1 = 0;
+    if (intro[4] != 0) {
+        instance->work8 = intro[4];
+    } else {
+        instance->work8 = 0x118;
+    }
+    if (intro[5] != 0) {
+        instance->work9 = intro[5];
+    } else {
+        instance->work9 = -0x118;
+    }
+    f = instance->flags;
+    if (f & 0x20000) {
+        if (instance->work2 != 0) {
+            func_800331BC(instance->work2);
+            instance->work2 = 0;
+        }
+    } else {
+        instance->flags = f | 0x10000;
+        instance->work2 = 0;
+        WORK_AS(int, instance->work5) = 0;
+        WORK_AS(int, instance->work4) = 0x64;
+        WORK_AS(int, instance->work3) = (rand() & 0x3F) - 0x20;
+        WORK_AS(int, instance->work6) = 0;
+        instance->work7 = 0;
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/REZOP", rezop_rezfan_OnUpdate);
 

--- a/src/level/RTA.c
+++ b/src/level/RTA.c
@@ -2,6 +2,7 @@
 
 #include "level/RTA.h"
 #include "OBTABLE.h"
+#include "INSTANCE.h"
 #include "types/G2String.h"
 #include "types/intro/QMark.h"
 
@@ -202,7 +203,30 @@ void rta_zturtle_OnCollide(Instance* instance, GameTracker* gameTracker) {
     }
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/RTA", rta_zarchsig_OnCollide);
+extern int D_800EB8A0;
+
+void rta_zarchsig_OnCollide(Instance* instance, GameTracker* gameTracker) {
+    Instance* player;
+    Instance* collider;
+    Object* obj;
+    Instance* born;
+
+    player = gameTracker->player;
+    collider = instance->bspTree->instanceSpline;
+    if (collider == player) {
+        obj = OBTABLE_FindObject("count___");
+        born = INSTANCE_BirthObject(collider, obj);
+        born->rotation.x = 0;
+        born->rotation.y = 0;
+        born->rotation.z = 0;
+        born = INSTANCE_BirthObject(collider, obj);
+        born->rotation.x = 0;
+        born->rotation.y = 0;
+        born->rotation.z = 0x7FE;
+        func_80018B60(collider, D_800EB8A0, collider->position.x, collider->position.y, collider->position.z + 0x15E);
+        INSTANCE_PlainDeath(instance, 1, 0, 0);
+    }
+}
 
 void rta_count_OnCreate(Instance* instance, GameTracker* gameTracker) {
     instance->work0 = 0x20;
@@ -226,8 +250,6 @@ void rta_count_OnUpdate(Instance* instance, GameTracker* gameTracker) {
         instance->work0 += 0x10;
     }
 }
-
-extern int D_800EB8A0;
 
 void rta_zcargo_OnCollide(Instance* instance, GameTracker* gameTracker) {
     int* data = ((int*)instance->object->data);
@@ -304,7 +326,29 @@ void func_8015BD04_DC374(Instance* instance) {
     }
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/RTA", func_8015BD54_DC3C4);
+int func_8015BD54_DC3C4(Instance* instance) {
+    int* intro = instance->introData;
+    int done = 0;
+
+    if (instance->currentSubState == 0) {
+        done = 1;
+    } else if (WORK_AS(int, instance->work3) >= intro[2]) {
+        done = 1;
+        WORK_AS(int, instance->work3) = 0;
+    } else {
+        WORK_AS(int, instance->work3) += 1;
+        if (instance->currentMainState == intro[0]) {
+            instance->position.x += intro[3];
+            instance->position.y += intro[4];
+            instance->position.z += intro[5];
+        } else {
+            instance->position.x -= intro[3];
+            instance->position.y -= intro[4];
+            instance->position.z -= intro[5];
+        }
+    }
+    return done;
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/RTA", rta_zswitch_OnCreate);
 
@@ -312,7 +356,39 @@ INCLUDE_ASM("asm/nonmatchings/level/RTA", rta_zswitch_OnUpdate);
 
 INCLUDE_ASM("asm/nonmatchings/level/RTA", rta_zswitch_OnCollide);
 
-INCLUDE_ASM("asm/nonmatchings/level/RTA", rta_zswitchm_OnCreate);
+extern short D_8015EDFE_DF46E;
+extern short D_8015EE00_DF470;
+extern int D_8015EE04_DF474;
+extern int D_8015EE08_DF478;
+
+void rta_zswitchm_OnCreate(Instance* instance, GameTracker* gameTracker) {
+    int scale = D_8015EE08_DF478;
+    int f;
+
+    instance->position.z = D_8015EE04_DF474;
+    D_8015EDFE_DF46E = 0;
+    D_8015EE00_DF470 = 0;
+    instance->scale.x = scale;
+    instance->scale.y = scale;
+    instance->scale.z = scale;
+    if (instance->flags & 0x20000) {
+        instance->intro->flags &= ~8;
+    } else {
+        f = instance->flags | 0x10000;
+        instance->flags = f | 0x400;
+        if (instance->intro->flags & 0x1000) {
+            instance->intro->flags &= ~0x800;
+        } else {
+            instance->flags = f | 0x480;
+            instance->currentMainState = 0;
+            instance->currentSubState = 0;
+            instance->currentAnimFrame = 0;
+            memset(&instance->work0, 0, 0x28);
+            instance->work0 = func_8015C344_DC9B4(instance);
+            gameTracker->player->rotation.z = 0x800;
+        }
+    }
+}
 
 int func_8015C344_DC9B4(Instance* instance) {
     int result;
@@ -468,7 +544,23 @@ void rta_fxgen_OnCreate(Instance* instance, GameTracker* gameTracker) {
 
 INCLUDE_ASM("asm/nonmatchings/level/RTA", rta_fxgen_OnUpdate);
 
-INCLUDE_ASM("asm/nonmatchings/level/RTA", func_8015CE34_DD4A4);
+int func_8015CE34_DD4A4(Instance* instance, SVECTOR* offset, int arg2, short arg3, int arg4) {
+    SVECTOR rel;
+    SVECTOR pos;
+    int spray;
+
+    MATH3D_ApplyMatrixSV(instance->matrix, offset, &rel);
+    pos.x = instance->position.x + rel.x;
+    pos.y = instance->position.y + rel.y;
+    pos.z = instance->position.z + rel.z;
+    spray = func_800176E8(&pos, instance->work0, D_800EB8A0, arg3);
+    if (spray != 0) {
+        func_80017CD8(spray, 0, 0, arg2);
+        func_80017D28(spray, 0, 0, -3);
+        func_80017AE0(spray, arg4);
+    }
+    return spray;
+}
 
 void rta_zstmvent_OnCreate(Instance* instance, GameTracker* gameTracker) {
     int r;

--- a/src/level/RTA.c
+++ b/src/level/RTA.c
@@ -207,23 +207,23 @@ extern int D_800EB8A0;
 
 void rta_zarchsig_OnCollide(Instance* instance, GameTracker* gameTracker) {
     Instance* player;
-    Instance* collider;
+    Instance* other;
     Object* obj;
     Instance* born;
 
     player = gameTracker->player;
-    collider = instance->bspTree->instanceSpline;
-    if (collider == player) {
+    other = instance->bspTree->instanceSpline;
+    if (other == player) {
         obj = OBTABLE_FindObject("count___");
-        born = INSTANCE_BirthObject(collider, obj);
+        born = INSTANCE_BirthObject(other, obj);
         born->rotation.x = 0;
         born->rotation.y = 0;
         born->rotation.z = 0;
-        born = INSTANCE_BirthObject(collider, obj);
+        born = INSTANCE_BirthObject(other, obj);
         born->rotation.x = 0;
         born->rotation.y = 0;
         born->rotation.z = 0x7FE;
-        func_80018B60(collider, D_800EB8A0, collider->position.x, collider->position.y, collider->position.z + 0x15E);
+        func_80018B60(other, D_800EB8A0, other->position.x, other->position.y, other->position.z + 0x15E);
         INSTANCE_PlainDeath(instance, 1, 0, 0);
     }
 }
@@ -547,19 +547,19 @@ INCLUDE_ASM("asm/nonmatchings/level/RTA", rta_fxgen_OnUpdate);
 int func_8015CE34_DD4A4(Instance* instance, SVECTOR* offset, int arg2, short arg3, int arg4) {
     SVECTOR rel;
     SVECTOR pos;
-    int spray;
+    int other;
 
     MATH3D_ApplyMatrixSV(instance->matrix, offset, &rel);
     pos.x = instance->position.x + rel.x;
     pos.y = instance->position.y + rel.y;
     pos.z = instance->position.z + rel.z;
-    spray = func_800176E8(&pos, instance->work0, D_800EB8A0, arg3);
-    if (spray != 0) {
-        func_80017CD8(spray, 0, 0, arg2);
-        func_80017D28(spray, 0, 0, -3);
-        func_80017AE0(spray, arg4);
+    other = func_800176E8(&pos, instance->work0, D_800EB8A0, arg3);
+    if (other != 0) {
+        func_80017CD8(other, 0, 0, arg2);
+        func_80017D28(other, 0, 0, -3);
+        func_80017AE0(other, arg4);
     }
-    return spray;
+    return other;
 }
 
 void rta_zstmvent_OnCreate(Instance* instance, GameTracker* gameTracker) {

--- a/src/level/SCIFI.c
+++ b/src/level/SCIFI.c
@@ -1,6 +1,7 @@
 #include "common.h"
 
 #include "level/SCIFI.h"
+#include <compiler/gcc/string.h>
 #include "types/G2String.h"
 #include "INSTANCE.h"
 #include "OBTABLE.h"
@@ -46,7 +47,36 @@ void func_80159A84_DF8A4(Instance* arg0) {
 
 INCLUDE_ASM("asm/nonmatchings/level/SCIFI", func_80159B10_DF930);
 
-INCLUDE_ASM("asm/nonmatchings/level/SCIFI", func_80159D54_DFB74);
+typedef struct {
+    char _00[4];
+    short pitch;          // 0x4
+    unsigned char delay;  // 0x6
+    unsigned char spread; // 0x7
+} AmbientSoundRec;
+
+typedef struct {
+    AmbientSoundRec recs[3]; // 0x00
+    short index;             // 0x18
+    char _1A[6];
+    short timer;             // 0x20
+} AmbientSoundData;
+
+void func_80159D54_DFB74(AmbientSoundData* d) {
+    AmbientSoundRec* r;
+
+    if (d->index < 3) {
+        if (d->timer == 0) {
+            r = &d->recs[d->index];
+            d->timer = r->delay;
+            if (r->spread != 0) {
+                d->timer += r->spread - rand() % (r->spread * 2);
+            }
+            func_800509E0(0xF7, 0x32, 0x40, r->pitch);
+        } else {
+            d->timer -= 1;
+        }
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/SCIFI", func_80159E3C_DFC5C);
 
@@ -119,7 +149,26 @@ void scifi_crawler_OnCollide(Instance* instance, GameTracker* gameTracker) {
     }
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/SCIFI", scifi_rocket_OnCreate);
+void scifi_rocket_OnCreate(Instance* instance, GameTracker* gameTracker) {
+    int flags = instance->flags;
+
+    if (flags & 0x20000) {
+        if (instance->work1 != 0) {
+            instance->work1 = 0;
+            gameTracker->player->work0 &= ~0x10000000;
+            gameTracker->player->work0 |= 0x100;
+            gameTracker->player->flags &= ~0x100;
+        }
+        if (WORK_AS(int, instance->work5) != 0) {
+            func_800331BC(WORK_AS(int, instance->work5));
+        }
+    } else {
+        instance->flags = flags | 0x10000;
+        WORK_AS_IDX(short, instance->work0, 0) = 0;
+        WORK_AS(int, instance->work5) = 0;
+        instance->flags &= ~0x2000000;
+    }
+}
 
 void func_8015A36C_E018C(Instance* instance, void* unused, SVECTOR* out, SVECTOR* in) {
     MATRIX mat;
@@ -624,7 +673,15 @@ void func_8015BFA8_E1DC8(Instance* instance) {
     func_8002E350(instance);
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/SCIFI", func_8015BFD4_E1DF4);
+void func_8015BFD4_E1DF4(Instance* instance, int arg1) {
+    short* data = instance->data;
+    int total;
+    int rem;
+
+    total = data[0] * data[1] / 2;
+    rem = (arg1 + data[5] + data[4] * data[1] / 2) % total;
+    instance->position.z = data[3] + instance->work0 + rem * (data[2] + data[2]) / data[1];
+}
 
 void scifi_bldbota_OnCreate(Instance* instance, GameTracker* gameTracker) {
     if (instance->flags & 0x20000) {
@@ -642,7 +699,7 @@ void scifi_bldbota_OnUpdate(Instance* instance, GameTracker* gameTracker) {
 
     frame = instance->currentTextureAnimFrame;
     instance->currentTextureAnimFrame = frame + 1;
-    func_8015BFD4_E1DF4(instance->work0, (short)frame);
+    func_8015BFD4_E1DF4((Instance*)instance->work0, (short)frame);
 }
 
 void scifi_abubble_OnCreate(Instance* instance, GameTracker* gameTracker) {
@@ -715,7 +772,26 @@ void scifi_acrate_OnCreate(Instance* instance, GameTracker* gameTracker) {
 void scifi_acrate_OnUpdate(Instance* instance, GameTracker* gameTracker) {
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/SCIFI", scifi_acrate_OnCollide);
+extern char D_80164E60_EAC80[];
+extern char D_80164E6C_EAC8C[];
+
+void scifi_acrate_OnCollide(Instance* instance, GameTracker* gameTracker) {
+    BSPTree* bsp = instance->bspTree;
+    short* fc = WORK_AS_PTR(short, instance->work0);
+    Instance* crate;
+
+    if ((bsp->_06 == 1 && ((unsigned char*)bsp->_0C)[5] >= 8)
+        || (bsp->instanceSpline != 0 && strcmp(bsp->instanceSpline->object->name, D_80164E60_EAC80) == 0)) {
+        crate = INSTANCE_BirthObject(instance, OBTABLE_FindObject(D_80164E6C_EAC8C));
+        if (crate != 0) {
+            crate->intro = 0;
+            crate->work0 = fc[0];
+            crate->work1 = fc[1];
+            crate->flags |= 8;
+        }
+        INSTANCE_PlainDeath(instance, 5, -1, 0);
+    }
+}
 
 void scifi_xa_OnCreate(Instance* instance, GameTracker* gameTracker)
 {
@@ -736,9 +812,54 @@ void scifi_xa_OnUpdate(Instance* instance, GameTracker* gameTracker) {
     }
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/SCIFI", scifi_apod_OnCreate);
+void scifi_apod_OnCreate(Instance* instance, GameTracker* gameTracker) {
+    short* data = ((short*)instance->object->data);
 
-INCLUDE_ASM("asm/nonmatchings/level/SCIFI", func_8015C5CC_E23EC);
+    instance->flags |= 0x10000;
+    if (instance->flags & 0x20000) {
+        if (instance->work9 != 0) {
+            ((int*)gameTracker)[0x4C08 / 4] &= ~4;
+        }
+        if (WORK_AS(int, instance->work3) != 0) {
+            func_800331BC(WORK_AS(int, instance->work3));
+        }
+    } else {
+        instance->work9 = 0;
+        WORK_AS(int, instance->work4) = (rand() & 0x7F) - 0x40;
+        WORK_AS(int, instance->work3) = 0;
+        instance->initialPos = instance->position;
+        instance->currentMainState = 1;
+        func_8004A7B8(instance, 0, 0);
+        instance->work0 = data[0];
+        instance->work1 = 0;
+        instance->work2 = 0;
+        instance->flags2 |= 8;
+    }
+}
+
+void func_8015C5CC_E23EC(int arg0, Instance* instance, int arg2, ...) {
+    int frame;
+    int model;
+    short idx;
+    int div;
+
+    if (instance->work2 == 1) {
+        idx = 2;
+        div = 0x28;
+    } else {
+        idx = 1;
+        div = 0x14;
+    }
+    frame = instance->currentTextureAnimFrame;
+    model = instance->currentModel;
+    instance->currentModel = idx;
+    instance->flags |= 0x80;
+    instance->currentTextureAnimFrame = frame % div;
+    func_8003D698(instance, arg0, 0);
+    instance->currentModel = model;
+    instance->currentTextureAnimFrame = frame;
+    instance->flags &= ~0x80;
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/SCIFI", scifi_apod_OnUpdate);
 
@@ -1217,9 +1338,63 @@ INCLUDE_ASM("asm/nonmatchings/level/SCIFI", scifi_rt_OnCreate);
 
 INCLUDE_ASM("asm/nonmatchings/level/SCIFI", func_80161C3C_E7A5C);
 
-INCLUDE_ASM("asm/nonmatchings/level/SCIFI", func_80161D18_E7B38);
+void func_80161D18_E7B38(Instance* instance) {
+    Object* obj = instance->object;
+    char* fc = WORK_AS_PTR(char, instance->work0);
+    int colors[2];
+    char* base;
+    char* end;
+    char* face;
+    Model* model;
 
-INCLUDE_ASM("asm/nonmatchings/level/SCIFI", func_80161DF4_E7C14);
+    colors[0] = 0x300000FF;
+    colors[1] = 0x30000000;
+    if (obj != 0) {
+        model = obj->modelList[0];
+        base = ((char*)model->_14);
+        end = base + model->_10 * 12;
+        if (base < end) {
+            face = base + 8;
+            end += 8;
+            do {
+                if (!(face[-1] & 2)) {
+                    *(int*)face = colors[(char)(fc[8] % 2)];
+                }
+                face += 12;
+            } while (face < end);
+        }
+        fc[8] += 1;
+    }
+}
+
+void func_80161DF4_E7C14(int arg0, Instance* instance) {
+    Object* obj = instance->object;
+    char* fc = WORK_AS_PTR(char, instance->work0);
+    int colors[2];
+    char* base;
+    char* end;
+    char* face;
+    Model* model;
+
+    colors[0] = 0x300000FF;
+    colors[1] = 0x30000000;
+    if (obj != 0) {
+        model = obj->modelList[0];
+        base = ((char*)model->_14);
+        end = base + model->_10 * 12;
+        if (base < end) {
+            face = base + 8;
+            end += 8;
+            do {
+                if (!(face[-1] & 2)) {
+                    *(int*)face = colors[(char)(fc[8] % 2)];
+                }
+                face += 12;
+            } while (face < end);
+        }
+        fc[8] = fc[8] == 0;
+    }
+}
 
 /* write 0x30000000 into every unprotected 12-byte segment entry of the
    first model (meaning of the value unknown) */

--- a/src/level/SCIFI.c
+++ b/src/level/SCIFI.c
@@ -150,9 +150,7 @@ void scifi_crawler_OnCollide(Instance* instance, GameTracker* gameTracker) {
 }
 
 void scifi_rocket_OnCreate(Instance* instance, GameTracker* gameTracker) {
-    int flags = instance->flags;
-
-    if (flags & 0x20000) {
+    if (instance->flags & 0x20000) {
         if (instance->work1 != 0) {
             instance->work1 = 0;
             gameTracker->player->work0 &= ~0x10000000;
@@ -163,7 +161,7 @@ void scifi_rocket_OnCreate(Instance* instance, GameTracker* gameTracker) {
             func_800331BC(WORK_AS(int, instance->work5));
         }
     } else {
-        instance->flags = flags | 0x10000;
+        instance->flags |= 0x10000;
         WORK_AS_IDX(short, instance->work0, 0) = 0;
         WORK_AS(int, instance->work5) = 0;
         instance->flags &= ~0x2000000;
@@ -699,7 +697,7 @@ void scifi_bldbota_OnUpdate(Instance* instance, GameTracker* gameTracker) {
 
     frame = instance->currentTextureAnimFrame;
     instance->currentTextureAnimFrame = frame + 1;
-    func_8015BFD4_E1DF4((Instance*)instance->work0, (short)frame);
+    func_8015BFD4_E1DF4(WORK_AS(Instance*, instance->work0), (short)frame);
 }
 
 void scifi_abubble_OnCreate(Instance* instance, GameTracker* gameTracker) {
@@ -778,16 +776,16 @@ extern char D_80164E6C_EAC8C[];
 void scifi_acrate_OnCollide(Instance* instance, GameTracker* gameTracker) {
     BSPTree* bsp = instance->bspTree;
     short* fc = WORK_AS_PTR(short, instance->work0);
-    Instance* crate;
+    Instance* other;
 
     if ((bsp->_06 == 1 && ((unsigned char*)bsp->_0C)[5] >= 8)
         || (bsp->instanceSpline != 0 && strcmp(bsp->instanceSpline->object->name, D_80164E60_EAC80) == 0)) {
-        crate = INSTANCE_BirthObject(instance, OBTABLE_FindObject(D_80164E6C_EAC8C));
-        if (crate != 0) {
-            crate->intro = 0;
-            crate->work0 = fc[0];
-            crate->work1 = fc[1];
-            crate->flags |= 8;
+        other = INSTANCE_BirthObject(instance, OBTABLE_FindObject(D_80164E6C_EAC8C));
+        if (other != 0) {
+            other->intro = 0;
+            other->work0 = fc[0];
+            other->work1 = fc[1];
+            other->flags |= 8;
         }
         INSTANCE_PlainDeath(instance, 5, -1, 0);
     }
@@ -818,7 +816,7 @@ void scifi_apod_OnCreate(Instance* instance, GameTracker* gameTracker) {
     instance->flags |= 0x10000;
     if (instance->flags & 0x20000) {
         if (instance->work9 != 0) {
-            ((int*)gameTracker)[0x4C08 / 4] &= ~4;
+            gameTracker->gameFlags &= ~4;
         }
         if (WORK_AS(int, instance->work3) != 0) {
             func_800331BC(WORK_AS(int, instance->work3));


### PR DESCRIPTION
## Summary

36 more level functions decompiled to byte-matching C, continuing the easiest-first sweep upward through the 35-62 instruction tier. Written against the post-#113 field names/`WORK_AS` conventions throughout. Full clean `make clean && make split && make build && make diff` matches the ROM.

## Functions

| Level | Functions |
|-------|-----------|
| CIRCUIT | circuit_charger_OnCollide, func_8015F930_86B10 |
| FINAL | func_8015ADC4_8BF64, func_8015BFB8_8D158 |
| GEXZIL | func_8015B144_942C4, func_8015B964_94AE4, func_8016014C_992CC, func_80161938_9AAB8 |
| HORROR | func_8015A014_9D844, func_80161F4C_A577C, horror_huckhed_OnCreate, horror_ldgeact_OnUpdate, horror_splitob_OnCreate, horror_zomleg_OnUpdate |
| KUNGFU | kungfu_canball_OnUpdate |
| LOONEY | func_8015C158_B4408, func_8015E4C4_B6774, func_8015FEC8_B8178 |
| MOOSHU | func_8015BB44_C44C4, func_8015C2E0_C4C60, mooshu_moosprk_OnCollide |
| PREHST | func_8015FC2C_CD4AC, prehst_lavadrp_OnCreate |
| REZOP | rezop_rezfan_OnCreate |
| RTA | func_8015BD54_DC3C4, func_8015CE34_DD4A4, rta_zarchsig_OnCollide, rta_zswitchm_OnCreate |
| SCIFI | func_80159D54_DFB74, func_8015BFD4_E1DF4, func_8015C5CC_E23EC, func_80161D18_E7B38, func_80161DF4_E7C14, scifi_acrate_OnCollide, scifi_apod_OnCreate, scifi_rocket_OnCreate |

## Techniques of note

- **func_80161938_9AAB8 (GEXZIL)**: struct returned by value (hidden a0 pointer) holding four min/max selects funnelled through one rotating short temp.
- **func_8015F930_86B10 (CIRCUIT)**: `short` return type with `int` frame parameter — the single sll/sra pair sits at the shared return exit; a short parameter instead narrows `frame = arg1[3]` to a halfword load.
- **func_8015BB44_C44C4 (MOOSHU)**: 11-entry jump-table dispatcher; `unsigned short raw` + `short state = raw - 1` reproduces the lhu/addiu/sll/sra/sltiu header, case blocks laid out in source order.
- **func_80161F4C_A577C / func_8015A014_9D844 + twin**: by-value SVECTOR parameter read from the caller's home slots; the natural 9-term matrix row expressions auto-fold to the target's mixed sra/srl shifts.
- **rta_zswitchm_OnCreate**: big-constant flag ORs split through a shared variable (`f = flags | 0x10000` reused for `f | 0x400` and `f | 0x480`).
- **rezop_rezfan_OnCreate**: select-with-default written as both-arms-store if/else so cross-jump merges the stores and the branch delay slot stays empty.
- **scifi_acrate_OnCollide**: last-two-statement swap emits the target's store order and keeps the flags load below the intro store.
- Twins ported across levels: HORROR func_8015A014_9D844 = PREHST func_8015FC2C_CD4AC (spray tick), SCIFI func_80161D18/DF4 face color-cycler pair.