### PR TITLE
Decompile 17 level functions (twin-cluster batch incl. 219-insn eel pair)

### DIFF
--- a/src/level/CIRCUIT.c
+++ b/src/level/CIRCUIT.c
@@ -751,7 +751,50 @@ void circuit_qmark_OnCollide(Instance* instance, GameTracker* gameTracker) {
 
 INCLUDE_ASM("asm/nonmatchings/level/CIRCUIT", func_8015EC00_85DE0);
 
-INCLUDE_ASM("asm/nonmatchings/level/CIRCUIT", circuit_reza_OnCreate);
+extern char D_80163604_8A7E4[];
+
+void circuit_reza_OnCreate(Instance* instance, GameTracker* gameTracker) {
+    unsigned char* fc = WORK_AS_PTR(unsigned char, instance->work0);
+    short* intro = ((short*)instance->introData);
+
+    instance->flags |= 0x100000;
+    if (strcmp(gameTracker->level->levelType, D_80163604_8A7E4) == 0) {
+        instance->currentModelAnim = 0;
+        instance->currentAnimFrame = 0;
+        WORK_AS(int, instance->work3) = 0;
+        instance->flags &= ~0x100000;
+        instance->flags2 &= ~0x10;
+        WORK_AS_IDX(char, instance->work7, 0) = SCRIPT_CountFramesInSpline(instance);
+    } else {
+        if (intro == 0) {
+            WORK_AS_IDX(char, instance->work7, 1) = 0;
+            WORK_AS(int, instance->work6) = 0x80;
+        } else {
+            if (intro[1] == 0) {
+                intro[1] = 0x80;
+            }
+            if (intro[0] == 2) {
+                WORK_AS_IDX(char, instance->work7, 1) = 0;
+            }
+            if (instance->intro->multiSpline != 0) {
+                WORK_AS_IDX(char, instance->work7, 2) = 0;
+                WORK_AS_IDX(char, instance->work7, 0) = SCRIPT_CountFramesInSpline(instance);
+                WORK_AS_IDX(char, instance->work7, 3) |= 1;
+                WORK_AS_IDX(char, instance->work7, 1) = ((unsigned char*)intro)[1] & 0xFB;
+            } else {
+                WORK_AS_IDX(char, instance->work7, 1) = 0;
+                WORK_AS_IDX(char, instance->work7, 3) |= 8;
+            }
+            *(int*)(fc + 0x18) = intro[1];
+        }
+        if (fc[0x1D] == 1) {
+            func_8004A7B8(instance, 3, 0);
+        } else {
+            fc[0x1F] |= 2;
+            func_8004A7B8(instance, 0, 0);
+        }
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/CIRCUIT", circuit_reza_OnUpdate);
 

--- a/src/level/CIRCUIT.c
+++ b/src/level/CIRCUIT.c
@@ -175,7 +175,35 @@ void circuit_crawler_OnCollide(Instance* instance, GameTracker* gameTracker) {
     }
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/CIRCUIT", circuit_charger_OnCreate);
+void circuit_charger_OnCreate(Instance* instance, GameTracker* gameTracker) {
+    short* intro = ((short*)instance->introData);
+    short* data = ((short*)instance->object->data);
+
+    if (instance->flags & 0x20000) {
+        if (WORK_AS(int, instance->work4) != 0) {
+            func_800331BC(WORK_AS(int, instance->work4));
+            WORK_AS(int, instance->work4) = 0;
+        }
+    } else {
+        WORK_AS(int, instance->work4) = 0;
+        WORK_AS(int, instance->work5) = 0x4D;
+        WORK_AS(int, instance->work6) = (rand() & 0x1F) - 0x10;
+        instance->work7 = 0;
+        instance->work8 = 1;
+    }
+    instance->work1 = 2;
+    instance->work2 = 0x14;
+    WORK_AS(int, instance->work3) = 0x12C;
+    instance->work0 = 0;
+    instance->flags |= 0x10000;
+    if (intro != 0) {
+        WORK_AS(int, instance->work3) = intro[1];
+    } else if (data != 0) {
+        instance->work1 = data[0];
+        instance->work2 = data[1];
+        WORK_AS(int, instance->work3) = data[3];
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/CIRCUIT", circuit_charger_OnUpdate);
 

--- a/src/level/CIRCUIT.c
+++ b/src/level/CIRCUIT.c
@@ -232,7 +232,35 @@ void func_8015B548_82728(Instance* instance) {
 
 INCLUDE_ASM("asm/nonmatchings/level/CIRCUIT", func_8015B570_82750);
 
-INCLUDE_ASM("asm/nonmatchings/level/CIRCUIT", circuit_ebridge_OnCreate);
+void func_8015B780_82960(Instance* instance, GameTracker* gameTracker);
+
+void circuit_ebridge_OnCreate(Instance* instance, GameTracker* gameTracker) {
+    int* intro = ((int*)instance->introData);
+    int* data = ((int*)instance->object->data);
+
+    if (instance->flags & 0x20000) {
+        func_8015B780_82960(instance, gameTracker);
+    } else {
+        instance->flags |= 0x10000;
+        instance->work1 = 0x1FF;
+        instance->work6 = 0;
+        instance->work0 = 0x201;
+        func_8015B548_82728(instance);
+        instance->initialPos.x = instance->position.x;
+        instance->initialPos.y = instance->position.y;
+        instance->initialPos.z = instance->position.z;
+        INSTANCE_InsertInstanceWithFlagsSet(instance, 0x1000);
+        instance->currentMainState = 0;
+        instance->work3 = 0x12C;
+        instance->flags |= 0x800;
+        if (intro != 0) {
+            instance->work3 = intro[0];
+        } else if (data != 0) {
+            instance->work3 = data[0];
+        }
+        instance->flags2 |= 8;
+    }
+}
 
 void func_8015B780_82960(Instance* instance, GameTracker* gameTracker) {
     Camera* camera;

--- a/src/level/HORROR.c
+++ b/src/level/HORROR.c
@@ -1183,7 +1183,50 @@ void horror_qmark_OnCollide(Instance* instance, GameTracker* gameTracker) {
 
 INCLUDE_ASM("asm/nonmatchings/level/HORROR", func_80163B88_A73B8);
 
-INCLUDE_ASM("asm/nonmatchings/level/HORROR", horror_reza_OnCreate);
+extern char D_80164CCC_A84FC[];
+
+void horror_reza_OnCreate(Instance* instance, GameTracker* gameTracker) {
+    unsigned char* fc = WORK_AS_PTR(unsigned char, instance->work0);
+    short* intro = ((short*)instance->introData);
+
+    instance->flags |= 0x100000;
+    if (strcmp(gameTracker->level->levelType, D_80164CCC_A84FC) == 0) {
+        instance->currentModelAnim = 0;
+        instance->currentAnimFrame = 0;
+        WORK_AS(int, instance->work3) = 0;
+        instance->flags &= ~0x100000;
+        instance->flags2 &= ~0x10;
+        WORK_AS_IDX(char, instance->work7, 0) = SCRIPT_CountFramesInSpline(instance);
+    } else {
+        if (intro == 0) {
+            WORK_AS_IDX(char, instance->work7, 1) = 0;
+            WORK_AS(int, instance->work6) = 0x80;
+        } else {
+            if (intro[1] == 0) {
+                intro[1] = 0x80;
+            }
+            if (intro[0] == 2) {
+                WORK_AS_IDX(char, instance->work7, 1) = 0;
+            }
+            if (instance->intro->multiSpline != 0) {
+                WORK_AS_IDX(char, instance->work7, 2) = 0;
+                WORK_AS_IDX(char, instance->work7, 0) = SCRIPT_CountFramesInSpline(instance);
+                WORK_AS_IDX(char, instance->work7, 3) |= 1;
+                WORK_AS_IDX(char, instance->work7, 1) = ((unsigned char*)intro)[1] & 0xFB;
+            } else {
+                WORK_AS_IDX(char, instance->work7, 1) = 0;
+                WORK_AS_IDX(char, instance->work7, 3) |= 8;
+            }
+            *(int*)(fc + 0x18) = intro[1];
+        }
+        if (fc[0x1D] == 1) {
+            func_8004A7B8(instance, 3, 0);
+        } else {
+            fc[0x1F] |= 2;
+            func_8004A7B8(instance, 0, 0);
+        }
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/HORROR", horror_reza_OnUpdate);
 

--- a/src/level/KUNGFU.c
+++ b/src/level/KUNGFU.c
@@ -1019,17 +1019,46 @@ extern int D_80078244;
 extern int D_800EB8A0;
 extern void func_801616D4_B08F4();
 
-void func_801619A4_B0BC4(Instance* instance, int arg1, int arg2) {
+void func_801619A4_B0BC4(Instance* instance, GameTracker* gameTracker, short* pos) {
     Model* model;
 
     if (instance->work0 != 0) {
         model = ((Object*)instance->work0)->modelList[0];
         D_80078244 = (rand() & 3) + 2;
-        func_800170E8(model, model->_14 + 0xC, arg2, 0, 0, D_800EB8A0, func_801616D4_B08F4, func_80161944_B0B64, 0x28);
+        func_800170E8(model, model->_14 + 0xC, pos, 0, 0, D_800EB8A0, func_801616D4_B08F4, func_80161944_B0B64, 0x28);
     }
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", kungfu_leafgen_OnUpdate);
+void kungfu_leafgen_OnUpdate(Instance* instance, GameTracker* gameTracker) {
+    short* fc = WORK_AS_PTR(short, instance->work0);
+    int i;
+
+    if (instance->object->animList != 0) {
+        func_8002DAF8(instance, -1);
+    }
+    if (WORK_AS(int, instance->work5) != 0) {
+        if (WORK_AS(int, instance->work6) == 0) {
+            for (i = 0; i < 5; i++) {
+                func_801619A4_B0BC4(instance, gameTracker, fc + 2);
+            }
+            if (!func_80033220(0xD3)) {
+                func_80050508(instance, 0xD3, 0, 0x64, 0xBB8);
+            }
+        } else if (WORK_AS(int, instance->work3) != instance->work1 || WORK_AS_IDX(short, instance->work4, 0) != WORK_AS_IDX(short, instance->work2, 0)) {
+            instance->work7 -= 1;
+            if (instance->work7 < 0) {
+                func_801619A4_B0BC4(instance, gameTracker, WORK_AS_PTR(short, instance->work1));
+                instance->work7 = (rand() & 0xF) + 1;
+                if (!func_80033220(0xD3)) {
+                    func_80050508(instance, 0xD3, 0, 0x64, 0xBB8);
+                }
+            }
+        }
+    }
+    *(SVector*)&fc[6] = *(SVector*)&fc[2];
+    *(int*)&fc[12] = *(int*)&fc[10];
+    *(int*)&fc[10] = 0;
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", kungfu_leafgen_OnCollide);
 

--- a/src/level/KUNGFU.c
+++ b/src/level/KUNGFU.c
@@ -4,6 +4,7 @@
 #include "types/intro/BTimer.h"
 #include "types/G2String.h"
 #include "SPLINE.h"
+#include "SCRIPT.h"
 #include "OBTABLE.h"
 
 
@@ -929,7 +930,29 @@ void kungfu_oneway_OnCollide(Instance* instance, GameTracker* gameTracker) {
     func_80022D54(instance, gameTracker);
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", func_80160D4C_AFF6C);
+void func_80160D4C_AFF6C(Instance* instance) {
+    SVECTOR euler;
+    int isParent;
+    int isClass;
+    MultiSpline* multi;
+    SVECTOR* pt;
+
+    multi = SCRIPT_GetMultiSpline(instance, &isParent, &isClass);
+    if (multi->rotational != 0) {
+        G2Quat_ToEuler((short*)SplineGetLastRot(multi->rotational, SCRIPT_GetRotSplineDef(instance, multi, isParent, isClass)), (short*)&euler);
+        instance->rotation.x = euler.x;
+        instance->rotation.y = euler.y;
+        instance->rotation.z = euler.z;
+    }
+    if (multi->positional != 0) {
+        pt = SplineGetLastPoint(multi->positional, SCRIPT_GetPosSplineDef(instance, multi, isParent, isClass));
+        if (pt != 0) {
+            instance->position.x = pt->x;
+            instance->position.y = pt->y;
+            instance->position.z = pt->z;
+        }
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", func_80160E4C_B006C);
 

--- a/src/level/LOONEY.c
+++ b/src/level/LOONEY.c
@@ -513,17 +513,46 @@ extern int D_80078244;
 extern int D_800EB8A0;
 extern void func_8015B934_B3BE4();
 
-void func_8015BC04_B3EB4(Instance* instance, int arg1, int arg2) {
+void func_8015BC04_B3EB4(Instance* instance, GameTracker* gameTracker, short* pos) {
     Model* model;
 
     if (instance->work0 != 0) {
         model = ((Object*)instance->work0)->modelList[0];
         D_80078244 = (rand() & 3) + 2;
-        func_800170E8(model, model->_14 + 0xC, arg2, 0, 0, D_800EB8A0, func_8015B934_B3BE4, func_8015BBA4_B3E54, 0x28);
+        func_800170E8(model, model->_14 + 0xC, pos, 0, 0, D_800EB8A0, func_8015B934_B3BE4, func_8015BBA4_B3E54, 0x28);
     }
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/LOONEY", looney_leafgen_OnUpdate);
+void looney_leafgen_OnUpdate(Instance* instance, GameTracker* gameTracker) {
+    short* fc = WORK_AS_PTR(short, instance->work0);
+    int i;
+
+    if (instance->object->animList != 0) {
+        func_8002DAF8(instance, -1);
+    }
+    if (WORK_AS(int, instance->work5) != 0) {
+        if (WORK_AS(int, instance->work6) == 0) {
+            for (i = 0; i < 5; i++) {
+                func_8015BC04_B3EB4(instance, gameTracker, fc + 2);
+            }
+            if (!func_80033220(0xD3)) {
+                func_80050508(instance, 0xD3, 0, 0x64, 0xBB8);
+            }
+        } else if (WORK_AS(int, instance->work3) != instance->work1 || WORK_AS_IDX(short, instance->work4, 0) != WORK_AS_IDX(short, instance->work2, 0)) {
+            instance->work7 -= 1;
+            if (instance->work7 < 0) {
+                func_8015BC04_B3EB4(instance, gameTracker, WORK_AS_PTR(short, instance->work1));
+                instance->work7 = (rand() & 0xF) + 1;
+                if (!func_80033220(0xD3)) {
+                    func_80050508(instance, 0xD3, 0, 0x64, 0xBB8);
+                }
+            }
+        }
+    }
+    *(SVector*)&fc[6] = *(SVector*)&fc[2];
+    *(int*)&fc[12] = *(int*)&fc[10];
+    *(int*)&fc[10] = 0;
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/LOONEY", looney_leafgen_OnCollide);
 
@@ -906,7 +935,19 @@ void looney_grrfish_OnCreate(Instance* instance, GameTracker* gameTracker) {
 
 INCLUDE_ASM("asm/nonmatchings/level/LOONEY", func_80160164_B8414);
 
-INCLUDE_ASM("asm/nonmatchings/level/LOONEY", func_80160318_B85C8);
+extern int D_80161D9C_BA04C;
+
+void func_80160318_B85C8(SVECTOR* pos, int count) {
+    SVector randVec;
+    int i;
+
+    for (i = 0; i < count; i++) {
+        randVec.x = rand() % 30 - 15;
+        randVec.y = rand() % 30 - 15;
+        randVec.z = rand() % 10 + 25;
+        func_80019828(pos, &randVec, &D_80161D9C_BA04C, pos->z);
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/LOONEY", looney_grrfish_OnUpdate);
 

--- a/src/level/MOOSHU.c
+++ b/src/level/MOOSHU.c
@@ -414,19 +414,42 @@ INCLUDE_ASM("asm/nonmatchings/level/MOOSHU", mooshu_jacob_OnCreate);
 
 INCLUDE_ASM("asm/nonmatchings/level/MOOSHU", mooshu_jacob_OnUpdate);
 
-INCLUDE_ASM("asm/nonmatchings/level/MOOSHU", func_8015D084_C5A04);
+typedef struct {
+    int _00;
+    int count;              // 0x4
+    unsigned char** faces;  // 0x8
+} MooLevrGroup;
+
+void func_8015D084_C5A04(Instance* instance, GameTracker* gameTracker) {
+    MooLevrGroup group;
+    short i = 0;
+    short* fc = WORK_AS_PTR(short, instance->work0);
+
+    group = ((MooLevrGroup*)gameTracker->level->_6C)[WORK_AS_IDX(short, instance->work2, 1)];
+    if (group.count > 0) {
+        do {
+            if (group.faces[i][0xC] >= 0x29) {
+                group.faces[i][0xC] = 0x28;
+            }
+            if (group.faces[i][0xD] >= 0x29) {
+                group.faces[i][0xD] = 0x28;
+            }
+            if (group.faces[i][0xE] >= 0x29) {
+                group.faces[i][0xE] = 0x28;
+            }
+            i += 1;
+        } while (i < group.count);
+    }
+    fc[2] = 0x28;
+    fc[3] = 0x28;
+    fc[4] = 0x28;
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/MOOSHU", func_8015D190_C5B10);
 
 INCLUDE_ASM("asm/nonmatchings/level/MOOSHU", func_8015D240_C5BC0);
 
 INCLUDE_ASM("asm/nonmatchings/level/MOOSHU", func_8015D544_C5EC4);
-
-typedef struct {
-    int _00;
-    int count;              // 0x4
-    unsigned char** faces;  // 0x8
-} MooLevrGroup;
 
 void func_8015D6B0_C6030(Instance* instance, GameTracker* gameTracker) {
     MooLevrGroup group;

--- a/src/level/MOOSHU.c
+++ b/src/level/MOOSHU.c
@@ -422,7 +422,34 @@ INCLUDE_ASM("asm/nonmatchings/level/MOOSHU", func_8015D240_C5BC0);
 
 INCLUDE_ASM("asm/nonmatchings/level/MOOSHU", func_8015D544_C5EC4);
 
-INCLUDE_ASM("asm/nonmatchings/level/MOOSHU", func_8015D6B0_C6030);
+typedef struct {
+    int _00;
+    int count;              // 0x4
+    unsigned char** faces;  // 0x8
+} MooLevrGroup;
+
+void func_8015D6B0_C6030(Instance* instance, GameTracker* gameTracker) {
+    MooLevrGroup group;
+    short i = 0;
+    short* fc = WORK_AS_PTR(short, instance->work0);
+
+    group = ((MooLevrGroup*)gameTracker->level->_6C)[WORK_AS_IDX(short, instance->work0, 1)];
+    if (group.count > 0) {
+        do {
+            if (group.faces[i][0xC] < 0xFA) {
+                group.faces[i][0xC] = 0xFA;
+            }
+            if (group.faces[i][0xD] < 0xFA) {
+                group.faces[i][0xD] = 0xFA;
+            }
+            if (group.faces[i][0xE] < 0xFA) {
+                group.faces[i][0xE] = 0xFA;
+            }
+            i += 1;
+        } while (i < group.count);
+    }
+    fc[6] = 0x10;
+}
 
 void func_8015D7B4_C6134(Instance* instance, GameTracker* gameTracker)
 {

--- a/src/level/MOOSHU.c
+++ b/src/level/MOOSHU.c
@@ -324,7 +324,32 @@ void mooshu_moolevr_OnCreate(Instance* instance, GameTracker* gameTracker)
 
 INCLUDE_ASM("asm/nonmatchings/level/MOOSHU", mooshu_moolevr_OnUpdate);
 
-INCLUDE_ASM("asm/nonmatchings/level/MOOSHU", mooshu_moolevr_OnCollide);
+void func_8015C780_C5100(Instance* instance, GameTracker* gameTracker);
+
+void mooshu_moolevr_OnCollide(Instance* instance, GameTracker* gameTracker) {
+    Instance* target;
+    Instance* target2;
+    SVECTOR pos;
+
+    if (func_80027500(instance->bspTree, gameTracker)) {
+        if (instance->currentMainState == 0) {
+            target = 0;
+            target2 = 0;
+            if (instance->intro->_04[0] >= 3) {
+                target = ((Intro**)instance->intro->_04)[1]->instance;
+                target2 = ((Intro**)instance->intro->_04)[3]->instance;
+            }
+            if (target != 0 && target2 != 0) {
+                pos = target2->position;
+                pos.z += 0x320;
+                func_8015DA78_C63F8(target2, target, 7, &pos, 0xF);
+            }
+            func_8015C780_C5100(instance, gameTracker);
+            func_8015B8B0_C4230(target, gameTracker);
+            instance->currentSubState = 4;
+        }
+    }
+}
 
 int func_8015C6D0_C5050(Instance* instance) {
     if (instance->rotation.x == 0 || (instance->currentMainState == 3 && instance->rotation.x < 0x400)) {
@@ -348,7 +373,7 @@ void func_8015C710_C5090(Instance* instance, GameTracker* gameTracker) {
     }
 }
 
-void func_8015C780_C5100(Instance* instance) {
+void func_8015C780_C5100(Instance* instance, GameTracker* gameTracker) {
     if (instance->work0 == 0) {
         instance->currentSubState = 0;
         instance->work2 = 0;

--- a/src/level/PREHST.c
+++ b/src/level/PREHST.c
@@ -257,7 +257,94 @@ void prehst_eel_OnCreate(Instance* instance, GameTracker* gameTracker) {
     instance->work2 = ((short*)instance->object->animList[1])[1];
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/PREHST", prehst_eel_OnUpdate);
+void prehst_eel_OnUpdate(Instance* instance, GameTracker* gameTracker) {
+    Instance* player = gameTracker->player;
+    int dir;
+    int state;
+    int dx;
+    int dy;
+
+    dx = instance->position.x - player->position.x;
+    dy = instance->position.y - player->position.y;
+    instance->work0 = dx * dx + dy * dy;
+    dir = (short)ratan2(dy, dx) - 0x400;
+    if (instance->work0 < ((int*)instance->data)[2] && instance->currentMainState == 0 && instance->work1 == 0) {
+        instance->currentMainState = 2;
+        instance->_D0[3] = 8;
+        instance->currentModelAnim = 0;
+        instance->currentAnimFrame = 0;
+        instance->flags &= ~0x800;
+        func_80050980(0);
+    } else if (instance->work1 > 0) {
+        instance->work1 -= 1;
+    }
+    if (instance->currentMainState == 2) {
+        if (instance->_D0[3] > 0) {
+            instance->position.z += 0x60;
+            if (instance->currentAnimFrame < instance->work2) {
+                func_8002DAF8(instance, -1);
+                if (instance->currentAnimFrame < instance->work2) {
+                    func_8002DAF8(instance, -1);
+                }
+            }
+            func_8004ACB0(&instance->rotation.z, (short)dir, 0x80);
+            instance->_D0[3] -= 1;
+            return;
+        } else if (instance->_D0[3] == 0) {
+            instance->currentMainState = 3;
+            instance->currentModelAnim = 2;
+            instance->currentAnimFrame = 0;
+            instance->_D0[3] = ((short*)instance->object->animList[2])[1];
+            return;
+        }
+    }
+    state = instance->currentMainState;
+    if (state == 3) {
+        if (instance->_D0[3] > 0) {
+            if (instance->currentAnimFrame < ((short*)instance->object->animList[2])[1]) {
+                func_8002DAF8(instance, -1);
+                func_8002DAF8(instance, -1);
+            }
+            func_8004ACB0(&instance->rotation.z, (short)dir, 0x80);
+            instance->_D0[3] -= 1;
+            if (instance->currentAnimFrame == 0x16) {
+                func_80050980(0);
+            }
+            return;
+        } else if (instance->_D0[3] == 0) {
+            if (instance->work0 < ((int*)instance->data)[2]) {
+                instance->currentMainState = state;
+                instance->currentModelAnim = 2;
+                instance->currentAnimFrame = 0;
+                instance->_D0[3] = ((short*)instance->object->animList[2])[1];
+                return;
+            }
+            instance->currentMainState = 4;
+            instance->currentModelAnim = 3;
+            instance->currentAnimFrame = 0;
+            instance->_D0[3] = 8;
+            return;
+        }
+    }
+    if (instance->currentMainState == 4) {
+        if (instance->_D0[3] > 0) {
+            instance->position.z -= 0x60;
+            if (instance->currentAnimFrame < instance->work2) {
+                func_8002DAF8(instance, -1);
+                if (instance->currentAnimFrame < instance->work2) {
+                    func_8002DAF8(instance, -1);
+                }
+            }
+            instance->_D0[3] -= 1;
+            return;
+        }
+        if (instance->_D0[3] == 0) {
+            instance->currentMainState = 0;
+            instance->flags |= 0x800;
+            instance->work1 = rand() % 5;
+        }
+    }
+}
 
 void prehst_eel_OnCollide(Instance* instance, GameTracker* gameTracker) {
     if (func_80027500(instance->bspTree, gameTracker)) {

--- a/src/level/RTA.c
+++ b/src/level/RTA.c
@@ -541,7 +541,19 @@ void func_8015C8C0_DCF30(Instance* instance, GameTracker* gameTracker) {
 
 INCLUDE_ASM("asm/nonmatchings/level/RTA", func_8015C8C8_DCF38);
 
-INCLUDE_ASM("asm/nonmatchings/level/RTA", func_8015CA24_DD094);
+extern int D_8015EE10_DF480;
+
+void func_8015CA24_DD094(SVECTOR* pos, int count) {
+    SVector randVec;
+    int i;
+
+    for (i = 0; i < count; i++) {
+        randVec.x = rand() % 30 - 15;
+        randVec.y = rand() % 30 - 15;
+        randVec.z = rand() % 10 + 25;
+        func_80019828(pos, &randVec, &D_8015EE10_DF480, pos->z);
+    }
+}
 
 extern char D_8015EE18_DF488[];
 

--- a/src/level/RTA.c
+++ b/src/level/RTA.c
@@ -94,7 +94,23 @@ INCLUDE_ASM("asm/nonmatchings/level/RTA", rta_zshark_OnUpdate);
 
 INCLUDE_ASM("asm/nonmatchings/level/RTA", rta_zshark_OnCollide);
 
-INCLUDE_ASM("asm/nonmatchings/level/RTA", func_8015A2B0_DA920);
+void func_8015A2B0_DA920(Instance* instance, short arg1) {
+    if (*(int*)&instance->_34[2] != 0) {
+        if (func_80033200(*(int*)&instance->_34[2]) == 0) {
+            *(int*)&instance->_34[2] = func_80050508(instance, 0x119, 0, 0x7E, arg1);
+        } else if (func_800506B8(instance, *(int*)&instance->_34[2], 0, 0x7E, arg1) == 0) {
+            func_800331BC(*(int*)&instance->_34[2]);
+            *(int*)&instance->_34[2] = 0;
+        }
+    } else if (instance->_40[3] != 0) {
+        instance->_40[3] -= 1;
+    } else if (!(instance->intro->flags & 0x80)) {
+        *(int*)&instance->_34[2] = func_80050508(instance, 0x119, 0, 0x7E, arg1);
+        if (*(int*)&instance->_34[2] == 0) {
+            instance->_40[3] = 5;
+        }
+    }
+}
 
 void rta_crawler_OnCreate(Instance* instance, GameTracker* gameTracker)
 {
@@ -583,7 +599,37 @@ void rta_zstmvent_OnCreate(Instance* instance, GameTracker* gameTracker) {
     instance->work2 = 0;
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/RTA", rta_zstmvent_OnUpdate);
+void rta_zstmvent_OnUpdate(Instance* instance, GameTracker* gameTracker) {
+    int* fc = WORK_AS_PTR(int, instance->work0);
+
+    if (instance->work2 == 0 && instance->position.z < WORK_AS(int, instance->work5)) {
+        if (instance->work1 > 0) {
+            instance->work1 -= 1;
+        } else {
+            instance->work1 = 0;
+            instance->work2 = 1;
+        }
+        return;
+    }
+    if (instance->position.z >= fc[6]) {
+        instance->position.z = fc[4];
+        fc[1] = (rand() & 0x3F) + 0x80;
+        fc[2] = 0;
+    } else {
+        if (fc[5] < instance->position.z) {
+            fc[2] = 0;
+        } else {
+            if (fc[2] == 0) {
+                return;
+            }
+            if (fc[0] == 0) {
+                return;
+            }
+            func_8015D0B4_DD724(instance);
+        }
+        instance->position.z += 0x28;
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/RTA", func_8015D0B4_DD724);
 

--- a/src/level/SCIFI.c
+++ b/src/level/SCIFI.c
@@ -378,7 +378,94 @@ void scifi_eel_OnCreate(Instance* instance, GameTracker* gameTracker) {
     instance->work2 = ((short*)instance->object->animList[1])[1];
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/SCIFI", scifi_eel_OnUpdate);
+void scifi_eel_OnUpdate(Instance* instance, GameTracker* gameTracker) {
+    Instance* player = gameTracker->player;
+    int dir;
+    int state;
+    int dx;
+    int dy;
+
+    dx = instance->position.x - player->position.x;
+    dy = instance->position.y - player->position.y;
+    instance->work0 = dx * dx + dy * dy;
+    dir = (short)ratan2(dy, dx) - 0x400;
+    if (instance->work0 < ((int*)instance->data)[2] && instance->currentMainState == 0 && instance->work1 == 0) {
+        instance->currentMainState = 2;
+        instance->_D0[3] = 8;
+        instance->currentModelAnim = 0;
+        instance->currentAnimFrame = 0;
+        instance->flags &= ~0x800;
+        func_80050980(0);
+    } else if (instance->work1 > 0) {
+        instance->work1 -= 1;
+    }
+    if (instance->currentMainState == 2) {
+        if (instance->_D0[3] > 0) {
+            instance->position.z += 0x60;
+            if (instance->currentAnimFrame < instance->work2) {
+                func_8002DAF8(instance, -1);
+                if (instance->currentAnimFrame < instance->work2) {
+                    func_8002DAF8(instance, -1);
+                }
+            }
+            func_8004ACB0(&instance->rotation.z, (short)dir, 0x80);
+            instance->_D0[3] -= 1;
+            return;
+        } else if (instance->_D0[3] == 0) {
+            instance->currentMainState = 3;
+            instance->currentModelAnim = 2;
+            instance->currentAnimFrame = 0;
+            instance->_D0[3] = ((short*)instance->object->animList[2])[1];
+            return;
+        }
+    }
+    state = instance->currentMainState;
+    if (state == 3) {
+        if (instance->_D0[3] > 0) {
+            if (instance->currentAnimFrame < ((short*)instance->object->animList[2])[1]) {
+                func_8002DAF8(instance, -1);
+                func_8002DAF8(instance, -1);
+            }
+            func_8004ACB0(&instance->rotation.z, (short)dir, 0x80);
+            instance->_D0[3] -= 1;
+            if (instance->currentAnimFrame == 0x16) {
+                func_80050980(0);
+            }
+            return;
+        } else if (instance->_D0[3] == 0) {
+            if (instance->work0 < ((int*)instance->data)[2]) {
+                instance->currentMainState = state;
+                instance->currentModelAnim = 2;
+                instance->currentAnimFrame = 0;
+                instance->_D0[3] = ((short*)instance->object->animList[2])[1];
+                return;
+            }
+            instance->currentMainState = 4;
+            instance->currentModelAnim = 3;
+            instance->currentAnimFrame = 0;
+            instance->_D0[3] = 8;
+            return;
+        }
+    }
+    if (instance->currentMainState == 4) {
+        if (instance->_D0[3] > 0) {
+            instance->position.z -= 0x60;
+            if (instance->currentAnimFrame < instance->work2) {
+                func_8002DAF8(instance, -1);
+                if (instance->currentAnimFrame < instance->work2) {
+                    func_8002DAF8(instance, -1);
+                }
+            }
+            instance->_D0[3] -= 1;
+            return;
+        }
+        if (instance->_D0[3] == 0) {
+            instance->currentMainState = 0;
+            instance->flags |= 0x800;
+            instance->work1 = rand() % 5;
+        }
+    }
+}
 
 void scifi_eel_OnCollide(Instance* instance, GameTracker* gameTracker) {
     if (func_80027500(instance->bspTree, gameTracker)) {


### PR DESCRIPTION
## Summary

17 more level functions decompiled to byte-matching C. This batch leans on twin-cluster porting: a normalized-instruction scan of the remaining stubs found cross-level twin groups, so several functions here were derived once and landed on two levels each — including the two 219-instruction eel state machines, the largest functions matched in these batches so far. Full clean `make clean && make split && make build && make diff` matches the ROM.

## Functions

| Level | Functions |
|-------|-----------|
| CIRCUIT | circuit_ebridge_OnCreate, circuit_charger_OnCreate, circuit_reza_OnCreate |
| GEXZIL | gexzil_mekblst_OnUpdate |
| HORROR | horror_reza_OnCreate, func_8015A014_9D844 |
| KUNGFU | func_80160D4C_AFF6C, kungfu_leafgen_OnUpdate |
| LOONEY | func_80160318_B85C8, looney_leafgen_OnUpdate |
| MOOSHU | mooshu_moolevr_OnCollide, func_8015D6B0_C6030, func_8015D084_C5A04 |
| PREHST | func_8015FC2C_CD4AC, prehst_eel_OnUpdate |
| RTA | func_8015A2B0_DA920, rta_zstmvent_OnUpdate, func_8015CA24_DD094 |
| SCIFI | scifi_eel_OnUpdate |

(Also byte-neutral signature corrections confirmed against ROM callers: func_8015C780_C5100 gained its real GameTracker* param; the KUNGFU/LOONEY leaf-burst helpers func_801619A4/func_8015BC04 are (Instance*, GameTracker*, short* pos).)

## Techniques of note

- **eel_OnUpdate pair**: `int dir = (short)ratan2(dy, dx) - 0x400;` — the cast on the call result with the bias outside reproduces the eager truncation with the addiu scheduled later; use-sites take fresh `(short)dir` casts. The ==4 state check is a flat `if` (not `else if`) — visible because the preceding arm's stores force a reload of the state field.
- **reza_OnCreate pair**: compares `gameTracker->level->levelType` against "horror_____" — Reza's create path branches on being in his home level. work7 accessed as four individual bytes via WORK_AS_IDX(char, ..., 0-3).
- **leafgen_OnUpdate pair**: mixed access bases (conditions instance-relative, the loop arg and tail through a short* over work0), with the sound-check duplicated per arm and cross-jump merging the copies.
- **rta_zstmvent_OnUpdate**: the post-rand() stores must go through the cached work pointer so it survives the call in a saved register.
- **func_8015D6B0/func_8015D084 (MOOSHU)**: 12-byte struct assignment from a Level-table record; `short i` loop index reproduces the (i<<16)>>14 scaled-index fold.