### PR TITLE
Decompile 5 functions from Trouble Matching issues #118-#120

### DIFF
--- a/src/level/GEXZIL.c
+++ b/src/level/GEXZIL.c
@@ -1,6 +1,8 @@
 #include "common.h"
 
 #include "level/GEXZIL.h"
+#include "OBTABLE.h"
+#include "INSTANCE.h"
 #include "types/G2String.h"
 
 void gexzil_bug_OnCreate(Instance* instance, GameTracker* gameTracker) {
@@ -56,7 +58,41 @@ INCLUDE_RODATA("asm/nonmatchings/level/GEXZIL", D_80162A90_9BC10);
 
 INCLUDE_RODATA("asm/nonmatchings/level/GEXZIL", D_80162AA0_9BC20);
 
-INCLUDE_ASM("asm/nonmatchings/level/GEXZIL", func_8015A09C_9321C);
+extern int D_800EB8A0;
+extern char D_80162AA0_9BC20[];
+
+Instance* func_8015A09C_9321C(Instance* instance, Instance* target, short arg2, SVECTOR* pos, short arg4) {
+    Instance* bolt;
+    Object* spotObj;
+    Object* boltObj;
+    int spray;
+
+    spotObj = OBTABLE_FindObject(D_80162AA0_9BC20);
+    boltObj = OBTABLE_FindObject("ebolt___");
+    bolt = 0;
+    if (boltObj != 0) {
+        bolt = INSTANCE_BirthObject(instance, boltObj);
+        if (bolt != 0) {
+            bolt->work0 = arg4;
+            WORK_AS(Instance*, bolt->work1) = target;
+            bolt->position = *pos;
+            bolt->intro = NULL;
+            bolt->work7 = bolt->work2 = arg2;
+            if (spotObj != 0) {
+                if (arg4 < 0) {
+                    arg4 = -2;
+                }
+                spray = func_800176E8(&target->position, spotObj->modelList[0], D_800EB8A0, arg4);
+                if (spray != 0) {
+                    func_80015E80(spray, -0x8000);
+                    WORK_AS(int, bolt->work3) = spray;
+                }
+            }
+            func_80159DEC_92F6C(bolt, target);
+        }
+    }
+    return bolt;
+}
 
 extern void func_80017AB8(short* arg0, short arg1);
 void gexzil_ebolt_OnCreate(Instance* instance, GameTracker* gameTracker) {
@@ -422,7 +458,7 @@ void func_8015F680_98800(Instance* instance) {
     instance->_B8 = 0;
     d[0x1C] = d[0x1D];
     if (((int*)d)[0x90 / 4] != 0) {
-        func_8002E350(((int*)d)[0x90 / 4]);
+        func_8002E350(((Instance**)d)[0x90 / 4]);
         ((int*)d)[0x90 / 4] = 0;
     }
 }

--- a/src/level/GEXZIL.c
+++ b/src/level/GEXZIL.c
@@ -65,7 +65,7 @@ Instance* func_8015A09C_9321C(Instance* instance, Instance* target, short arg2, 
     Instance* bolt;
     Object* spotObj;
     Object* boltObj;
-    int spray;
+    int other;
 
     spotObj = OBTABLE_FindObject(D_80162AA0_9BC20);
     boltObj = OBTABLE_FindObject("ebolt___");
@@ -82,10 +82,10 @@ Instance* func_8015A09C_9321C(Instance* instance, Instance* target, short arg2, 
                 if (arg4 < 0) {
                     arg4 = -2;
                 }
-                spray = func_800176E8(&target->position, spotObj->modelList[0], D_800EB8A0, arg4);
-                if (spray != 0) {
-                    func_80015E80(spray, -0x8000);
-                    WORK_AS(int, bolt->work3) = spray;
+                other = func_800176E8(&target->position, spotObj->modelList[0], D_800EB8A0, arg4);
+                if (other != 0) {
+                    func_80015E80(other, -0x8000);
+                    WORK_AS(int, bolt->work3) = other;
                 }
             }
             func_80159DEC_92F6C(bolt, target);

--- a/src/level/HORROR.c
+++ b/src/level/HORROR.c
@@ -6,6 +6,7 @@
 #include "types/intro/BTimer.h"
 #include "types/G2String.h"
 #include "level/COMMON.h"
+#include "OBTABLE.h"
 
 #include "types/Vector.h"
 extern int D_800E5FD8;
@@ -551,43 +552,60 @@ typedef struct {
 } SprayData;
 
 INCLUDE_ASM("asm/nonmatchings/level/HORROR", func_8015F620_A2E50);
-/* near-match (18 diffs: frame a1/a2, mflo v0/v1, z-check v0/v1 swap — scheduler difference):
-void func_8015F620_A2E50(void* arg0) {
-    SprayData* data;
-    Instance* player;
-    int dz;
-    int posZadj;
-    int dx;
-    int dy;
 
-    data = ((SprayData*)arg0);
-    data->unk24 -= 5;
-    data->unk28 += 5;
-    data->frame++;
-    data->unk2C -= 5;
-    data->unk30 -= 5;
-    data->unk34 += 5;
-    data->unk38 += 5;
-    data->unk3C += 5;
-    data->unk40 -= 5;
-    func_80016894(arg0);
-    player = PlayerInstance;
-    dx = player->position.x - data->posX;
-    dy = player->position.y - data->posY;
-    if (dx * dx + dy * dy < 0x4000) {
-        posZadj = data->posZ - 0x100;
-        dz = player->position.z - posZadj;
-        if (dz < 0) dz = -dz;
-        if (dz < 0x100) {
-            if (player->currentSubState != 0x200000) {
-                func_800223F8(gameTracker8, 0x78, 0);
+extern int D_800EB8A0;
+extern void func_80017E88();
+extern void func_8015F620_A2E50();
+
+void horror_spray_OnUpdate(Instance* instance, GameTracker* gameTracker) {
+    SVECTOR rot;
+    SVECTOR pos;
+    Model* model;
+    int state;
+
+    int dy, dx;
+    dx = PlayerInstance->position.x - instance->position.x;
+    dy = PlayerInstance->position.y - instance->position.y;
+
+    func_8004ACB0(&instance->rotation.z, (short)(ratan2(dy, dx) + 0x400), 0x200);
+
+    state = instance->currentMainState;
+    instance->work9 += 1;
+    if (state == 0) {
+        if (instance->work9 >= 0x5A) {
+            instance->currentMainState = 1;
+            instance->work9 = 0;
+        }
+    } else if (state == 1) {
+        model = OBTABLE_FindObject("sprysht_")->modelList[0];
+        if (WORK_AS(int, instance->work7) != 0) {
+            WORK_AS(int, instance->work8) += 8;
+            if (WORK_AS(int, instance->work8) == 0x80) {
+                WORK_AS(int, instance->work7) = 0;
             }
+        } else {
+            WORK_AS(int, instance->work8) -= 8;
+            if (WORK_AS(int, instance->work8) == -0x80) {
+                WORK_AS(int, instance->work7) = state;
+            }
+        }
+        pos.x = instance->position.x + (((short)func_8003A6AC(instance->rotation.z - 0x400)) >> 5);
+        pos.y = instance->position.y + (((short)func_8003A4E0(instance->rotation.z - 0x400)) >> 5);
+        pos.z = instance->position.z;
+        rot.x = (short)func_8003A6AC(instance->rotation.z - 0x400 + (WORK_AS(int, instance->work8))) * 0x19 >> 0xB;
+        rot.y = (short)func_8003A4E0(instance->rotation.z - 0x400 + (WORK_AS(int, instance->work8))) * 0x19 >> 0xB;
+        rot.z = 0;
+        func_800170E8(model, model->_14, &pos, &rot, 0, D_800EB8A0, func_80017E88, func_8015F620_A2E50, 0x14);
+        if (PlayerInstance->currentSubState == 0x200000) {
+            WORK_AS(int, instance->work6) += 1;
+        }
+        if (instance->work9 >= 0x5A || WORK_AS(int, instance->work6) >= 0xA) {
+            instance->work9 = 0;
+            WORK_AS(int, instance->work6) = 0;
+            instance->currentMainState = 0;
         }
     }
 }
-*/
-
-INCLUDE_ASM("asm/nonmatchings/level/HORROR", horror_spray_OnUpdate);
 
 void horror_spray_OnCollide(Instance* instance, GameTracker* gameTracker) {
     if (instance->bspTree->_06 == 1

--- a/src/level/KUNGFU.c
+++ b/src/level/KUNGFU.c
@@ -114,7 +114,59 @@ void func_80159B1C_A8D3C(void* arg0) {
 
 INCLUDE_RODATA("asm/nonmatchings/level/KUNGFU", D_801626C0_B18E0);
 
-INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", kungfu_spray_OnUpdate);
+extern int D_800EB8A0;
+extern void func_80017E88();
+extern void func_80159B1C_A8D3C();
+
+void kungfu_spray_OnUpdate(Instance* instance, GameTracker* gameTracker) {
+    SVECTOR rot;
+    SVECTOR pos;
+    Model* model;
+    int state;
+
+    int dy, dx;
+    dx = PlayerInstance->position.x - instance->position.x;
+    dy = PlayerInstance->position.y - instance->position.y;
+
+    func_8004ACB0(&instance->rotation.z, (short)(ratan2(dy, dx) + 0x400), 0x200);
+
+    state = instance->currentMainState;
+    instance->work9 += 1;
+    if (state == 0) {
+        if (instance->work9 >= 0x5A) {
+            instance->currentMainState = 1;
+            instance->work9 = 0;
+        }
+    } else if (state == 1) {
+        model = OBTABLE_FindObject("sprysht_")->modelList[0];
+        if (WORK_AS(int, instance->work7) != 0) {
+            WORK_AS(int, instance->work8) += 8;
+            if (WORK_AS(int, instance->work8) == 0x80) {
+                WORK_AS(int, instance->work7) = 0;
+            }
+        } else {
+            WORK_AS(int, instance->work8) -= 8;
+            if (WORK_AS(int, instance->work8) == -0x80) {
+                WORK_AS(int, instance->work7) = state;
+            }
+        }
+        pos.x = instance->position.x + (((short)func_8003A6AC(instance->rotation.z - 0x400)) >> 5);
+        pos.y = instance->position.y + (((short)func_8003A4E0(instance->rotation.z - 0x400)) >> 5);
+        pos.z = instance->position.z;
+        rot.x = (short)func_8003A6AC(instance->rotation.z - 0x400 + (WORK_AS(int, instance->work8))) * 0x19 >> 0xB;
+        rot.y = (short)func_8003A4E0(instance->rotation.z - 0x400 + (WORK_AS(int, instance->work8))) * 0x19 >> 0xB;
+        rot.z = 0;
+        func_800170E8(model, model->_14, &pos, &rot, 0, D_800EB8A0, func_80017E88, func_80159B1C_A8D3C, 0x14);
+        if (PlayerInstance->currentSubState == 0x200000) {
+            WORK_AS(int, instance->work6) += 1;
+        }
+        if (instance->work9 >= 0x5A || WORK_AS(int, instance->work6) >= 0xA) {
+            instance->work9 = 0;
+            WORK_AS(int, instance->work6) = 0;
+            instance->currentMainState = 0;
+        }
+    }
+}
 
 void kungfu_spray_OnCollide(Instance* instance, GameTracker* gameTracker) {
     if (instance->bspTree->_06 == 1

--- a/src/level/MOOSHU.c
+++ b/src/level/MOOSHU.c
@@ -490,7 +490,7 @@ Instance* func_8015DA78_C63F8(Instance* instance, Instance* target, short arg2, 
     Instance* bolt;
     Object* spotObj;
     Object* boltObj;
-    int spray;
+    int other;
 
     spotObj = OBTABLE_FindObject("bluspot_");
     boltObj = OBTABLE_FindObject("ebolt___");
@@ -507,10 +507,10 @@ Instance* func_8015DA78_C63F8(Instance* instance, Instance* target, short arg2, 
                 if (arg4 < 0) {
                     arg4 = -2;
                 }
-                spray = func_800176E8(&target->position, spotObj->modelList[0], D_800EB8A0, arg4);
-                if (spray != 0) {
-                    func_80015E80(spray, -0x8000);
-                    WORK_AS(int, bolt->work3) = spray;
+                other = func_800176E8(&target->position, spotObj->modelList[0], D_800EB8A0, arg4);
+                if (other != 0) {
+                    func_80015E80(other, -0x8000);
+                    WORK_AS(int, bolt->work3) = other;
                 }
             }
             func_8015D7C8_C6148(bolt, target);

--- a/src/level/MOOSHU.c
+++ b/src/level/MOOSHU.c
@@ -1,6 +1,8 @@
 #include "common.h"
 
 #include "level/MOOSHU.h"
+#include "OBTABLE.h"
+#include "INSTANCE.h"
 
 /* quantize a stick/velocity pair into a direction code (0-3) */
 void func_80159720_C20A0(short* out, int arg1, short* vec) {
@@ -325,6 +327,7 @@ void mooshu_moolevr_OnCreate(Instance* instance, GameTracker* gameTracker)
 INCLUDE_ASM("asm/nonmatchings/level/MOOSHU", mooshu_moolevr_OnUpdate);
 
 void func_8015C780_C5100(Instance* instance, GameTracker* gameTracker);
+Instance* func_8015DA78_C63F8(Instance* instance, Instance* target, short arg2, SVECTOR* pos, short arg4);
 
 void mooshu_moolevr_OnCollide(Instance* instance, GameTracker* gameTracker) {
     Instance* target;
@@ -481,7 +484,40 @@ void func_8015D7B4_C6134(Instance* instance, GameTracker* gameTracker)
 
 INCLUDE_ASM("asm/nonmatchings/level/MOOSHU", func_8015D7C8_C6148);
 
-INCLUDE_ASM("asm/nonmatchings/level/MOOSHU", func_8015DA78_C63F8);
+extern int D_800EB8A0;
+
+Instance* func_8015DA78_C63F8(Instance* instance, Instance* target, short arg2, SVECTOR* pos, short arg4) {
+    Instance* bolt;
+    Object* spotObj;
+    Object* boltObj;
+    int spray;
+
+    spotObj = OBTABLE_FindObject("bluspot_");
+    boltObj = OBTABLE_FindObject("ebolt___");
+    bolt = 0;
+    if (boltObj != 0) {
+        bolt = INSTANCE_BirthObject(instance, boltObj);
+        if (bolt != 0) {
+            bolt->work0 = arg4;
+            WORK_AS(Instance*, bolt->work1) = target;
+            bolt->position = *pos;
+            bolt->intro = NULL;
+            bolt->work7 = bolt->work2 = arg2;
+            if (spotObj != 0) {
+                if (arg4 < 0) {
+                    arg4 = -2;
+                }
+                spray = func_800176E8(&target->position, spotObj->modelList[0], D_800EB8A0, arg4);
+                if (spray != 0) {
+                    func_80015E80(spray, -0x8000);
+                    WORK_AS(int, bolt->work3) = spray;
+                }
+            }
+            func_8015D7C8_C6148(bolt, target);
+        }
+    }
+    return bolt;
+}
 
 extern void func_80017AB8(short* arg0, short arg1);
 void mooshu_ebolt_OnCreate(Instance* instance, GameTracker* gameTracker) {

--- a/src/level/RTA.c
+++ b/src/level/RTA.c
@@ -351,7 +351,29 @@ INCLUDE_ASM("asm/nonmatchings/level/RTA", rta_zgeyser_OnUpdate);
 
 INCLUDE_ASM("asm/nonmatchings/level/RTA", rta_zgeyser_OnCollide);
 
-INCLUDE_ASM("asm/nonmatchings/level/RTA", rta_zdoor_OnCreate);
+void func_8015BD04_DC374(Instance* instance);
+
+void rta_zdoor_OnCreate(Instance* instance, GameTracker* gameTracker) {
+    if (instance->flags & 0x20000) {
+        instance->intro->flags &= ~8;
+    } else {
+        instance->flags |= 0x10400;
+        if (((int*)instance->introData) != 0) {
+            int* intro = ((int*)instance->introData);
+            if (intro[0] == 0) {
+                intro[0] = 0;
+            } else {
+                intro[0] = 1;
+            }
+            instance->currentSubState = 0;
+            memset(&instance->work0, 0, 0x28);
+            instance->work0 = instance->initialPos.x + intro[2] * intro[3];
+            instance->work1 = instance->initialPos.y + intro[2] * intro[4];
+            instance->work2 = instance->initialPos.z + intro[2] * intro[5];
+            func_8015BD04_DC374(instance);
+        }
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/RTA", rta_zdoor_OnUpdate);
 


### PR DESCRIPTION
## Summary

Five functions from the Trouble Matching issues you solved — all byte-verified against the ROM, full clean build passes (`make clean && make split && make build && make diff`).

Closes #118, closes #119, closes #120.

| Function | File | Size | Notes |
|---|---|---|---|
| rta_zdoor_OnCreate | RTA.c | 67 | your #118 fix as written: pointer local inside the guarded branch, both-arms normalize-to-bool |
| horror_spray_OnUpdate | HORROR.c | 153 | your #119 fix; added explicit `(short)` casts on the four sin/cos results since our tree still has them implicit — droppable once the short-returning declarations land |
| kungfu_spray_OnUpdate | KUNGFU.c | 153 | twin, with `func_80159B1C_A8D3C` as the particle callback |
| func_8015DA78_C63F8 | MOOSHU.c | 78 | your #120 fix (parameter reused, no `mode` local) |
| func_8015A09C_9321C | GEXZIL.c | 78 | twin, referencing the shared `D_80162AA0_9BC20` blob for "bluspot_" and calling func_80159DEC_92F6C |

## Techniques

- The three lessons from your fixes (branch-scoped pointer locals, argument-expression hoisting for load order, parameter reuse over shadow locals) are what made these land — they're in our notes now.
- HORROR.c/MOOSHU.c/GEXZIL.c gained `OBTABLE.h`/`INSTANCE.h` includes (functions only, no extern globals); the one call the new typing exposed (GEXZIL func_8015F680_98800's `func_8002E350` arg) was respelled `((Instance**)d)[0x90 / 4]`, byte-identical.
- Removed HORROR.c's old spray-callback near-match comment block; that function's current best attempt (73/73, 6 words — down from 9 after finding its zero-cost `int arg1` passthrough) is filed as #123.