### PR TITLE
Decompile 18 level functions (HORROR camera cluster, RTA, FINAL debug prints, issue solutions)

### DIFF
--- a/include/types/Vector.h
+++ b/include/types/Vector.h
@@ -24,6 +24,12 @@ typedef struct
     int x, y, z;
 } LVECTOR;
 
+typedef struct
+{
+    int x, y, z;
+    int pad;
+} LVector; // Required padding difference
+
 FORCE_INLINE void SVECTOR_Subtract(SVECTOR* lhs, SVECTOR* rhs, SVECTOR* out)
 {
     out->x = lhs->x - rhs->x;

--- a/src/level/CIRCUIT.c
+++ b/src/level/CIRCUIT.c
@@ -364,7 +364,27 @@ void func_8015C18C_8336C(Instance* instance, int val) {
     }
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/CIRCUIT", circuit_orbplat_OnCreate);
+void circuit_orbplat_OnCreate(Instance* instance, GameTracker* gameTracker) {
+    short* data = ((short*)instance->object->data);
+
+    instance->work0 = -0x400;
+    instance->work8 = 0x320;
+
+    if (data != 0) {
+        instance->work8 = data[0];
+    }
+
+    instance->initialPos.x = ((Intro**)instance->intro->_04)[2]->position.x + (instance->work8 * ((short)func_8003A6AC(instance->work0)) >> 12);
+    instance->initialPos.y = ((Intro**)instance->intro->_04)[2]->position.y + (instance->work8 * ((short)func_8003A4E0(instance->work0)) >> 12);
+
+    instance->work4 = instance->work8;
+    instance->work5 = 0;
+    instance->work6 = 0x20;
+    instance->work7 = 0x38;
+
+    instance->currentSubState = 0;
+    instance->currentMainState = 1;
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/CIRCUIT", circuit_orbplat_OnUpdate);
 

--- a/src/level/FINAL.c
+++ b/src/level/FINAL.c
@@ -601,7 +601,23 @@ void final_finaltv_OnCreate(Instance* instance, GameTracker* gameTracker) {
     instance->work0 = 30;
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/FINAL", final_finaltv_OnUpdate);
+void final_finaltv_OnUpdate(Instance* instance, GameTracker* gameTracker) {
+    if (instance->work0 > 0) {
+        instance->work0--;
+        return;
+    }
+
+    instance->work0--;
+
+    if (instance->work0 == -0x21) {
+        func_80050508(instance, 0x154, 0, 0x7F, 0x4E20);
+    }
+    instance->_D0[2] += instance->_E0[1];
+    if (instance->_F0 < abs(instance->_D0[2])) {
+        instance->_D0[2] = instance->_D0[2] < 0 ? -instance->_F0 : instance->_F0;
+    }
+    instance->position.z += instance->_D0[2];
+}
 
 
 void final_finaltv_OnCollide(Instance* instance, GameTracker* gameTracker) {

--- a/src/level/FINAL.c
+++ b/src/level/FINAL.c
@@ -472,6 +472,8 @@ void func_8015CB70_8DD10(Instance* instance, GameTracker* gameTracker, int count
     short* p;
     int c;
 
+    /* raw derefs below (not p[i]) keep the loads under the coordinate
+       stores in the schedule; the index form hoists them */
     p = WORK_AS(short*, instance->work0);
     if (count >= 0x29) {
         c = 0x64;
@@ -509,6 +511,7 @@ void func_8015CC64_8DE04(Instance* instance, GameTracker* gameTracker, int count
     char buf[16];
     int c;
 
+    /* raw position derefs: same scheduling pin as func_8015CB70 */
     c = 0x96;
     if (count >= 0x29) {
         D_800BDEE0[0] = 0xDC;

--- a/src/level/FINAL.c
+++ b/src/level/FINAL.c
@@ -461,7 +461,40 @@ void func_8015CB34_8DCD4(char* buf, short val) {
 
 INCLUDE_RODATA("asm/nonmatchings/level/FINAL", D_801615B8_92758);
 
-INCLUDE_ASM("asm/nonmatchings/level/FINAL", func_8015CB70_8DD10);
+extern int D_800BDEE0[];
+extern int D_800BDEE4;
+
+void func_8015CB70_8DD10(Instance* instance, GameTracker* gameTracker, int count) {
+    extern char D_801615C8_92768[];
+    extern char D_801615D0_92770[];
+    extern char D_801615D8_92778[];
+    char buf[16];
+    short* p;
+    int c;
+
+    p = WORK_AS(short*, instance->work0);
+    if (count >= 0x29) {
+        c = 0x64;
+        D_800BDEE0[0] = 0xDC;
+        D_800BDEE4 = c;
+        osSyncPrintf("Target");
+        c = 0x6C;
+        D_800BDEE0[0] = 0xDC;
+        D_800BDEE4 = c;
+        func_8015CB34_8DCD4(buf, *(short*)((char*)p + 0x3C));
+        osSyncPrintf(D_801615C8_92768, buf);
+        c = 0x74;
+        D_800BDEE0[0] = 0xDC;
+        D_800BDEE4 = c;
+        func_8015CB34_8DCD4(buf, *(short*)((char*)p + 0x3E));
+        osSyncPrintf(D_801615D0_92770, buf);
+        c = 0x7C;
+        D_800BDEE0[0] = 0xDC;
+        D_800BDEE4 = c;
+        func_8015CB34_8DCD4(buf, *(short*)((char*)p + 0x40));
+        osSyncPrintf(D_801615D8_92778, buf);
+    }
+}
 
 INCLUDE_RODATA("asm/nonmatchings/level/FINAL", D_801615C8_92768); // X %s
 
@@ -469,7 +502,35 @@ INCLUDE_RODATA("asm/nonmatchings/level/FINAL", D_801615D0_92770); // Y %s
 
 INCLUDE_RODATA("asm/nonmatchings/level/FINAL", D_801615D8_92778); // Z %s
 
-INCLUDE_ASM("asm/nonmatchings/level/FINAL", func_8015CC64_8DE04);
+void func_8015CC64_8DE04(Instance* instance, GameTracker* gameTracker, int count) {
+    extern char D_801615C8_92768[];
+    extern char D_801615D0_92770[];
+    extern char D_801615D8_92778[];
+    char buf[16];
+    int c;
+
+    c = 0x96;
+    if (count >= 0x29) {
+        D_800BDEE0[0] = 0xDC;
+        D_800BDEE4 = c;
+        osSyncPrintf("Position");
+        c = 0x9E;
+        D_800BDEE0[0] = 0xDC;
+        D_800BDEE4 = c;
+        func_8015CB34_8DCD4(buf, *(short*)((char*)instance + 0x48));
+        osSyncPrintf(D_801615C8_92768, buf);
+        c = 0xA6;
+        D_800BDEE0[0] = 0xDC;
+        D_800BDEE4 = c;
+        func_8015CB34_8DCD4(buf, *(short*)((char*)instance + 0x4A));
+        osSyncPrintf(D_801615D0_92770, buf);
+        c = 0xAE;
+        D_800BDEE0[0] = 0xDC;
+        D_800BDEE4 = c;
+        func_8015CB34_8DCD4(buf, *(short*)((char*)instance + 0x4C));
+        osSyncPrintf(D_801615D8_92778, buf);
+    }
+}
 
 extern int D_800BDEE0[5];
 

--- a/src/level/FINAL.c
+++ b/src/level/FINAL.c
@@ -462,7 +462,6 @@ void func_8015CB34_8DCD4(char* buf, short val) {
 INCLUDE_RODATA("asm/nonmatchings/level/FINAL", D_801615B8_92758);
 
 extern int D_800BDEE0[];
-extern int D_800BDEE4;
 
 void func_8015CB70_8DD10(Instance* instance, GameTracker* gameTracker, int count) {
     extern char D_801615C8_92768[];
@@ -478,21 +477,21 @@ void func_8015CB70_8DD10(Instance* instance, GameTracker* gameTracker, int count
     if (count >= 0x29) {
         c = 0x64;
         D_800BDEE0[0] = 0xDC;
-        D_800BDEE4 = c;
+        D_800BDEE0[1] = c;
         osSyncPrintf("Target");
         c = 0x6C;
         D_800BDEE0[0] = 0xDC;
-        D_800BDEE4 = c;
+        D_800BDEE0[1] = c;
         func_8015CB34_8DCD4(buf, *(short*)((char*)p + 0x3C));
         osSyncPrintf(D_801615C8_92768, buf);
         c = 0x74;
         D_800BDEE0[0] = 0xDC;
-        D_800BDEE4 = c;
+        D_800BDEE0[1] = c;
         func_8015CB34_8DCD4(buf, *(short*)((char*)p + 0x3E));
         osSyncPrintf(D_801615D0_92770, buf);
         c = 0x7C;
         D_800BDEE0[0] = 0xDC;
-        D_800BDEE4 = c;
+        D_800BDEE0[1] = c;
         func_8015CB34_8DCD4(buf, *(short*)((char*)p + 0x40));
         osSyncPrintf(D_801615D8_92778, buf);
     }
@@ -511,26 +510,25 @@ void func_8015CC64_8DE04(Instance* instance, GameTracker* gameTracker, int count
     char buf[16];
     int c;
 
-    /* raw position derefs: same scheduling pin as func_8015CB70 */
     c = 0x96;
     if (count >= 0x29) {
         D_800BDEE0[0] = 0xDC;
-        D_800BDEE4 = c;
+        D_800BDEE0[1] = c;
         osSyncPrintf("Position");
         c = 0x9E;
         D_800BDEE0[0] = 0xDC;
-        D_800BDEE4 = c;
-        func_8015CB34_8DCD4(buf, *(short*)((char*)instance + 0x48));
+        D_800BDEE0[1] = c;
+        func_8015CB34_8DCD4(buf, instance->position.x);
         osSyncPrintf(D_801615C8_92768, buf);
         c = 0xA6;
         D_800BDEE0[0] = 0xDC;
-        D_800BDEE4 = c;
-        func_8015CB34_8DCD4(buf, *(short*)((char*)instance + 0x4A));
+        D_800BDEE0[1] = c;
+        func_8015CB34_8DCD4(buf, instance->position.y);
         osSyncPrintf(D_801615D0_92770, buf);
         c = 0xAE;
         D_800BDEE0[0] = 0xDC;
-        D_800BDEE4 = c;
-        func_8015CB34_8DCD4(buf, *(short*)((char*)instance + 0x4C));
+        D_800BDEE0[1] = c;
+        func_8015CB34_8DCD4(buf, instance->position.z);
         osSyncPrintf(D_801615D8_92778, buf);
     }
 }

--- a/src/level/HORROR.c
+++ b/src/level/HORROR.c
@@ -1068,13 +1068,106 @@ void func_80161F4C_A577C(Instance* instance, SVECTOR offset) {
     }
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/HORROR", func_80162024_A5854);
+void func_80162024_A5854(Instance* instance, SVECTOR offset) {
+    MATRIX m;
+    SVECTOR vec;
+    SVECTOR res;
 
-INCLUDE_ASM("asm/nonmatchings/level/HORROR", func_80162118_A5948);
+    MATH3D_SetUnityMatrix(&m);
+    if (instance->rotation.z > 0) {
+        instance->rotation.z -= 0x20;
+        RotMatrixZ(instance->rotation.z + instance->intro->rotation.z, &m);
+        vec.x = 0;
+        vec.z = 0;
+        vec.y = -0x40;
+        res.x = (vec.x * m.m[0][0] >> 12) + (vec.y * m.m[0][1] >> 12) + (vec.z * m.m[0][2] >> 12);
+        res.y = (vec.x * m.m[1][0] >> 12) + (vec.y * m.m[1][1] >> 12) + (vec.z * m.m[1][2] >> 12);
+        res.z = (vec.x * m.m[2][0] >> 12) + (vec.y * m.m[2][1] >> 12) + (vec.z * m.m[2][2] >> 12);
+        instance->position.x = res.x + offset.x;
+        instance->position.y = res.y + offset.y;
+        instance->position.z = res.z + offset.z;
+    } else {
+        WORK_AS_IDX(char, instance->work8, 2) = 0;
+    }
+}
 
-INCLUDE_ASM("asm/nonmatchings/level/HORROR", func_80162214_A5A44);
+void func_80162118_A5948(Instance* instance, SVECTOR offset) {
+    MATRIX m;
+    SVECTOR vec;
+    SVECTOR res;
 
-INCLUDE_ASM("asm/nonmatchings/level/HORROR", func_801622E4_A5B14);
+    MATH3D_SetUnityMatrix(&m);
+    if (instance->rotation.z < 0x400) {
+        instance->rotation.z += 0x20;
+        RotMatrixZ(instance->rotation.z + instance->intro->rotation.z, &m);
+        vec.x = 0;
+        vec.z = 0;
+        vec.y = -0x40;
+        res.x = (vec.x * m.m[0][0] >> 12) + (vec.y * m.m[0][1] >> 12) + (vec.z * m.m[0][2] >> 12);
+        res.y = (vec.x * m.m[1][0] >> 12) + (vec.y * m.m[1][1] >> 12) + (vec.z * m.m[1][2] >> 12);
+        res.z = (vec.x * m.m[2][0] >> 12) + (vec.y * m.m[2][1] >> 12) + (vec.z * m.m[2][2] >> 12);
+        instance->position.x = res.x + offset.x;
+        instance->position.y = res.y + offset.y;
+        instance->position.z = res.z + offset.z;
+    } else {
+        WORK_AS_IDX(char, instance->work8, 2) = 4;
+    }
+}
+
+void func_80162214_A5A44(Instance* instance, SVECTOR offset) {
+    MATRIX m;
+    SVECTOR vec;
+    SVECTOR res;
+
+    MATH3D_SetUnityMatrix(&m);
+    if (instance->rotation.z < 0) {
+        instance->rotation.z += 0x20;
+        RotMatrixZ(instance->rotation.z + instance->intro->rotation.z, &m);
+        vec.y = 0x40;
+        vec.x = 0;
+        vec.z = 0;
+        res.x = (vec.x * m.m[0][0] >> 12) + (vec.y * m.m[0][1] >> 12) + (vec.z * m.m[0][2] >> 12);
+        res.y = (vec.x * m.m[1][0] >> 12) + (vec.y * m.m[1][1] >> 12) + (vec.z * m.m[1][2] >> 12);
+        res.z = (vec.x * m.m[2][0] >> 12) + (vec.y * m.m[2][1] >> 12) + (vec.z * m.m[2][2] >> 12);
+        instance->position.x = res.x + offset.x;
+        instance->position.y = res.y + offset.y;
+        instance->position.z = res.z + offset.z;
+    } else {
+        WORK_AS_IDX(char, instance->work8, 2) = 0;
+    }
+}
+
+void func_801622E4_A5B14(GameTracker* arg0, short arg1, int arg2, Instance* arg3) {
+    Camera* camera;
+    int base;
+
+    camera = arg0->camera;
+    base = (int)arg3 + 0xC8;
+    func_8000B054(camera);
+    if ((arg1 != arg3->intro->rotation.z) ? !(arg3->_C4[4] & 2) : (arg3->_C4[4] & 2)) {
+        if (((short*)camera)[0x16 / 2] != 0) {
+            camera->smooth = 0;
+        } else {
+            camera->smooth = 0x1E;
+        }
+        camera->cameraKey = ((CameraKey*)(base + 0x3E));
+        ((int*)camera)[0x520 / 4] = base + 0x3E;
+        ((int*)camera)[0x3DC / 4] = 0;
+        ((int*)camera)[0x3E0 / 4] = 0;
+        CAMERA_SetMode(camera, 2);
+    } else {
+        if (((short*)camera)[0x16 / 2] != 0) {
+            camera->smooth = 0;
+        } else {
+            camera->smooth = 0x1E;
+        }
+        camera->cameraKey = ((CameraKey*)(base + 0x26));
+        ((int*)camera)[0x520 / 4] = base + 0x26;
+        ((int*)camera)[0x3DC / 4] = 0;
+        ((int*)camera)[0x3E0 / 4] = 0;
+        CAMERA_SetMode(camera, 2);
+    }
+}
 
 void func_801623DC_A5C0C(GameTracker* arg0, short arg1, int arg2, void* arg3) {
     Camera* camera;
@@ -1134,7 +1227,29 @@ int func_80162524_A5D54(short* arg0, short* arg1) {
     return result;
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/HORROR", func_8016257C_A5DAC);
+void func_8016257C_A5DAC(Instance* arg0, Instance* arg1) {
+    Camera* camera;
+
+    camera = gameTracker8->camera;
+    camera->smooth = 0;
+    camera->focusRotationX = ((unsigned short*)camera)[0x17A / 2];
+    if (func_80162524_A5D54((short*)camera, (short*)((int)arg1 + 0x106)) != 0) {
+        ((int*)camera)[0x520 / 4] = (int)arg0 + 0xEE;
+        camera->cameraKey = ((CameraKey*)((int)arg0 + 0xEE));
+        ((int*)camera)[0x3DC / 4] = 0;
+        ((int*)camera)[0x3E0 / 4] = 0;
+        CAMERA_SetMode(camera, 2);
+    } else if (func_80162524_A5D54((short*)camera, (short*)((int)arg1 + 0xEE)) != 0 || !(arg0->_C4[4] & 2)) {
+        ((int*)camera)[0x520 / 4] = (int)arg0 + 0x106;
+        camera->cameraKey = ((CameraKey*)((int)arg0 + 0x106));
+        ((int*)camera)[0x3DC / 4] = 0;
+        ((int*)camera)[0x3E0 / 4] = 0;
+        CAMERA_SetMode(camera, 2);
+    } else {
+        camera->lock &= ~4;
+        camera->lock &= ~2;
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/HORROR", horror_door_OnUpdate);
 

--- a/src/level/HORROR.c
+++ b/src/level/HORROR.c
@@ -1139,10 +1139,10 @@ void func_80162214_A5A44(Instance* instance, SVECTOR offset) {
 
 void func_801622E4_A5B14(GameTracker* arg0, short arg1, int arg2, Instance* arg3) {
     Camera* camera;
-    int base;
+    void* base;
 
     camera = arg0->camera;
-    base = (int)arg3 + 0xC8;
+    base = (void*)(&arg3->_C4[2]);
     func_8000B054(camera);
     if ((arg1 != arg3->intro->rotation.z) ? !(arg3->_C4[4] & 2) : (arg3->_C4[4] & 2)) {
         if (((short*)camera)[0x16 / 2] != 0) {
@@ -1150,8 +1150,7 @@ void func_801622E4_A5B14(GameTracker* arg0, short arg1, int arg2, Instance* arg3
         } else {
             camera->smooth = 0x1E;
         }
-        camera->cameraKey = ((CameraKey*)(base + 0x3E));
-        ((int*)camera)[0x520 / 4] = base + 0x3E;
+        ((CameraKey**)camera)[0x520 / 4] = camera->cameraKey = ((CameraKey*)(base + 0x3E));
         ((int*)camera)[0x3DC / 4] = 0;
         ((int*)camera)[0x3E0 / 4] = 0;
         CAMERA_SetMode(camera, 2);
@@ -1161,8 +1160,7 @@ void func_801622E4_A5B14(GameTracker* arg0, short arg1, int arg2, Instance* arg3
         } else {
             camera->smooth = 0x1E;
         }
-        camera->cameraKey = ((CameraKey*)(base + 0x26));
-        ((int*)camera)[0x520 / 4] = base + 0x26;
+        ((CameraKey**)camera)[0x520 / 4] = camera->cameraKey = ((CameraKey*)(base + 0x26));
         ((int*)camera)[0x3DC / 4] = 0;
         ((int*)camera)[0x3E0 / 4] = 0;
         CAMERA_SetMode(camera, 2);

--- a/src/level/KUNGFU.c
+++ b/src/level/KUNGFU.c
@@ -1059,7 +1059,107 @@ void kungfu_leafgen_OnCreate(Instance* instance, GameTracker* gameTracker) {
     p[7] = (rand() & 0xF) + 1;
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", func_801616D4_B08F4);
+typedef struct {
+    char _00[8];
+    void* next;
+    unsigned short flags;
+    short _0E;
+    void* callback;
+    void* _14;
+    int _18;
+    short posX;
+    short posY;
+    short posZ;
+    short _22;
+    unsigned short unk24;
+    short _26;
+    unsigned short unk28;
+    short _2A;
+    unsigned short unk2C;
+    short _2E;
+    unsigned short unk30;
+    short _32;
+    unsigned short unk34;
+    short _36;
+    unsigned short unk38;
+    short _3A;
+    unsigned short unk3C;
+    short _3E;
+    unsigned short unk40;
+    short _42;
+    short _44;
+    unsigned short _46;
+    unsigned short _48;
+    short _4A;
+    unsigned short _4C;
+    unsigned short _4E;
+    unsigned short _50;
+    unsigned short _52;
+    unsigned short _54;
+    unsigned short _56;
+    char _58[0x14];
+    unsigned short frame;
+} ParticleData;
+
+extern int D_80078244;
+extern int D_80078248;
+
+void func_801616D4_B08F4(ParticleData* p, void* callback, char* data, void* arg3, unsigned short* def, char* table, SVECTOR* pos, int arg7, int arg8, int arg9, unsigned short arg10) {
+    short* va;
+    short* vb;
+    short* vc;
+    int* nxt;
+    int i0;
+    int i1;
+    int i2;
+    unsigned short px0;
+
+    px0 = pos->x;
+    i0 = def[0];
+    i1 = def[1];
+    i2 = def[2];
+    va = (short*)(table + i0 * 12);
+    p->posX = px0;
+    p->posY = pos->y;
+    p->posZ = pos->z;
+    vb = (short*)(table + i2 * 12);
+    p->unk24 = (va[0] - vb[0]) * D_80078244;
+    p->_26 = (va[1] - vb[1]) * D_80078244;
+    vc = (short*)(table + i1 * 12);
+    p->unk28 = (va[2] - vb[2]) * D_80078244;
+    p->unk2C = (vc[0] - vb[0]) * D_80078244;
+    p->_2E = (vc[1] - vb[1]) * D_80078244;
+    p->unk30 = (vc[2] - vb[2]) * D_80078244;
+    p->unk34 = 0;
+    p->_36 = 0;
+    p->unk38 = 0;
+    if (((unsigned char*)def)[7] & 2) {
+        p->flags |= 1;
+        nxt = ((int**)def)[2];
+        p->next = nxt;
+        p->_18 = (nxt[3] & 0x3FFFFFF) | 0x24000000;
+    } else {
+        p->flags &= ~1;
+        p->_18 = (((int*)def)[2] & 0x3FFFFFF) | 0x20000000;
+    }
+    p->callback = callback;
+    p->_14 = data;
+    p->_4C = 0;
+    p->_4E = 0;
+    p->_50 = 0;
+    p->_52 = 0;
+    p->_54 = 0;
+    p->_0E = arg10;
+    p->_56 = D_80078248 - 2;
+    D_80078248 ^= 1;
+    p->_44 = (rand() & 0x3F) - 0x10;
+    p->_46 = (rand() & 0x3F) - 0x10;
+    p->_48 = (rand() & 0x3F) - 0x10;
+    MATH3D_SetUnityMatrix((char*)p->_14 + 0xC);
+    RotMatrixX(rand() & 0xFFF, (char*)p->_14 + 0xC);
+    RotMatrixY(rand() & 0xFFF, (char*)p->_14 + 0xC);
+    RotMatrixZ(rand() & 0xFFF, (char*)p->_14 + 0xC);
+}
 
 void func_80161944_B0B64(short* arg0) {
     func_800162C0(arg0);

--- a/src/level/KUNGFU.c
+++ b/src/level/KUNGFU.c
@@ -6,6 +6,7 @@
 #include "SPLINE.h"
 #include "SCRIPT.h"
 #include "OBTABLE.h"
+#include "MATRIX.h"
 
 
 extern int D_800E5FD8;
@@ -1112,7 +1113,55 @@ void kungfu_leafgen_OnUpdate(Instance* instance, GameTracker* gameTracker) {
     *(int*)&fc[10] = 0;
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", kungfu_leafgen_OnCollide);
+void kungfu_leafgen_OnCollide(Instance* instance, GameTracker* gameTracker) {
+    extern MATRIX* D_800E97C8;
+    extern SVECTOR D_800EB800;
+    BSPTree* bsp;
+    LVECTOR out;
+    short code;
+    int zv;
+
+    bsp = instance->bspTree;
+    if (bsp->instanceSpline == gameTracker->player) {
+        code = bsp->_06;
+        switch (code) {
+            case 4:
+                WORK_AS_IDX(short, instance->work1, 0) = bsp->globalOffset.x;
+                WORK_AS_IDX(short, instance->work1, 1) = bsp->globalOffset.y;
+                zv = (unsigned short)bsp->globalOffset.z;
+                instance->work5 = 1;
+                WORK_AS_IDX(short, instance->work2, 0) = zv;
+                break;
+            case 1:
+                switch (bsp->_04) {
+                    case 2:
+                        instance->work5 = code;
+                        break;
+                    case 1:
+                        if ((bsp->_08[4] - 7) < 3U) {
+                            MATH3D_ApplyMatrixT(D_800E97C8, &D_800EB800, &out);
+                            WORK_AS_IDX(short, instance->work1, 0) = out.x;
+                            WORK_AS_IDX(short, instance->work1, 1) = out.y;
+                            zv = out.z;
+                            instance->work5 = code;
+                            WORK_AS_IDX(short, instance->work2, 0) = zv;
+                        }
+                        break;
+                    case 5:
+                        if ((bsp->_08[2] - 7) < 3U) {
+                            MATH3D_ApplyMatrixT(D_800E97C8, &D_800EB800, &out);
+                            WORK_AS_IDX(short, instance->work1, 0) = out.x;
+                            WORK_AS_IDX(short, instance->work1, 1) = out.y;
+                            zv = out.z;
+                            instance->work5 = code;
+                            WORK_AS_IDX(short, instance->work2, 0) = zv;
+                        }
+                        break;
+                }
+                break;
+        }
+    }
+}
 
 extern int D_801626C0_B18E0[];
 void kungfu_funplat_OnCreate(Instance* instance, GameTracker* gameTracker) {

--- a/src/level/KUNGFU.c
+++ b/src/level/KUNGFU.c
@@ -1218,43 +1218,37 @@ void kungfu_leafgen_OnCollide(Instance* instance, GameTracker* gameTracker) {
     extern SVECTOR D_800EB800;
     BSPTree* bsp;
     LVECTOR out;
-    short code;
-    int zv;
 
     bsp = instance->bspTree;
     if (bsp->instanceSpline == gameTracker->player) {
-        code = bsp->_06;
-        switch (code) {
+        switch (bsp->_06) {
             case 4:
-                WORK_AS_IDX(short, instance->work1, 0) = bsp->globalOffset.x;
-                WORK_AS_IDX(short, instance->work1, 1) = bsp->globalOffset.y;
-                zv = (unsigned short)bsp->globalOffset.z;
+                WORK_AS(SVECTOR, instance->work1).x = bsp->globalOffset.x;
+                WORK_AS(SVECTOR, instance->work1).y = bsp->globalOffset.y;
+                WORK_AS(SVECTOR, instance->work1).z = bsp->globalOffset.z;
                 instance->work5 = 1;
-                WORK_AS_IDX(short, instance->work2, 0) = zv;
                 break;
             case 1:
                 switch (bsp->_04) {
                     case 2:
-                        instance->work5 = code;
+                        instance->work5 = 1;
                         break;
                     case 1:
                         if ((bsp->_08[4] - 7) < 3U) {
                             MATH3D_ApplyMatrixT(D_800E97C8, &D_800EB800, &out);
-                            WORK_AS_IDX(short, instance->work1, 0) = out.x;
-                            WORK_AS_IDX(short, instance->work1, 1) = out.y;
-                            zv = out.z;
-                            instance->work5 = code;
-                            WORK_AS_IDX(short, instance->work2, 0) = zv;
+                            WORK_AS(SVECTOR, instance->work1).x = out.x;
+                            WORK_AS(SVECTOR, instance->work1).y = out.y;
+                            WORK_AS(SVECTOR, instance->work1).z = out.z;
+                            instance->work5 = 1;
                         }
                         break;
                     case 5:
                         if ((bsp->_08[2] - 7) < 3U) {
                             MATH3D_ApplyMatrixT(D_800E97C8, &D_800EB800, &out);
-                            WORK_AS_IDX(short, instance->work1, 0) = out.x;
-                            WORK_AS_IDX(short, instance->work1, 1) = out.y;
-                            zv = out.z;
-                            instance->work5 = code;
-                            WORK_AS_IDX(short, instance->work2, 0) = zv;
+                            WORK_AS(SVECTOR, instance->work1).x = out.x;
+                            WORK_AS(SVECTOR, instance->work1).y = out.y;
+                            WORK_AS(SVECTOR, instance->work1).z = out.z;
+                            instance->work5 = 1;
                         }
                         break;
                 }

--- a/src/level/KUNGFU.c
+++ b/src/level/KUNGFU.c
@@ -1112,14 +1112,12 @@ void func_801616D4_B08F4(ParticleData* p, void* callback, char* data, void* arg3
     int i0;
     int i1;
     int i2;
-    unsigned short px0;
 
-    px0 = pos->x;
     i0 = def[0];
     i1 = def[1];
     i2 = def[2];
     va = (short*)(table + i0 * 12);
-    p->posX = px0;
+    p->posX = pos->x;
     p->posY = pos->y;
     p->posZ = pos->z;
     vb = (short*)(table + i2 * 12);

--- a/src/level/LOONEY.c
+++ b/src/level/LOONEY.c
@@ -500,7 +500,65 @@ void looney_leafgen_OnCreate(Instance* instance, GameTracker* gameTracker) {
     p[7] = (rand() & 0xF) + 1;
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/LOONEY", func_8015B934_B3BE4);
+extern int D_80078244;
+extern int D_80078248;
+
+void func_8015B934_B3BE4(ParticleData* p, void* callback, char* data, void* arg3, unsigned short* def, char* table, SVECTOR* pos, int arg7, int arg8, int arg9, unsigned short arg10) {
+    short* va;
+    short* vb;
+    short* vc;
+    int* nxt;
+    int i0;
+    int i1;
+    int i2;
+    unsigned short px0;
+
+    px0 = pos->x;
+    i0 = def[0];
+    i1 = def[1];
+    i2 = def[2];
+    va = (short*)(table + i0 * 12);
+    p->posX = px0;
+    p->posY = pos->y;
+    p->posZ = pos->z;
+    vb = (short*)(table + i2 * 12);
+    p->unk24 = (va[0] - vb[0]) * D_80078244;
+    p->_26 = (va[1] - vb[1]) * D_80078244;
+    vc = (short*)(table + i1 * 12);
+    p->unk28 = (va[2] - vb[2]) * D_80078244;
+    p->unk2C = (vc[0] - vb[0]) * D_80078244;
+    p->_2E = (vc[1] - vb[1]) * D_80078244;
+    p->unk30 = (vc[2] - vb[2]) * D_80078244;
+    p->unk34 = 0;
+    p->_36 = 0;
+    p->unk38 = 0;
+    if (((unsigned char*)def)[7] & 2) {
+        p->flags |= 1;
+        nxt = ((int**)def)[2];
+        p->next = nxt;
+        p->_18 = (nxt[3] & 0x3FFFFFF) | 0x24000000;
+    } else {
+        p->flags &= ~1;
+        p->_18 = (((int*)def)[2] & 0x3FFFFFF) | 0x20000000;
+    }
+    p->callback = callback;
+    p->_14 = data;
+    p->_4C = 0;
+    p->_4E = 0;
+    p->_50 = 0;
+    p->_52 = 0;
+    p->_54 = 0;
+    p->_0E = arg10;
+    p->_56 = D_80078248 - 2;
+    D_80078248 ^= 1;
+    p->_44 = (rand() & 0x3F) - 0x10;
+    p->_46 = (rand() & 0x3F) - 0x10;
+    p->_48 = (rand() & 0x3F) - 0x10;
+    MATH3D_SetUnityMatrix((char*)p->_14 + 0xC);
+    RotMatrixX(rand() & 0xFFF, (char*)p->_14 + 0xC);
+    RotMatrixY(rand() & 0xFFF, (char*)p->_14 + 0xC);
+    RotMatrixZ(rand() & 0xFFF, (char*)p->_14 + 0xC);
+}
 
 void func_8015BBA4_B3E54(short* arg0) {
     func_800162C0(arg0);

--- a/src/level/LOONEY.c
+++ b/src/level/LOONEY.c
@@ -554,7 +554,55 @@ void looney_leafgen_OnUpdate(Instance* instance, GameTracker* gameTracker) {
     *(int*)&fc[10] = 0;
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/LOONEY", looney_leafgen_OnCollide);
+void looney_leafgen_OnCollide(Instance* instance, GameTracker* gameTracker) {
+    extern MATRIX* D_800E97C8;
+    extern SVECTOR D_800EB800;
+    BSPTree* bsp;
+    LVECTOR out;
+    short code;
+    int zv;
+
+    bsp = instance->bspTree;
+    if (bsp->instanceSpline == gameTracker->player) {
+        code = bsp->_06;
+        switch (code) {
+            case 4:
+                WORK_AS_IDX(short, instance->work1, 0) = bsp->globalOffset.x;
+                WORK_AS_IDX(short, instance->work1, 1) = bsp->globalOffset.y;
+                zv = (unsigned short)bsp->globalOffset.z;
+                instance->work5 = 1;
+                WORK_AS_IDX(short, instance->work2, 0) = zv;
+                break;
+            case 1:
+                switch (bsp->_04) {
+                    case 2:
+                        instance->work5 = code;
+                        break;
+                    case 1:
+                        if ((bsp->_08[4] - 7) < 3U) {
+                            MATH3D_ApplyMatrixT(D_800E97C8, &D_800EB800, &out);
+                            WORK_AS_IDX(short, instance->work1, 0) = out.x;
+                            WORK_AS_IDX(short, instance->work1, 1) = out.y;
+                            zv = out.z;
+                            instance->work5 = code;
+                            WORK_AS_IDX(short, instance->work2, 0) = zv;
+                        }
+                        break;
+                    case 5:
+                        if ((bsp->_08[2] - 7) < 3U) {
+                            MATH3D_ApplyMatrixT(D_800E97C8, &D_800EB800, &out);
+                            WORK_AS_IDX(short, instance->work1, 0) = out.x;
+                            WORK_AS_IDX(short, instance->work1, 1) = out.y;
+                            zv = out.z;
+                            instance->work5 = code;
+                            WORK_AS_IDX(short, instance->work2, 0) = zv;
+                        }
+                        break;
+                }
+                break;
+        }
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/LOONEY", looney_funguy_OnCreate);
 

--- a/src/level/LOONEY.c
+++ b/src/level/LOONEY.c
@@ -662,7 +662,33 @@ void looney_leafgen_OnCollide(Instance* instance, GameTracker* gameTracker) {
     }
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/LOONEY", looney_funguy_OnCreate);
+extern int D_80161C34_B9EE4[];
+
+void looney_funguy_OnCreate(Instance* instance, GameTracker* gameTracker) {
+    int* intro = ((int*)instance->introData);
+    long* fca = &instance->work0;
+
+    if (instance->flags & 0x20000) {
+        if (intro != NULL) {
+            *intro = instance->work5;
+        }
+    } else {
+        if (instance->object->data == NULL) {
+            fca[0] = (long)D_80161C34_B9EE4;
+        }
+        else {
+            fca[0] = (long)instance->object->data;
+        }
+
+        if (intro != NULL) {
+            fca[5] = *intro;
+        } else {
+            fca[5]  = (long)((Instance*)((Instance*)fca)->node.prev)->matrix;
+        }
+
+        instance->flags |= 0x10000;
+    }
+}
 
 
 INCLUDE_ASM("asm/nonmatchings/level/LOONEY", func_8015BFCC_B427C);

--- a/src/level/LOONEY.c
+++ b/src/level/LOONEY.c
@@ -511,14 +511,12 @@ void func_8015B934_B3BE4(ParticleData* p, void* callback, char* data, void* arg3
     int i0;
     int i1;
     int i2;
-    unsigned short px0;
 
-    px0 = pos->x;
     i0 = def[0];
     i1 = def[1];
     i2 = def[2];
     va = (short*)(table + i0 * 12);
-    p->posX = px0;
+    p->posX = pos->x;
     p->posY = pos->y;
     p->posZ = pos->z;
     vb = (short*)(table + i2 * 12);

--- a/src/level/LOONEY.c
+++ b/src/level/LOONEY.c
@@ -617,43 +617,37 @@ void looney_leafgen_OnCollide(Instance* instance, GameTracker* gameTracker) {
     extern SVECTOR D_800EB800;
     BSPTree* bsp;
     LVECTOR out;
-    short code;
-    int zv;
 
     bsp = instance->bspTree;
     if (bsp->instanceSpline == gameTracker->player) {
-        code = bsp->_06;
-        switch (code) {
+        switch (bsp->_06) {
             case 4:
-                WORK_AS_IDX(short, instance->work1, 0) = bsp->globalOffset.x;
-                WORK_AS_IDX(short, instance->work1, 1) = bsp->globalOffset.y;
-                zv = (unsigned short)bsp->globalOffset.z;
+                WORK_AS(SVECTOR, instance->work1).x = bsp->globalOffset.x;
+                WORK_AS(SVECTOR, instance->work1).y = bsp->globalOffset.y;
+                WORK_AS(SVECTOR, instance->work1).z = bsp->globalOffset.z;
                 instance->work5 = 1;
-                WORK_AS_IDX(short, instance->work2, 0) = zv;
                 break;
             case 1:
                 switch (bsp->_04) {
                     case 2:
-                        instance->work5 = code;
+                        instance->work5 = 1;
                         break;
                     case 1:
                         if ((bsp->_08[4] - 7) < 3U) {
                             MATH3D_ApplyMatrixT(D_800E97C8, &D_800EB800, &out);
-                            WORK_AS_IDX(short, instance->work1, 0) = out.x;
-                            WORK_AS_IDX(short, instance->work1, 1) = out.y;
-                            zv = out.z;
-                            instance->work5 = code;
-                            WORK_AS_IDX(short, instance->work2, 0) = zv;
+                            WORK_AS(SVECTOR, instance->work1).x = out.x;
+                            WORK_AS(SVECTOR, instance->work1).y = out.y;
+                            WORK_AS(SVECTOR, instance->work1).z = out.z;
+                            instance->work5 = 1;
                         }
                         break;
                     case 5:
                         if ((bsp->_08[2] - 7) < 3U) {
                             MATH3D_ApplyMatrixT(D_800E97C8, &D_800EB800, &out);
-                            WORK_AS_IDX(short, instance->work1, 0) = out.x;
-                            WORK_AS_IDX(short, instance->work1, 1) = out.y;
-                            zv = out.z;
-                            instance->work5 = code;
-                            WORK_AS_IDX(short, instance->work2, 0) = zv;
+                            WORK_AS(SVECTOR, instance->work1).x = out.x;
+                            WORK_AS(SVECTOR, instance->work1).y = out.y;
+                            WORK_AS(SVECTOR, instance->work1).z = out.z;
+                            instance->work5 = 1;
                         }
                         break;
                 }

--- a/src/level/MOOSHU.c
+++ b/src/level/MOOSHU.c
@@ -448,7 +448,24 @@ void func_8015D084_C5A04(Instance* instance, GameTracker* gameTracker) {
     fc[4] = 0x28;
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/MOOSHU", func_8015D190_C5B10);
+void func_8015D190_C5B10(Instance* instance) {
+    int* data = instance->intro->data;
+    Intro** cur;
+    short i;
+
+    if (OBTABLE_FindObject("moodam__") != 0) {
+        cur = (Intro**)(data + 2);
+        i = 0;
+        if (data[1] > 0) {
+            do {
+                (*cur)->flags &= ~8;
+                func_8002E21C(*cur);
+                cur += 1;
+                i += 1;
+            } while (i < data[1]);
+        }
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/MOOSHU", func_8015D240_C5BC0);
 

--- a/src/level/MOOSHU.c
+++ b/src/level/MOOSHU.c
@@ -450,19 +450,14 @@ void func_8015D084_C5A04(Instance* instance, GameTracker* gameTracker) {
 
 void func_8015D190_C5B10(Instance* instance) {
     int* data = instance->intro->data;
-    Intro** cur;
+    Intro** pIntro;
     short i;
 
-    if (OBTABLE_FindObject("moodam__") != 0) {
-        cur = (Intro**)(data + 2);
-        i = 0;
-        if (data[1] > 0) {
-            do {
-                (*cur)->flags &= ~8;
-                func_8002E21C(*cur);
-                cur += 1;
-                i += 1;
-            } while (i < data[1]);
+    if (OBTABLE_FindObject("moodam__") != NULL) {
+        pIntro = (Intro**)(data + 2);
+        for (i = 0; i < data[1]; pIntro++, i++) {
+            (*pIntro)->flags &= ~8;
+            func_8002E21C(*pIntro);
         }
     }
 }

--- a/src/level/RTA.c
+++ b/src/level/RTA.c
@@ -32,7 +32,32 @@ void rta_zgrate_OnUpdate(Instance* instance, GameTracker* gameTracker) {
     }
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/RTA", rta_zshark_OnCreate);
+typedef struct {
+    int x, y, z, pad;
+} SharkVector;
+
+void rta_zshark_OnCreate(Instance* instance, GameTracker* gameTracker) {
+    extern SharkVector D_8015EE40_DF4B0;
+    SharkVector v;
+    MATRIX m;
+    LVECTOR out;
+    int f;
+
+    v = D_8015EE40_DF4B0;
+    f = instance->flags;
+    if (!(f & 0x20000)) {
+        instance->flags = f | 0x10400;
+        func_8003E758(&instance->rotation, &m);
+        MATH3D_ApplyMatrixLV(&m, ((LVECTOR*)&v), &out);
+        instance->currentModelAnim = 0;
+        instance->work0 = 0;
+        instance->work1 = 0;
+        instance->work6 = instance->position.x + out.x;
+        instance->work7 = instance->position.y + out.y;
+        instance->work8 = instance->position.z + out.z;
+        instance->work9 = 0;
+    }
+}
 
 INCLUDE_RODATA("asm/nonmatchings/level/RTA", D_8015ED10_DF380);
 
@@ -329,7 +354,26 @@ void rta_zwleak_OnUpdate(Instance* instance, GameTracker* gameTracker) {
     func_8015A2B0_DA920(instance, 0x9C4);
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/RTA", rta_zwleak_OnCollide);
+extern void func_8000B054();
+extern void func_800256A8();
+
+void rta_zwleak_OnCollide(Instance* instance, GameTracker* gameTracker) {
+    Instance* player;
+    short* d;
+
+    player = gameTracker->player;
+    d = ((short*)player->data);
+    d[0x8C / 2] = instance->work5 * instance->work1 >> 12;
+    d[0x8E / 2] = instance->work6 * instance->work1 >> 12;
+    d[0x90 / 2] = 0;
+    d[0x98 / 2] = 0;
+    d[0x94 / 2] = -(d[0x8C / 2] / 15);
+    d[0x96 / 2] = -(d[0x8E / 2] / 15);
+    if (player->currentMainState == 4) {
+        func_8000B054(gameTracker->camera);
+    }
+    func_800256A8(gameTracker);
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/RTA", func_8015B1D4_DB844);
 

--- a/src/level/RTA.c
+++ b/src/level/RTA.c
@@ -333,7 +333,32 @@ INCLUDE_ASM("asm/nonmatchings/level/RTA", rta_zwleak_OnCollide);
 
 INCLUDE_ASM("asm/nonmatchings/level/RTA", func_8015B1D4_DB844);
 
-INCLUDE_ASM("asm/nonmatchings/level/RTA", func_8015B4EC_DBB5C);
+void func_8015B4EC_DBB5C(short* arg0, int arg1) {
+    extern int D_8015EF1C_DF58C;
+    int x;
+    int a3;
+
+    x = arg0[0x20 / 2];
+    a3 = x + arg0[0x50 / 2] + arg0[0x56 / 2];
+    if (D_8015EF1C_DF58C < a3) {
+        ((unsigned short*)arg0)[0x52 / 2] += ((unsigned short*)arg0)[0x52 / 2] * 2;
+        a3 = D_8015EF1C_DF58C - arg0[0x20 / 2];
+        ((unsigned short*)arg0)[0x54 / 2] += ((unsigned short*)arg0)[0x54 / 2] * 2;
+        if (a3 > 0) {
+            arg0[0x50 / 2] = a3;
+            if (arg0[0xE / 2] >= 5) {
+                arg0[0xE / 2] = 4;
+            }
+        } else {
+            arg0[0xE / 2] = 0;
+        }
+    } else if (arg0[0x50 / 2] < 0) {
+        if (arg0[0xE / 2] >= 4) {
+            arg0[0xE / 2] = 3;
+        }
+    }
+    func_800162C0(arg0, arg1);
+}
 
 extern char D_8015EE74_DF4E4[];
 

--- a/src/level/RTA.c
+++ b/src/level/RTA.c
@@ -32,13 +32,9 @@ void rta_zgrate_OnUpdate(Instance* instance, GameTracker* gameTracker) {
     }
 }
 
-typedef struct {
-    int x, y, z, pad;
-} SharkVector;
-
 void rta_zshark_OnCreate(Instance* instance, GameTracker* gameTracker) {
-    extern SharkVector D_8015EE40_DF4B0;
-    SharkVector v;
+    extern LVector D_8015EE40_DF4B0;
+    LVector v;
     MATRIX m;
     LVECTOR out;
 

--- a/src/level/RTA.c
+++ b/src/level/RTA.c
@@ -41,20 +41,18 @@ void rta_zshark_OnCreate(Instance* instance, GameTracker* gameTracker) {
     SharkVector v;
     MATRIX m;
     LVECTOR out;
-    int f;
 
     v = D_8015EE40_DF4B0;
-    f = instance->flags;
-    if (!(f & 0x20000)) {
-        instance->flags = f | 0x10400;
+    if (!(instance->flags & 0x20000)) {
+        instance->flags |= 0x10400;
         func_8003E758(&instance->rotation, &m);
         MATH3D_ApplyMatrixLV(&m, ((LVECTOR*)&v), &out);
         instance->currentModelAnim = 0;
         instance->work0 = 0;
         instance->work1 = 0;
-        instance->work6 = instance->position.x + out.x;
-        instance->work7 = instance->position.y + out.y;
-        instance->work8 = instance->position.z + out.z;
+        WORK_AS(LVECTOR, instance->work6).x = instance->position.x + out.x;
+        WORK_AS(LVECTOR, instance->work6).y = instance->position.y + out.y;
+        WORK_AS(LVECTOR, instance->work6).z = instance->position.z + out.z;
         instance->work9 = 0;
     }
 }


### PR DESCRIPTION
## Summary

18 functions decompiled and byte-matched across 7 level files. Full clean build (`make clean && make split && make build && make diff`) passes: **No differences found.**

Closes #130, closes #132.

## Functions

| File | Function | Insns | Notes |
|------|----------|-------|-------|
| KUNGFU.c | kungfu_leafgen_OnCollide | 79 | twin of looney |
| LOONEY.c | looney_leafgen_OnCollide | 79 | |
| LOONEY.c | func_8015B934_B3BE4 | 156 | leaf-debris per-face init |
| KUNGFU.c | func_801616D4_B08F4 | 156 | twin of the above |
| MOOSHU.c | func_8015D190_C5B10 | 44 | moodam intro-flag scan loop |
| RTA.c | func_8015B4EC_DBB5C | 47 | particle ground-bounce callback |
| HORROR.c | func_80162024_A5854 | 61 | rotation transform, vec=(0,-0x40,0) |
| HORROR.c | func_80162118_A5948 | 63 | rotation transform |
| HORROR.c | func_80162214_A5A44 | 52 | rotation transform, vec=(0,0x40,0) |
| HORROR.c | func_801622E4_A5B14 | 62 | camera-key switcher |
| HORROR.c | func_8016257C_A5DAC | 52 | camera-key prober |
| RTA.c | rta_zshark_OnCreate | 58 | matrix transform into work6-8 |
| RTA.c | rta_zwleak_OnCollide | 60 | player-data impulse writeback |
| FINAL.c | func_8015CB70_8DD10 | 61 | Target X/Y/Z debug print |
| FINAL.c | func_8015CC64_8DE04 | 60 | Position X/Y/Z debug print |
| FINAL.c | final_finaltv_OnUpdate | 44 | from your #130 solution |
| LOONEY.c | looney_funguy_OnCreate | 38 | from your #130 solution |
| CIRCUIT.c | circuit_orbplat_OnCreate | 60 | from your #132 solution (+`(short)` casts for our implicit sin/cos decls) |

## Techniques

- **Store-forced reloads**: a store through the same base pointer earlier in source order kills cse's memory equivalence even for provably distinct constant offsets, producing the genuine second load of an already-read field; the scheduler then hoists the reload back above the store, so the ROM shows reload-then-store order (func_8015B4EC, orbplat).
- **Callee declarations flip mflo ties**: implicit-int callees reserve a phantom $v0 return pseudo per call; declaring them `extern void` freed $v0 and snapped rta_zwleak's product temps into place.
- **Scheduler alias pinning**: array-index loads are marked in-struct and hoist over scalar-global stores; the raw-deref spelling (`*(short*)((char*)p + 0x3C)`) pins them below, preserving the pre-jal hazard nops in the FINAL print twins. Commented in the code.
- **Scalar/array extern split**: `D_800BDEE4` must be its own scalar extern (per-store assembler-macro `sw`) while `D_800BDEE0` stays array-indexed (cached base register) — the two relocation styles coexist in one function.
- **Camera-key cluster**: ternary conditions with per-arm flag tests, duplicated store tails merged by cross-jump, two-statement mask clears for `lock &= ~4; lock &= ~2;`, and a base pointer kept live across `func_8000B054` (a call between def and use blocks the constant-chain fold).