### PR TITLE
Decompile ~30 level functions (census sweep: init/collide/spawn/state-machine handlers)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-splat64[mips]>=0.38.0
+splat64[mips]>=0.38.0,<0.42.0
 spimdisasm>=1.40.1

--- a/src/level/CIRCUIT.c
+++ b/src/level/CIRCUIT.c
@@ -364,7 +364,27 @@ void func_8015C18C_8336C(Instance* instance, int val) {
     }
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/CIRCUIT", circuit_orbplat_OnCreate);
+void circuit_orbplat_OnCreate(Instance* instance, GameTracker* gameTracker) {
+    short* data = ((short*)instance->object->data);
+
+    instance->work0 = -0x400;
+    instance->work8 = 0x320;
+
+    if (data != 0) {
+        instance->work8 = data[0];
+    }
+
+    instance->initialPos.x = ((Intro**)instance->intro->_04)[2]->position.x + (instance->work8 * ((short)func_8003A6AC(instance->work0)) >> 12);
+    instance->initialPos.y = ((Intro**)instance->intro->_04)[2]->position.y + (instance->work8 * ((short)func_8003A4E0(instance->work0)) >> 12);
+
+    instance->work4 = instance->work8;
+    instance->work5 = 0;
+    instance->work6 = 0x20;
+    instance->work7 = 0x38;
+
+    instance->currentSubState = 0;
+    instance->currentMainState = 1;
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/CIRCUIT", circuit_orbplat_OnUpdate);
 

--- a/src/level/CIRCUIT.c
+++ b/src/level/CIRCUIT.c
@@ -578,7 +578,40 @@ void circuit_follow_OnCreate(Instance* instance, GameTracker* gameTracker) {
     instance->flags |= 0x100800;
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/CIRCUIT", circuit_follow_OnUpdate);
+void func_8015D780_84960(Instance* instance, GameTracker* gameTracker);
+
+void circuit_follow_OnUpdate(Instance* instance, GameTracker* gameTracker) {
+    int state;
+    int* v;
+
+    if (instance->intro->flags & 0x80) {
+        instance->flags &= ~0x400;
+        return;
+    }
+    instance->flags |= 0x400;
+    if (instance->work0 > 0) {
+        instance->work0 -= 1;
+    }
+    state = instance->currentMainState;
+    if (state == 1) {
+        func_8015D780_84960(instance, gameTracker);
+    } else if (state == -1) {
+        if (func_800257B4(gameTracker->player) != 0) {
+            v = ((int*)instance->introData);
+            if (v != 0 && v[0] == 3) {
+                if (v[3] != 0) {
+                    SIGNAL_HandleSignal(instance, v[3] + 4, 0);
+                }
+            }
+            instance->currentMainState = 0;
+        } else {
+            gameTracker->player->flags |= 0x100;
+        }
+    }
+    if (instance->currentMainState > 0) {
+        instance->currentMainState = instance->currentMainState + 1;
+    }
+}
 
 void circuit_follow_OnCollide(Instance* instance, GameTracker* gameTracker) {
     Instance* player;

--- a/src/level/CIRCUIT.c
+++ b/src/level/CIRCUIT.c
@@ -5,6 +5,8 @@
 #include "types/intro/QMark.h"
 #include "types/intro/BTimer.h"
 #include "types/G2String.h"
+#include "INSTANCE.h"
+#include "SPLINE.h"
 
 #include "types/Vector.h"
 extern int D_800E5FD8;
@@ -650,7 +652,41 @@ void circuit_pball_OnCreate(Instance* instance, GameTracker* gameTracker)
     instance->flags |= 0x100000;
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/CIRCUIT", func_8015D7F0_849D0);
+extern char D_801635F8_8A7D8[];
+
+void func_8015D7F0_849D0(Instance* instance) {
+    Intro** v1;
+    Instance* obj;
+    SVECTOR* pt;
+    int spline2;
+
+    v1 = (Intro**)instance->intro->_04 + 1;
+    if (v1[0]->multiSpline != NULL) {
+        obj = INSTANCE_BirthCachedObject(instance, 0x1C);
+        if (obj != NULL) {
+            if (G2String_Compare_EQ(instance->object->name, D_801635F8_8A7D8)) {
+                obj->flags |= 0x800;
+                INSTANCE_InsertInstanceWithFlagsCleared(obj, 0xF000);
+            }
+            obj->work4 = 0;
+            pt = SplineGetFirstPoint(((Spline**)v1[0]->multiSpline)[0], (SplineDef*)&obj->work0);
+            if (pt != NULL) {
+                obj->position.x = pt->x;
+                obj->position.y = pt->y;
+                obj->position.z = pt->z;
+            }
+            spline2 = ((int*)v1[0]->multiSpline)[0x8/4];
+            if (spline2 != 0) {
+                pt = SplineGetFirstPoint((Spline*)spline2, (SplineDef*)&obj->work2);
+                if (pt != NULL) {
+                    obj->scale.x = pt->x;
+                    obj->scale.y = pt->y;
+                    obj->scale.z = pt->z;
+                }
+            }
+        }
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/CIRCUIT", circuit_pball_OnUpdate);
 

--- a/src/level/CIRCUIT.c
+++ b/src/level/CIRCUIT.c
@@ -629,7 +629,62 @@ void circuit_pball_OnCollide(Instance* instance, GameTracker* gameTracker) {
     }
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/CIRCUIT", func_8015DB80_84D60);
+void func_8015DB80_84D60(Instance* instance) {
+    int* d;
+    int* sd;
+    int* intro2;
+    int* skip;
+    unsigned short* len;
+    Intro** cur;
+    int t2;
+    int n;
+    int frame;
+    int j;
+    int sum;
+    int end;
+    int unused[2];
+
+    skip = 0;
+    d = ((int*)instance->intro->_04);
+    sum = 0;
+    n = d[0] - 1;
+    if (((Intro**)d)[1]->multiSpline != 0) {
+        sd = ((int**)((Intro**)d)[1]->multiSpline)[0];
+        intro2 = ((int*)((Intro**)d)[2]->instance->introData);
+        t2 = intro2[0];
+        len = ((unsigned short**)sd)[0];
+        cur = ((Intro**)(d + 2));
+        if (t2 != 0) {
+            skip = intro2 + 4;
+        }
+        frame = 0;
+        j = 0;
+        if (n > 0) {
+loop:
+            if (frame < ((short*)sd)[2]) {
+                if (t2 != 0 && frame == skip[0]) {
+                    end = frame + skip[1];
+                    if (frame < end) {
+                        do {
+                            sum += len[0];
+                            len += 0x20 / 2;
+                        } while (++frame < end);
+                    }
+                    skip += 2;
+                }
+                j++;
+                (*cur)->instance->work3 = ((short)sum);
+                cur++;
+                frame++;
+                sum += len[0];
+                len += 0x20 / 2;
+                if (j < n) {
+                    goto loop;
+                }
+            }
+        }
+    }
+}
 
 void circuit_ppath_OnCreate(Instance* instance, GameTracker* gameTracker) {
     Model* model;

--- a/src/level/FINAL.c
+++ b/src/level/FINAL.c
@@ -601,7 +601,23 @@ void final_finaltv_OnCreate(Instance* instance, GameTracker* gameTracker) {
     instance->work0 = 30;
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/FINAL", final_finaltv_OnUpdate);
+void final_finaltv_OnUpdate(Instance* instance, GameTracker* gameTracker) {
+    if (instance->work0 > 0) {
+        instance->work0--;
+        return;
+    }
+
+    instance->work0--;
+
+    if (instance->work0 == -0x21) {
+        func_80050508(instance, 0x154, 0, 0x7F, 0x4E20);
+    }
+    instance->_D0[2] += instance->_E0[1];
+    if (instance->_F0 < abs(instance->_D0[2])) {
+        instance->_D0[2] = instance->_D0[2] < 0 ? -instance->_F0 : instance->_F0;
+    }
+    instance->position.z += instance->_D0[2];
+}
 
 
 void final_finaltv_OnCollide(Instance* instance, GameTracker* gameTracker) {

--- a/src/level/FINAL.c
+++ b/src/level/FINAL.c
@@ -472,6 +472,8 @@ void func_8015CB70_8DD10(Instance* instance, GameTracker* gameTracker, int count
     short* p;
     int c;
 
+    /* raw derefs below (not p[i]) keep the loads under the coordinate
+       stores in the schedule; the index form hoists them */
     p = WORK_AS(short*, instance->work0);
     if (count >= 0x29) {
         c = 0x64;
@@ -509,6 +511,7 @@ void func_8015CC64_8DE04(Instance* instance, GameTracker* gameTracker, int count
     char buf[16];
     int c;
 
+    /* raw position derefs: same scheduling pin as func_8015CB70 */
     c = 0x96;
     if (count >= 0x29) {
         D_800BDEE0[0] = 0xDC;

--- a/src/level/FINAL.c
+++ b/src/level/FINAL.c
@@ -461,7 +461,40 @@ void func_8015CB34_8DCD4(char* buf, short val) {
 
 INCLUDE_RODATA("asm/nonmatchings/level/FINAL", D_801615B8_92758);
 
-INCLUDE_ASM("asm/nonmatchings/level/FINAL", func_8015CB70_8DD10);
+extern int D_800BDEE0[];
+extern int D_800BDEE4;
+
+void func_8015CB70_8DD10(Instance* instance, GameTracker* gameTracker, int count) {
+    extern char D_801615C8_92768[];
+    extern char D_801615D0_92770[];
+    extern char D_801615D8_92778[];
+    char buf[16];
+    short* p;
+    int c;
+
+    p = WORK_AS(short*, instance->work0);
+    if (count >= 0x29) {
+        c = 0x64;
+        D_800BDEE0[0] = 0xDC;
+        D_800BDEE4 = c;
+        osSyncPrintf("Target");
+        c = 0x6C;
+        D_800BDEE0[0] = 0xDC;
+        D_800BDEE4 = c;
+        func_8015CB34_8DCD4(buf, *(short*)((char*)p + 0x3C));
+        osSyncPrintf(D_801615C8_92768, buf);
+        c = 0x74;
+        D_800BDEE0[0] = 0xDC;
+        D_800BDEE4 = c;
+        func_8015CB34_8DCD4(buf, *(short*)((char*)p + 0x3E));
+        osSyncPrintf(D_801615D0_92770, buf);
+        c = 0x7C;
+        D_800BDEE0[0] = 0xDC;
+        D_800BDEE4 = c;
+        func_8015CB34_8DCD4(buf, *(short*)((char*)p + 0x40));
+        osSyncPrintf(D_801615D8_92778, buf);
+    }
+}
 
 INCLUDE_RODATA("asm/nonmatchings/level/FINAL", D_801615C8_92768); // X %s
 
@@ -469,7 +502,35 @@ INCLUDE_RODATA("asm/nonmatchings/level/FINAL", D_801615D0_92770); // Y %s
 
 INCLUDE_RODATA("asm/nonmatchings/level/FINAL", D_801615D8_92778); // Z %s
 
-INCLUDE_ASM("asm/nonmatchings/level/FINAL", func_8015CC64_8DE04);
+void func_8015CC64_8DE04(Instance* instance, GameTracker* gameTracker, int count) {
+    extern char D_801615C8_92768[];
+    extern char D_801615D0_92770[];
+    extern char D_801615D8_92778[];
+    char buf[16];
+    int c;
+
+    c = 0x96;
+    if (count >= 0x29) {
+        D_800BDEE0[0] = 0xDC;
+        D_800BDEE4 = c;
+        osSyncPrintf("Position");
+        c = 0x9E;
+        D_800BDEE0[0] = 0xDC;
+        D_800BDEE4 = c;
+        func_8015CB34_8DCD4(buf, *(short*)((char*)instance + 0x48));
+        osSyncPrintf(D_801615C8_92768, buf);
+        c = 0xA6;
+        D_800BDEE0[0] = 0xDC;
+        D_800BDEE4 = c;
+        func_8015CB34_8DCD4(buf, *(short*)((char*)instance + 0x4A));
+        osSyncPrintf(D_801615D0_92770, buf);
+        c = 0xAE;
+        D_800BDEE0[0] = 0xDC;
+        D_800BDEE4 = c;
+        func_8015CB34_8DCD4(buf, *(short*)((char*)instance + 0x4C));
+        osSyncPrintf(D_801615D8_92778, buf);
+    }
+}
 
 extern int D_800BDEE0[5];
 

--- a/src/level/FINAL.c
+++ b/src/level/FINAL.c
@@ -53,7 +53,39 @@ void final_lectro_OnCreate(Instance* instance, GameTracker* gameTracker) {
     }
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/FINAL", final_lectro_OnUpdate);
+void final_lectro_OnUpdate(Instance* instance, GameTracker* gameTracker) {
+    if (instance->intro->_2C != 0) {
+        if (func_80033268(0x147) == 0) {
+            func_80050508(instance, 0x147, 0, 0x5A, 0x2710);
+        }
+        instance->currentMainState = 2;
+    }
+    switch (instance->currentMainState) {
+    case 0:
+        if (instance->work0 != 0) {
+            if (func_80033248(instance->work0) != 0) {
+                if (func_80033200(instance->work0) != 0 && func_800506B8(instance, instance->work0, 0, 0x46, 0x2710) == 0) {
+                    func_800331BC(instance->work0);
+                    instance->work0 = 0;
+                }
+            } else {
+                instance->work0 = func_80050508(instance, 0x148, 0, 0x46, 0x2710);
+            }
+        } else {
+            instance->work0 = func_80050508(instance, 0x148, 0, 0x46, 0x2710);
+        }
+        instance->currentTextureAnimFrame += 1;
+        if (instance->currentTextureAnimFrame == 6) {
+            instance->currentTextureAnimFrame = 0;
+            return;
+        }
+    case 1:
+        return;
+    case 2:
+        func_8002E350(instance);
+        break;
+    }
+}
 
 void final_lectro_OnCollide(Instance* instance, GameTracker* gameTracker) {
 }

--- a/src/level/FINAL.c
+++ b/src/level/FINAL.c
@@ -2,6 +2,7 @@
 
 #include "level/FINAL.h"
 #include "types/G2String.h"
+#include "OBTABLE.h"
 
 extern int D_80161510_926B0;
 
@@ -126,8 +127,8 @@ extern char D_80161588_92728[];
 
 void final_rezbomb_OnCreate(Instance* instance, GameTracker* gameTracker) {
     *(short*)&instance->_E0[0] = 0;
-    instance->currentMainState = OBTABLE_FindObject(D_80161588_92728);
-    instance->currentSubState = OBTABLE_FindObject("rezxpl__");
+    instance->currentMainState = ((int)OBTABLE_FindObject(D_80161588_92728));
+    instance->currentSubState = ((int)OBTABLE_FindObject("rezxpl__"));
 }
 
 typedef struct {
@@ -551,11 +552,103 @@ void func_8015CD54_8DEF4(int arg0, int arg1, int count) {
     }
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/FINAL", func_8015CDF0_8DF90);
+void func_8015CDF0_8DF90(Instance* instance, GameTracker* gameTracker, int count) {
+    extern char D_801615C8_92768[];
+    extern char D_801615D0_92770[];
+    extern char D_801615D8_92778[];
+    char buf[16];
+    int c;
 
-INCLUDE_ASM("asm/nonmatchings/level/FINAL", func_8015CF08_8E0A8);
+    /* raw PlayerInstance derefs: same scheduling pin as func_8015CB70 */
+    if (count >= 0x29) {
+        c = 0x32;
+        D_800BDEE0[0] = 0xDC;
+        D_800BDEE4 = c;
+        osSyncPrintf("Coordinates");
+        c = 0x3A;
+        D_800BDEE0[0] = 0xDC;
+        D_800BDEE4 = c;
+        osSyncPrintf("Subject");
+        c = 0x42;
+        D_800BDEE0[0] = 0xDC;
+        D_800BDEE4 = c;
+        func_8015CB34_8DCD4(buf, *(short*)((char*)PlayerInstance + 0x48));
+        osSyncPrintf(D_801615C8_92768, buf);
+        c = 0x4A;
+        D_800BDEE0[0] = 0xDC;
+        D_800BDEE4 = c;
+        func_8015CB34_8DCD4(buf, *(short*)((char*)PlayerInstance + 0x4A));
+        osSyncPrintf(D_801615D0_92770, buf);
+        c = 0x52;
+        D_800BDEE0[0] = 0xDC;
+        D_800BDEE4 = c;
+        func_8015CB34_8DCD4(buf, *(short*)((char*)PlayerInstance + 0x4C));
+        osSyncPrintf(D_801615D8_92778, buf);
+    }
+}
 
-INCLUDE_ASM("asm/nonmatchings/level/FINAL", func_8015D018_8E1B8);
+void func_8015CF08_8E0A8(Instance* instance, GameTracker* gameTracker, int count) {
+    extern short D_80161850_929F0;
+    extern short D_80161852_929F2;
+    extern short D_80161854_929F4;
+    extern short D_80161856_929F6;
+    extern int D_80161858_929F8;
+    short* r;
+
+    if (count >= 0x29) {
+        func_8003F7B4(0x78, 0x5A, 0x8C, 0x5A);
+        func_8003F7B4(0xB4, 0x5A, 0xC8, 0x5A);
+        func_8003F7B4(0x78, 0x96, 0x8C, 0x96);
+        func_8003F7B4(0xB4, 0x96, 0xC8, 0x96);
+        func_8003F7B4(0x78, 0x5A, 0x78, 0x69);
+        func_8003F7B4(0x78, 0x87, 0x78, 0x96);
+        func_8003F7B4(0xC8, 0x5A, 0xC8, 0x69);
+        func_8003F7B4(0xC8, 0x87, 0xC8, 0x96);
+        r = &D_80161850_929F0;
+        *r = -0x28;
+        D_80161852_929F2 = -0x1E;
+        D_80161854_929F4 = 0x28;
+        D_80161856_929F6 = 0x1E;
+        D_80161858_929F8 = 0x7F;
+        func_8003F614(1, r, 0, 0);
+    }
+}
+
+void func_8015D018_8E1B8(int arg0, int arg1, short* arg2, int arg3) {
+    Object* obj;
+    Model* model;
+    SVECTOR offs;
+    SVECTOR pos;
+    SVECTOR vel;
+    int i;
+    int half;
+    int life;
+
+    obj = OBTABLE_FindObject("remsfx__");
+    i = 0;
+    if (obj != 0) {
+        half = arg3 >> 1;
+        model = obj->modelList[0];
+        do {
+            i++;
+            offs.x = rand() % arg3 - half;
+            offs.y = rand() % arg3 - half;
+            offs.z = rand() % arg3 - half;
+            pos.x = arg2[0] + offs.x;
+            pos.y = arg2[1] + offs.z;
+            pos.z = arg2[2] + offs.z;
+            vel.x = 0;
+            vel.y = 0;
+            vel.z = -1;
+            /* the dead life reassignment keeps the constant un-hoistable
+               (loop-invariant motion would steal a saved register from the
+               callback addresses); flow deletes the second store */
+            life = 0x1E;
+            func_800170E8(model, model->_14, arg1, &pos, &vel, D_800EB8A0, func_80017E88, func_80016894, life);
+            life = 0;
+        } while (i < 0x1E);
+    }
+}
 
 INCLUDE_RODATA("asm/nonmatchings/level/FINAL", D_80161610_927B0);
 
@@ -577,8 +670,8 @@ void final_popper_OnCreate(Instance* instance, GameTracker* gameTracker) {
     instance->work2 = 0;
     instance->position.z -= 0x12C;
     instance->flags |= 0x400;
-    WORK_AS(int, instance->work3) = OBTABLE_FindObject(D_80161588_92728);
-    WORK_AS(int, instance->work4) = OBTABLE_FindObject(D_8016166C_9280C);
+    WORK_AS(int, instance->work3) = ((int)OBTABLE_FindObject(D_80161588_92728));
+    WORK_AS(int, instance->work4) = ((int)OBTABLE_FindObject(D_8016166C_9280C));
 }
 
 INCLUDE_RODATA("asm/nonmatchings/level/FINAL", D_8016166C_9280C);
@@ -711,12 +804,12 @@ extern void func_8015F200_903A0(void); // unknown
 
 void final_frez_OnCreate(Instance* instance, GameTracker* gameTracker) {
     if (!(instance->flags & 0x20000)) {
-        instance->_D0[3] = OBTABLE_FindObject(D_80161588_92728);
+        instance->_D0[3] = ((int)OBTABLE_FindObject(D_80161588_92728));
         instance->_C4[2] = 0;
         instance->_C4[3] = 1;
         instance->_C4[4] = 1;
         instance->_40[6] -= 0x12C;
-        instance->_E0[2] = OBTABLE_FindObject(D_8016166C_9280C);
+        instance->_E0[2] = ((int)OBTABLE_FindObject(D_8016166C_9280C));
         instance->additionalDrawFunc = (void*)&func_8015F200_903A0;
         instance->flags |= 0x10400;
         instance->flags2 |= 8;

--- a/src/level/FINAL.c
+++ b/src/level/FINAL.c
@@ -318,7 +318,46 @@ void final_rezbomb_OnCollide(Instance* instance, GameTracker* gameTracker) {
 
 INCLUDE_ASM("asm/nonmatchings/level/FINAL", func_8015A9F0_8BB90);
 
-INCLUDE_ASM("asm/nonmatchings/level/FINAL", func_8015AC70_8BE10);
+extern int D_800785C8;
+
+void func_8015AC70_8BE10(Instance* instance) {
+    Camera* cam;
+    GameTracker* gt;
+    unsigned short* c;
+    SVECTOR mid;
+    SVECTOR rot;
+    int px;
+    int py;
+    int state;
+
+    cam = gameTracker8->camera;
+    state = PlayerInstance->currentMainState;
+    if (state != 5) {
+        D_800785C8 = state;
+    }
+    PlayerInstance->currentMainState = 5;
+    CAMERA_SetMode(gameTracker8->camera, 8);
+    c = (unsigned short*)cam;
+    mid.x = (instance->position.x + 0x2D00) / 2;
+    mid.y = (instance->position.y + 0x267A) / 2;
+    mid.z = instance->position.z + 0x200;
+    gt = gameTracker8;
+    py = instance->position.y;
+    rot.x = (py - 0x267A) << 2;
+    px = instance->position.x;
+    rot.y = (-px + 0x2D00) << 2;
+    rot.z = 0;
+    ((short*)gt->camera)[0] = mid.x + rot.x;
+    ((short*)gt->camera)[1] = mid.y + rot.y;
+    ((short*)gt->camera)[2] = mid.z + rot.z;
+    func_80005438(&cam->cameraCore._08[4], &mid, cam);
+    c[0x18] = c[0xC];
+    c[0x19] = c[0xD];
+    c[0x1A] = c[0xE];
+    c[4] = c[0xC];
+    c[5] = c[0xD];
+    c[0x17] = c[6] = c[0xE];
+}
 
 void func_8015ADC4_8BF64(Instance* instance) {
     Camera* cam;

--- a/src/level/FINAL.c
+++ b/src/level/FINAL.c
@@ -534,7 +534,6 @@ void func_8015CB34_8DCD4(char* buf, short val) {
 INCLUDE_RODATA("asm/nonmatchings/level/FINAL", D_801615B8_92758);
 
 extern int D_800BDEE0[];
-extern int D_800BDEE4;
 
 void func_8015CB70_8DD10(Instance* instance, GameTracker* gameTracker, int count) {
     extern char D_801615C8_92768[];
@@ -550,21 +549,21 @@ void func_8015CB70_8DD10(Instance* instance, GameTracker* gameTracker, int count
     if (count >= 0x29) {
         c = 0x64;
         D_800BDEE0[0] = 0xDC;
-        D_800BDEE4 = c;
+        D_800BDEE0[1] = c;
         osSyncPrintf("Target");
         c = 0x6C;
         D_800BDEE0[0] = 0xDC;
-        D_800BDEE4 = c;
+        D_800BDEE0[1] = c;
         func_8015CB34_8DCD4(buf, *(short*)((char*)p + 0x3C));
         osSyncPrintf(D_801615C8_92768, buf);
         c = 0x74;
         D_800BDEE0[0] = 0xDC;
-        D_800BDEE4 = c;
+        D_800BDEE0[1] = c;
         func_8015CB34_8DCD4(buf, *(short*)((char*)p + 0x3E));
         osSyncPrintf(D_801615D0_92770, buf);
         c = 0x7C;
         D_800BDEE0[0] = 0xDC;
-        D_800BDEE4 = c;
+        D_800BDEE0[1] = c;
         func_8015CB34_8DCD4(buf, *(short*)((char*)p + 0x40));
         osSyncPrintf(D_801615D8_92778, buf);
     }
@@ -583,26 +582,25 @@ void func_8015CC64_8DE04(Instance* instance, GameTracker* gameTracker, int count
     char buf[16];
     int c;
 
-    /* raw position derefs: same scheduling pin as func_8015CB70 */
     c = 0x96;
     if (count >= 0x29) {
         D_800BDEE0[0] = 0xDC;
-        D_800BDEE4 = c;
+        D_800BDEE0[1] = c;
         osSyncPrintf("Position");
         c = 0x9E;
         D_800BDEE0[0] = 0xDC;
-        D_800BDEE4 = c;
-        func_8015CB34_8DCD4(buf, *(short*)((char*)instance + 0x48));
+        D_800BDEE0[1] = c;
+        func_8015CB34_8DCD4(buf, instance->position.x);
         osSyncPrintf(D_801615C8_92768, buf);
         c = 0xA6;
         D_800BDEE0[0] = 0xDC;
-        D_800BDEE4 = c;
-        func_8015CB34_8DCD4(buf, *(short*)((char*)instance + 0x4A));
+        D_800BDEE0[1] = c;
+        func_8015CB34_8DCD4(buf, instance->position.y);
         osSyncPrintf(D_801615D0_92770, buf);
         c = 0xAE;
         D_800BDEE0[0] = 0xDC;
-        D_800BDEE4 = c;
-        func_8015CB34_8DCD4(buf, *(short*)((char*)instance + 0x4C));
+        D_800BDEE0[1] = c;
+        func_8015CB34_8DCD4(buf, instance->position.z);
         osSyncPrintf(D_801615D8_92778, buf);
     }
 }
@@ -630,30 +628,29 @@ void func_8015CDF0_8DF90(Instance* instance, GameTracker* gameTracker, int count
     char buf[16];
     int c;
 
-    /* raw PlayerInstance derefs: same scheduling pin as func_8015CB70 */
     if (count >= 0x29) {
         c = 0x32;
         D_800BDEE0[0] = 0xDC;
-        D_800BDEE4 = c;
+        D_800BDEE0[1] = c;
         osSyncPrintf("Coordinates");
         c = 0x3A;
         D_800BDEE0[0] = 0xDC;
-        D_800BDEE4 = c;
+        D_800BDEE0[1] = c;
         osSyncPrintf("Subject");
         c = 0x42;
         D_800BDEE0[0] = 0xDC;
-        D_800BDEE4 = c;
-        func_8015CB34_8DCD4(buf, *(short*)((char*)PlayerInstance + 0x48));
+        D_800BDEE0[1] = c;
+        func_8015CB34_8DCD4(buf, PlayerInstance->position.x);
         osSyncPrintf(D_801615C8_92768, buf);
         c = 0x4A;
         D_800BDEE0[0] = 0xDC;
-        D_800BDEE4 = c;
-        func_8015CB34_8DCD4(buf, *(short*)((char*)PlayerInstance + 0x4A));
+        D_800BDEE0[1] = c;
+        func_8015CB34_8DCD4(buf, PlayerInstance->position.y);
         osSyncPrintf(D_801615D0_92770, buf);
         c = 0x52;
         D_800BDEE0[0] = 0xDC;
-        D_800BDEE4 = c;
-        func_8015CB34_8DCD4(buf, *(short*)((char*)PlayerInstance + 0x4C));
+        D_800BDEE0[1] = c;
+        func_8015CB34_8DCD4(buf, PlayerInstance->position.z);
         osSyncPrintf(D_801615D8_92778, buf);
     }
 }

--- a/src/level/GEXZIL.c
+++ b/src/level/GEXZIL.c
@@ -159,7 +159,36 @@ void func_8015B144_942C4(Instance* instance, GameTracker* gameTracker) {
     }
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/GEXZIL", func_8015B220_943A0);
+int func_8015B220_943A0(Instance* instance, int arg1) {
+    int max;
+    short f;
+    unsigned char b;
+
+    instance->flags2 &= ~0x10;
+    if (arg1 != 0) {
+        return func_8002DAF8();
+    }
+    max = ((short*)instance->object->animList[instance->currentModelAnim])[1] - 1;
+    b = ((unsigned char*)&instance->currentAnimFrame)[1];
+    if (((int*)instance->_34)[0] > 0) {
+        ((int*)instance->_34)[0]--;
+    }
+    if (arg1 >= ((int*)instance->_34)[0]) {
+        f = ++instance->currentAnimFrame;
+        if (max < f) {
+            instance->currentAnimFrame = 0;
+            instance->flags2 |= 0x10;
+        } else if (f < 0) {
+            instance->currentAnimFrame = max;
+            instance->flags2 |= 0x10;
+        }
+        ((int*)instance->_34)[0] = 0;
+        if (instance->object->oflags2 & 8) {
+            func_80050400(instance, b);
+        }
+    }
+    return instance->flags2 & 0x10;
+}
 
 int func_8015B334_944B4(Intro* intro) {
     Instance* instance;

--- a/src/level/GEXZIL.c
+++ b/src/level/GEXZIL.c
@@ -287,7 +287,53 @@ void func_8015C188_95308(Instance* instance, short* arg1) {
     arg1[0x12 / 2] = 0;
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/GEXZIL", func_8015C208_95388);
+void func_8015C208_95388(Instance* instance, void* arg1) {
+    int flags;
+    int max;
+    int frame0;
+    short speed;
+    unsigned short acc;
+    int frame;
+    short a1;
+
+    flags = ((int*)arg1)[0x18/4];
+    max = ((short*)instance->object->animList[instance->currentModelAnim])[1] - 1;
+    if (flags & 0x400) {
+        ((int*)arg1)[0x18/4] = flags & ~0x400;
+        return;
+    }
+    if (((short*)arg1)[0x40/2] == 0) {
+        instance->flags2 &= ~0x10;
+        speed = ((short*)arg1)[0x12/2];
+        if (speed == 0) {
+            frame0 = instance->currentAnimFrame;
+            func_8002DAF8(instance, -1);
+            if (frame0 < max) {
+                instance->currentAnimFrame = frame0 + 1;
+                return;
+            }
+            instance->currentAnimFrame = 0;
+            return;
+        }
+        acc = ((unsigned short*)arg1)[0x14/2] + speed;
+        ((unsigned short*)arg1)[0x14/2] = acc;
+        frame = (acc << 16) >> 18;
+        instance->currentAnimFrame = frame;
+        a1 = ((short*)arg1)[0x12/2];
+        if (a1 > 0) {
+            if (max < frame) {
+                instance->currentAnimFrame = 0;
+                instance->flags2 |= 0x10;
+            }
+        } else if (a1 < 0 && frame < 0) {
+            instance->currentAnimFrame = max;
+            instance->flags2 |= 0x10;
+        }
+        if (instance->object->oflags2 & 8) {
+            func_80050400(instance, ((unsigned char*)&instance->currentAnimFrame)[1]);
+        }
+    }
+}
 
 void gexzil_mekblst_OnCreate(Instance* instance, GameTracker* gameTracker) {
     instance->intro = NULL;

--- a/src/level/GEXZIL.c
+++ b/src/level/GEXZIL.c
@@ -396,7 +396,35 @@ INCLUDE_RODATA("asm/nonmatchings/level/GEXZIL", D_80162B24_9BCA4);
 
 INCLUDE_RODATA("asm/nonmatchings/level/GEXZIL", D_80162B28_9BCA8);
 
-INCLUDE_ASM("asm/nonmatchings/level/GEXZIL", func_8015E8C0_97A40);
+void func_8015E8C0_97A40(Instance* instance, void* arg1) {
+    SVECTOR euler;
+    MATRIX* m;
+
+    if ((unsigned int)(instance->currentModelAnim - 0xB) < 2) {
+        if (((Instance**)arg1)[0x98/4] != NULL ||
+            (((Instance**)arg1)[0x98/4] = INSTANCE_BirthObject(instance, OBTABLE_FindObject("blububl_"))) != NULL) {
+            ((Instance**)arg1)[0x98/4]->rotation.z = instance->rotation.z - 0x400;
+            m = instance->oldMatrix;
+            if (m != NULL) {
+                func_800157BC(&m[5], (short*)&euler);
+                ((Instance**)arg1)[0x98/4]->rotation.x = euler.x;
+                ((Instance**)arg1)[0x98/4]->rotation.y = euler.y;
+                ((Instance**)arg1)[0x98/4]->rotation.z = euler.z;
+                ((Instance**)arg1)[0x98/4]->position.x = m[5].l[0];
+                ((Instance**)arg1)[0x98/4]->position.y = m[5].l[1];
+                ((Instance**)arg1)[0x98/4]->position.z = m[5].l[2];
+                return;
+            }
+            ((Instance**)arg1)[0x98/4]->position = instance->position;
+            ((Instance**)arg1)[0x98/4]->position.z += 0x100;
+        }
+    } else {
+        if (((Instance**)arg1)[0x98/4] != NULL) {
+            func_8002E350(((Instance**)arg1)[0x98/4]);
+            ((Instance**)arg1)[0x98/4] = NULL;
+        }
+    }
+}
 
 void func_8015EA18_97B98(Instance* instance, short* arg1) {
     instance->flags2 &= ~0x10;

--- a/src/level/HORROR.c
+++ b/src/level/HORROR.c
@@ -1068,13 +1068,106 @@ void func_80161F4C_A577C(Instance* instance, SVECTOR offset) {
     }
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/HORROR", func_80162024_A5854);
+void func_80162024_A5854(Instance* instance, SVECTOR offset) {
+    MATRIX m;
+    SVECTOR vec;
+    SVECTOR res;
 
-INCLUDE_ASM("asm/nonmatchings/level/HORROR", func_80162118_A5948);
+    MATH3D_SetUnityMatrix(&m);
+    if (instance->rotation.z > 0) {
+        instance->rotation.z -= 0x20;
+        RotMatrixZ(instance->rotation.z + instance->intro->rotation.z, &m);
+        vec.x = 0;
+        vec.z = 0;
+        vec.y = -0x40;
+        res.x = (vec.x * m.m[0][0] >> 12) + (vec.y * m.m[0][1] >> 12) + (vec.z * m.m[0][2] >> 12);
+        res.y = (vec.x * m.m[1][0] >> 12) + (vec.y * m.m[1][1] >> 12) + (vec.z * m.m[1][2] >> 12);
+        res.z = (vec.x * m.m[2][0] >> 12) + (vec.y * m.m[2][1] >> 12) + (vec.z * m.m[2][2] >> 12);
+        instance->position.x = res.x + offset.x;
+        instance->position.y = res.y + offset.y;
+        instance->position.z = res.z + offset.z;
+    } else {
+        WORK_AS_IDX(char, instance->work8, 2) = 0;
+    }
+}
 
-INCLUDE_ASM("asm/nonmatchings/level/HORROR", func_80162214_A5A44);
+void func_80162118_A5948(Instance* instance, SVECTOR offset) {
+    MATRIX m;
+    SVECTOR vec;
+    SVECTOR res;
 
-INCLUDE_ASM("asm/nonmatchings/level/HORROR", func_801622E4_A5B14);
+    MATH3D_SetUnityMatrix(&m);
+    if (instance->rotation.z < 0x400) {
+        instance->rotation.z += 0x20;
+        RotMatrixZ(instance->rotation.z + instance->intro->rotation.z, &m);
+        vec.x = 0;
+        vec.z = 0;
+        vec.y = -0x40;
+        res.x = (vec.x * m.m[0][0] >> 12) + (vec.y * m.m[0][1] >> 12) + (vec.z * m.m[0][2] >> 12);
+        res.y = (vec.x * m.m[1][0] >> 12) + (vec.y * m.m[1][1] >> 12) + (vec.z * m.m[1][2] >> 12);
+        res.z = (vec.x * m.m[2][0] >> 12) + (vec.y * m.m[2][1] >> 12) + (vec.z * m.m[2][2] >> 12);
+        instance->position.x = res.x + offset.x;
+        instance->position.y = res.y + offset.y;
+        instance->position.z = res.z + offset.z;
+    } else {
+        WORK_AS_IDX(char, instance->work8, 2) = 4;
+    }
+}
+
+void func_80162214_A5A44(Instance* instance, SVECTOR offset) {
+    MATRIX m;
+    SVECTOR vec;
+    SVECTOR res;
+
+    MATH3D_SetUnityMatrix(&m);
+    if (instance->rotation.z < 0) {
+        instance->rotation.z += 0x20;
+        RotMatrixZ(instance->rotation.z + instance->intro->rotation.z, &m);
+        vec.y = 0x40;
+        vec.x = 0;
+        vec.z = 0;
+        res.x = (vec.x * m.m[0][0] >> 12) + (vec.y * m.m[0][1] >> 12) + (vec.z * m.m[0][2] >> 12);
+        res.y = (vec.x * m.m[1][0] >> 12) + (vec.y * m.m[1][1] >> 12) + (vec.z * m.m[1][2] >> 12);
+        res.z = (vec.x * m.m[2][0] >> 12) + (vec.y * m.m[2][1] >> 12) + (vec.z * m.m[2][2] >> 12);
+        instance->position.x = res.x + offset.x;
+        instance->position.y = res.y + offset.y;
+        instance->position.z = res.z + offset.z;
+    } else {
+        WORK_AS_IDX(char, instance->work8, 2) = 0;
+    }
+}
+
+void func_801622E4_A5B14(GameTracker* arg0, short arg1, int arg2, Instance* arg3) {
+    Camera* camera;
+    int base;
+
+    camera = arg0->camera;
+    base = (int)arg3 + 0xC8;
+    func_8000B054(camera);
+    if ((arg1 != arg3->intro->rotation.z) ? !(arg3->_C4[4] & 2) : (arg3->_C4[4] & 2)) {
+        if (((short*)camera)[0x16 / 2] != 0) {
+            camera->smooth = 0;
+        } else {
+            camera->smooth = 0x1E;
+        }
+        camera->cameraKey = ((CameraKey*)(base + 0x3E));
+        ((int*)camera)[0x520 / 4] = base + 0x3E;
+        ((int*)camera)[0x3DC / 4] = 0;
+        ((int*)camera)[0x3E0 / 4] = 0;
+        CAMERA_SetMode(camera, 2);
+    } else {
+        if (((short*)camera)[0x16 / 2] != 0) {
+            camera->smooth = 0;
+        } else {
+            camera->smooth = 0x1E;
+        }
+        camera->cameraKey = ((CameraKey*)(base + 0x26));
+        ((int*)camera)[0x520 / 4] = base + 0x26;
+        ((int*)camera)[0x3DC / 4] = 0;
+        ((int*)camera)[0x3E0 / 4] = 0;
+        CAMERA_SetMode(camera, 2);
+    }
+}
 
 void func_801623DC_A5C0C(GameTracker* arg0, short arg1, int arg2, void* arg3) {
     Camera* camera;
@@ -1134,7 +1227,29 @@ int func_80162524_A5D54(short* arg0, short* arg1) {
     return result;
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/HORROR", func_8016257C_A5DAC);
+void func_8016257C_A5DAC(Instance* arg0, Instance* arg1) {
+    Camera* camera;
+
+    camera = gameTracker8->camera;
+    camera->smooth = 0;
+    camera->focusRotationX = ((unsigned short*)camera)[0x17A / 2];
+    if (func_80162524_A5D54((short*)camera, (short*)((int)arg1 + 0x106)) != 0) {
+        ((int*)camera)[0x520 / 4] = (int)arg0 + 0xEE;
+        camera->cameraKey = ((CameraKey*)((int)arg0 + 0xEE));
+        ((int*)camera)[0x3DC / 4] = 0;
+        ((int*)camera)[0x3E0 / 4] = 0;
+        CAMERA_SetMode(camera, 2);
+    } else if (func_80162524_A5D54((short*)camera, (short*)((int)arg1 + 0xEE)) != 0 || !(arg0->_C4[4] & 2)) {
+        ((int*)camera)[0x520 / 4] = (int)arg0 + 0x106;
+        camera->cameraKey = ((CameraKey*)((int)arg0 + 0x106));
+        ((int*)camera)[0x3DC / 4] = 0;
+        ((int*)camera)[0x3E0 / 4] = 0;
+        CAMERA_SetMode(camera, 2);
+    } else {
+        camera->lock &= ~4;
+        camera->lock &= ~2;
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/HORROR", horror_door_OnUpdate);
 

--- a/src/level/HORROR.c
+++ b/src/level/HORROR.c
@@ -31,7 +31,45 @@ void horror_drawer_OnCreate(Instance* instance, GameTracker* gameTracker) {
     }
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/HORROR", horror_drawer_OnUpdate);
+void horror_drawer_OnUpdate(Instance* instance, GameTracker* gameTracker) {
+    int state;
+    int f;
+
+    state = instance->currentMainState;
+    f = instance->work0 + 1;
+    instance->work0 = f;
+    if (state == 0) {
+        instance->scale.x -= 0x124;
+        if (instance->scale.x == 0) {
+            instance->scale.x = 1;
+        }
+        func_8002E704(instance);
+        if (instance->work0 == 0xE) {
+            instance->currentMainState = 2;
+            instance->work0 = 0;
+        }
+    } else if (state == 2) {
+        if (f == 0x28) {
+            instance->currentMainState = 1;
+            instance->work0 = 0;
+            func_80050508(instance, 0x46, 0, 0x64, 0xFA0);
+        }
+    } else if (state == 1) {
+        instance->scale.x += 0x124;
+        if (instance->scale.x >= 0x1000) {
+            instance->scale.x = 0x1000;
+        }
+        func_8002E704(instance);
+        if (instance->work0 == 0xE) {
+            instance->currentMainState = 3;
+            instance->work0 = 0;
+        }
+    } else if (state == 3 && f == 0x28) {
+        instance->currentMainState = 0;
+        instance->work0 = 0;
+        func_80050508(instance, 0x46, 0, 0x64, 0xFA0);
+    }
+}
 
 void horror_drawer_OnCollide(Instance* instance, GameTracker* gameTracker) {
 }

--- a/src/level/HORROR.c
+++ b/src/level/HORROR.c
@@ -383,7 +383,42 @@ INCLUDE_ASM("asm/nonmatchings/level/HORROR", horror_fltchst_OnCreate);
 
 INCLUDE_ASM("asm/nonmatchings/level/HORROR", horror_fltchst_OnUpdate);
 
-INCLUDE_ASM("asm/nonmatchings/level/HORROR", horror_fltchst_OnCollide);
+void horror_fltchst_OnCollide(Instance* instance, GameTracker* gameTracker) {
+    BSPTree* bsp;
+    int* introData;
+    int c6;
+    int state;
+    int* sig;
+
+    bsp = instance->bspTree;
+    c6 = bsp->_06;
+    introData = instance->introData;
+    if (c6 == 1 && bsp->instanceSpline == gameTracker->player &&
+        (unsigned int)(instance->currentMainState - 1) >= 2 && bsp->globalOffset.x < -0x18F) {
+        state = instance->work2;
+        instance->currentSubState = c6;
+        if (state != c6) {
+            if (instance->work0 == c6) {
+                instance->work1 = gameTracker->player->position.y;
+            } else if (instance->work0 == 2) {
+                instance->work1 = gameTracker->player->position.x;
+            }
+            if (instance->work4 != 1 && introData[0xC/4] != 0) {
+                sig = (int*)introData[0x8/4];
+                COLLIDE_HandleSignal(gameTracker->player, sig + 1, sig[0], 0);
+                instance->work4 = 1;
+            }
+        } else {
+            if (instance->work0 == state) {
+                gameTracker->player->position.y = instance->work1;
+                return;
+            }
+            if (instance->work0 == 2) {
+                gameTracker->player->position.x = instance->work1;
+            }
+        }
+    }
+}
 
 void horror_ledge_OnCreate(Instance* instance, GameTracker* gameTracker) {
     int* intro;

--- a/src/level/HORROR.c
+++ b/src/level/HORROR.c
@@ -499,7 +499,50 @@ void horror_polter_OnCreate(Instance* instance, GameTracker* gameTracker) {
     instance->scale.z = instance->scale.y = instance->scale.x = 1;
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/HORROR", horror_polter_OnUpdate);
+void horror_polter_OnUpdate(Instance* instance, GameTracker* gameTracker) {
+    int state;
+
+    state = instance->currentMainState;
+    if (state == 1) {
+        PlayerInstance->lightGroup = 0;
+        *(int*)PlayerInstance->_C4 = instance->work0;
+        if (instance->scale.x + 0x40 < 0x1000) {
+            instance->scale.x += 0x40;
+            instance->scale.y += 0x40;
+            instance->scale.z += 0x40;
+            return;
+        }
+        instance->scale.x = 0x1000;
+        instance->scale.y = 0x1000;
+        instance->scale.z = 0x1000;
+        if (PlayerInstance->scale.x + 0x80 < 0x1000) {
+            PlayerInstance->scale.x += 0x80;
+            PlayerInstance->scale.y += 0x80;
+            PlayerInstance->scale.z += 0x80;
+            return;
+        }
+        PlayerInstance->scale.x = 0x1000;
+        PlayerInstance->scale.y = 0x1000;
+        PlayerInstance->scale.z = 0x1000;
+        PlayerInstance->currentMainState = 0;
+        gameTracker->player->flags &= ~0x100;
+        instance->currentMainState = 2;
+        return;
+    }
+    if (state == 2) {
+        *(int*)PlayerInstance->_C4 = instance->work0;
+        if (instance->scale.x - 0x20 > 0) {
+            instance->scale.x -= 0x20;
+            instance->scale.y -= 0x20;
+            instance->scale.z -= 0x20;
+            return;
+        }
+        instance->scale.x = 0;
+        instance->scale.y = 0;
+        instance->scale.z = 0;
+        instance->currentMainState = 0;
+    }
+}
 
 void horror_polter_OnCollide(Instance* instance, GameTracker* gameTracker) {
 }

--- a/src/level/HORROR.c
+++ b/src/level/HORROR.c
@@ -509,7 +509,30 @@ void horror_skelh_OnCreate(Instance* instance, GameTracker* gameTracker) {
     }
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/HORROR", horror_skelh_OnUpdate);
+void horror_skelh_OnUpdate(Instance* instance, GameTracker* gameTracker) {
+    extern int D_800EB8A0;
+    int* ev;
+    int i;
+    int n;
+
+    ev = WORK_AS(int*, instance->work6);
+    if (instance->parent == NULL) {
+        INSTANCE_KillInstance(instance);
+        return;
+    }
+    if (SCRIPT_InstanceSplineProcess(instance, (SplineDef*)&instance->work0, WORK_AS_PTR(SplineDef, instance->work2), NULL, 1) > 0) {
+        INSTANCE_PlainDeath(instance, 5, -1, 0);
+        func_80050508(instance, 0xA, 0, 0x6E, 0xFA0);
+    }
+    if (ev != NULL) {
+        n = ev[2];
+        i = WORK_AS(int, instance->work4);
+        if (n > i && WORK_AS_IDX(short, instance->work0, 0) + 1 == ((int**)ev)[3][i]) {
+            func_8002768C(instance, D_800EB8A0, WORK_AS(int, instance->work4)++);
+            func_80050508(instance, 0x4C, 0, 0x64, 0xFA0);
+        }
+    }
+}
 
 void horror_skelh_OnCollide(Instance* instance, GameTracker* gameTracker) {
     BSPTree* bsp = instance->bspTree;

--- a/src/level/KUNGFU.c
+++ b/src/level/KUNGFU.c
@@ -1059,7 +1059,107 @@ void kungfu_leafgen_OnCreate(Instance* instance, GameTracker* gameTracker) {
     p[7] = (rand() & 0xF) + 1;
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", func_801616D4_B08F4);
+typedef struct {
+    char _00[8];
+    void* next;
+    unsigned short flags;
+    short _0E;
+    void* callback;
+    void* _14;
+    int _18;
+    short posX;
+    short posY;
+    short posZ;
+    short _22;
+    unsigned short unk24;
+    short _26;
+    unsigned short unk28;
+    short _2A;
+    unsigned short unk2C;
+    short _2E;
+    unsigned short unk30;
+    short _32;
+    unsigned short unk34;
+    short _36;
+    unsigned short unk38;
+    short _3A;
+    unsigned short unk3C;
+    short _3E;
+    unsigned short unk40;
+    short _42;
+    short _44;
+    unsigned short _46;
+    unsigned short _48;
+    short _4A;
+    unsigned short _4C;
+    unsigned short _4E;
+    unsigned short _50;
+    unsigned short _52;
+    unsigned short _54;
+    unsigned short _56;
+    char _58[0x14];
+    unsigned short frame;
+} ParticleData;
+
+extern int D_80078244;
+extern int D_80078248;
+
+void func_801616D4_B08F4(ParticleData* p, void* callback, char* data, void* arg3, unsigned short* def, char* table, SVECTOR* pos, int arg7, int arg8, int arg9, unsigned short arg10) {
+    short* va;
+    short* vb;
+    short* vc;
+    int* nxt;
+    int i0;
+    int i1;
+    int i2;
+    unsigned short px0;
+
+    px0 = pos->x;
+    i0 = def[0];
+    i1 = def[1];
+    i2 = def[2];
+    va = (short*)(table + i0 * 12);
+    p->posX = px0;
+    p->posY = pos->y;
+    p->posZ = pos->z;
+    vb = (short*)(table + i2 * 12);
+    p->unk24 = (va[0] - vb[0]) * D_80078244;
+    p->_26 = (va[1] - vb[1]) * D_80078244;
+    vc = (short*)(table + i1 * 12);
+    p->unk28 = (va[2] - vb[2]) * D_80078244;
+    p->unk2C = (vc[0] - vb[0]) * D_80078244;
+    p->_2E = (vc[1] - vb[1]) * D_80078244;
+    p->unk30 = (vc[2] - vb[2]) * D_80078244;
+    p->unk34 = 0;
+    p->_36 = 0;
+    p->unk38 = 0;
+    if (((unsigned char*)def)[7] & 2) {
+        p->flags |= 1;
+        nxt = ((int**)def)[2];
+        p->next = nxt;
+        p->_18 = (nxt[3] & 0x3FFFFFF) | 0x24000000;
+    } else {
+        p->flags &= ~1;
+        p->_18 = (((int*)def)[2] & 0x3FFFFFF) | 0x20000000;
+    }
+    p->callback = callback;
+    p->_14 = data;
+    p->_4C = 0;
+    p->_4E = 0;
+    p->_50 = 0;
+    p->_52 = 0;
+    p->_54 = 0;
+    p->_0E = arg10;
+    p->_56 = D_80078248 - 2;
+    D_80078248 ^= 1;
+    p->_44 = (rand() & 0x3F) - 0x10;
+    p->_46 = (rand() & 0x3F) - 0x10;
+    p->_48 = (rand() & 0x3F) - 0x10;
+    MATH3D_SetUnityMatrix((char*)p->_14 + 0xC);
+    RotMatrixX(rand() & 0xFFF, (char*)p->_14 + 0xC);
+    RotMatrixY(rand() & 0xFFF, (char*)p->_14 + 0xC);
+    RotMatrixZ(rand() & 0xFFF, (char*)p->_14 + 0xC);
+}
 
 void func_80161944_B0B64(short* arg0) {
     func_800162C0(arg0);

--- a/src/level/KUNGFU.c
+++ b/src/level/KUNGFU.c
@@ -6,6 +6,7 @@
 #include "SPLINE.h"
 #include "SCRIPT.h"
 #include "OBTABLE.h"
+#include "MATRIX.h"
 
 
 extern int D_800E5FD8;
@@ -1112,7 +1113,55 @@ void kungfu_leafgen_OnUpdate(Instance* instance, GameTracker* gameTracker) {
     *(int*)&fc[10] = 0;
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", kungfu_leafgen_OnCollide);
+void kungfu_leafgen_OnCollide(Instance* instance, GameTracker* gameTracker) {
+    extern MATRIX* D_800E97C8;
+    extern SVECTOR D_800EB800;
+    BSPTree* bsp;
+    LVECTOR out;
+    short code;
+    int zv;
+
+    bsp = instance->bspTree;
+    if (bsp->instanceSpline == gameTracker->player) {
+        code = bsp->_06;
+        switch (code) {
+            case 4:
+                WORK_AS_IDX(short, instance->work1, 0) = bsp->globalOffset.x;
+                WORK_AS_IDX(short, instance->work1, 1) = bsp->globalOffset.y;
+                zv = (unsigned short)bsp->globalOffset.z;
+                instance->work5 = 1;
+                WORK_AS_IDX(short, instance->work2, 0) = zv;
+                break;
+            case 1:
+                switch (bsp->_04) {
+                    case 2:
+                        instance->work5 = code;
+                        break;
+                    case 1:
+                        if ((bsp->_08[4] - 7) < 3U) {
+                            MATH3D_ApplyMatrixT(D_800E97C8, &D_800EB800, &out);
+                            WORK_AS_IDX(short, instance->work1, 0) = out.x;
+                            WORK_AS_IDX(short, instance->work1, 1) = out.y;
+                            zv = out.z;
+                            instance->work5 = code;
+                            WORK_AS_IDX(short, instance->work2, 0) = zv;
+                        }
+                        break;
+                    case 5:
+                        if ((bsp->_08[2] - 7) < 3U) {
+                            MATH3D_ApplyMatrixT(D_800E97C8, &D_800EB800, &out);
+                            WORK_AS_IDX(short, instance->work1, 0) = out.x;
+                            WORK_AS_IDX(short, instance->work1, 1) = out.y;
+                            zv = out.z;
+                            instance->work5 = code;
+                            WORK_AS_IDX(short, instance->work2, 0) = zv;
+                        }
+                        break;
+                }
+                break;
+        }
+    }
+}
 
 extern int D_801626C0_B18E0[];
 void kungfu_funplat_OnCreate(Instance* instance, GameTracker* gameTracker) {

--- a/src/level/KUNGFU.c
+++ b/src/level/KUNGFU.c
@@ -630,7 +630,21 @@ INCLUDE_RODATA("asm/nonmatchings/level/KUNGFU", D_801626EC_B190C);
 
 INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", kungfu_dragon_OnUpdate);
 
-INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", kungfu_dragflm_OnCreate);
+void kungfu_dragflm_OnCreate(Instance* instance, GameTracker* gameTracker) {
+    Instance* parent;
+
+    parent = instance->parent;
+    instance->flags |= 0x100000;
+    instance->work0 = ((short*)parent)[0xF6/2];
+    instance->work1 = 0x2000 / ((short*)parent)[0xF6/2];
+    instance->scale.x = 0x1000 / ((short*)parent)[0xF6/2];
+    instance->scale.y = 0x1000 / ((short*)parent)[0xF6/2];
+    instance->scale.z = 0x1000 / ((short*)parent)[0xF6/2];
+    if (!(instance->flags & 0x20000)) {
+        instance->work9 = (rand() & 0x3F) - 0x20;
+        instance->work8 = 0;
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", kungfu_dragflm_OnUpdate);
 

--- a/src/level/KUNGFU.c
+++ b/src/level/KUNGFU.c
@@ -1011,7 +1011,39 @@ INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", func_80160E4C_B006C);
 
 INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", func_80160F68_B0188);
 
-INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", kungfu_joyride_OnCreate);
+void kungfu_joyride_OnCreate(Instance* instance, GameTracker* gameTracker) {
+    MultiSpline* multi;
+    G2Quat* quat;
+    short* d0;
+    int isParent;
+    int isClass;
+    int flags;
+    Intro* pi;
+
+    d0 = ((short*)instance->_D0);
+    flags = instance->intro->flags;
+    if (flags & 0x1000) {
+        instance->intro->flags = flags & ~0x800;
+        return;
+    }
+    pi = gameTracker->player->intro;
+    d0[8 / 2] = 0;
+    instance->flags |= 0x100000;
+    instance->_E0[0] = (int)pi;
+    if (instance->intro->flags & 0x800) {
+        multi = SCRIPT_GetMultiSpline(instance, &isParent, &isClass);
+        quat = SplineGetLastRot(multi->rotational, &multi->curRotational);
+        if (isParent == 0 && isClass == 0) {
+            G2Quat_ToMatrix_S((MATRIX*)((char*)multi + 0x20), (short*)quat);
+            instance->flags |= 1;
+        }
+        d0[2 / 2] = -1;
+        SCRIPT_InstanceSplineSet(instance, SCRIPT_CountFramesInSpline(instance), 0, 0, 0);
+        return;
+    }
+    d0[2 / 2] = 1;
+    SCRIPT_InstanceSplineInit(instance, gameTracker);
+}
 
 void func_8016121C_B043C(Instance* instance, GameTracker* gameTracker) {
     Instance* player;

--- a/src/level/KUNGFU.c
+++ b/src/level/KUNGFU.c
@@ -7,6 +7,7 @@
 #include "SCRIPT.h"
 #include "OBTABLE.h"
 #include "MATRIX.h"
+#include "INSTANCE.h"
 
 
 extern int D_800E5FD8;
@@ -45,7 +46,41 @@ void kungfu_kbgen_OnCreate(Instance* instance, GameTracker* gameTracker) {
     }
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", kungfu_kbgen_OnUpdate);
+void kungfu_kbgen_OnUpdate(Instance* instance, GameTracker* gameTracker) {
+    int* intro;
+    Object* obj;
+    Instance* child;
+    int u;
+
+    intro = instance->introData;
+    obj = OBTABLE_FindObject((char*)intro + 0x10);
+    if (intro == NULL || obj == NULL) {
+        INSTANCE_KillInstance(instance);
+        return;
+    }
+    if (instance->currentMainState == 1) {
+        instance->work0 += 1;
+        if (instance->work0 == intro[0xC/4]) {
+            u = intro[0x8/4];
+            instance->currentMainState = 0;
+            instance->work0 = u;
+        }
+    } else {
+        instance->work0 += 1;
+        if (instance->work0 >= intro[0x8/4]) {
+            instance->work0 = 0;
+            child = INSTANCE_BirthObject(instance, obj);
+            if (child != NULL) {
+                obj->oflags |= 0x2000;
+                child->introData = intro;
+                if ((instance->object->oflags & 0x400) && (((unsigned short*)intro)[0x18/2] & 4) && (instance->work1 == 0)) {
+                    instance->work1 = 1;
+                    SCRIPT_InstanceSplineSet(child, ((short*)intro)[0xE/2], 0, 0, 0);
+                }
+            }
+        }
+    }
+}
 
 void kungfu_spray_OnCreate(Instance* instance, GameTracker* gameTracker) {
 }

--- a/src/level/KUNGFU.c
+++ b/src/level/KUNGFU.c
@@ -949,7 +949,40 @@ INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", kungfu_ninja_OnUpdate);
 
 INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", kungfu_ninja_OnCollide);
 
-INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", kungfu_swing_OnCreate);
+void kungfu_swing_OnCreate(Instance* instance, GameTracker* gameTracker) {
+    short* intro;
+    short v;
+    int av;
+    unsigned int t;
+    int r;
+
+    intro = ((short*)instance->object->data);
+    instance->work7 = 0;
+    WORK_AS_IDX(short, instance->work8, 0) = (rand() & 0x1F) - 0xF;
+    WORK_AS_IDX(short, instance->work2, 0) = 0x2C00;
+    WORK_AS_IDX(short, instance->work1, 1) = 0x180;
+    WORK_AS_IDX(short, instance->work3, 1) = 0xA00;
+    if (intro != 0) {
+        WORK_AS_IDX(short, instance->work2, 0) = intro[0];
+        av = intro[2 / 2];
+        if (av < 0) {
+            av = -av;
+        }
+        WORK_AS_IDX(short, instance->work1, 1) = av;
+        WORK_AS_IDX(short, instance->work3, 1) = ((int*)intro)[4 / 4];
+    }
+    v = WORK_AS_IDX(short, instance->work2, 0);
+    t = (short)(v / WORK_AS_IDX(short, instance->work1, 1)) * v;
+    instance->work0 = 0;
+    WORK_AS_IDX(short, instance->work1, 0) = WORK_AS_IDX(unsigned short, instance->work2, 0);
+    r = (int)((t + (t >> 31)) << 7) >> 16;
+    if (r < 0) {
+        r = -r;
+    }
+    WORK_AS_IDX(short, instance->work3, 0) = r;
+    *(SVECTOR*)&instance->work4 = *(SVECTOR*)&instance->position;
+    WORK_AS_IDX(short, instance->work5, 0) = WORK_AS_IDX(unsigned short, instance->work5, 0) - WORK_AS_IDX(short, instance->work3, 1);
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/KUNGFU", kungfu_swing_OnUpdate);
 

--- a/src/level/LOONEY.c
+++ b/src/level/LOONEY.c
@@ -500,7 +500,65 @@ void looney_leafgen_OnCreate(Instance* instance, GameTracker* gameTracker) {
     p[7] = (rand() & 0xF) + 1;
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/LOONEY", func_8015B934_B3BE4);
+extern int D_80078244;
+extern int D_80078248;
+
+void func_8015B934_B3BE4(ParticleData* p, void* callback, char* data, void* arg3, unsigned short* def, char* table, SVECTOR* pos, int arg7, int arg8, int arg9, unsigned short arg10) {
+    short* va;
+    short* vb;
+    short* vc;
+    int* nxt;
+    int i0;
+    int i1;
+    int i2;
+    unsigned short px0;
+
+    px0 = pos->x;
+    i0 = def[0];
+    i1 = def[1];
+    i2 = def[2];
+    va = (short*)(table + i0 * 12);
+    p->posX = px0;
+    p->posY = pos->y;
+    p->posZ = pos->z;
+    vb = (short*)(table + i2 * 12);
+    p->unk24 = (va[0] - vb[0]) * D_80078244;
+    p->_26 = (va[1] - vb[1]) * D_80078244;
+    vc = (short*)(table + i1 * 12);
+    p->unk28 = (va[2] - vb[2]) * D_80078244;
+    p->unk2C = (vc[0] - vb[0]) * D_80078244;
+    p->_2E = (vc[1] - vb[1]) * D_80078244;
+    p->unk30 = (vc[2] - vb[2]) * D_80078244;
+    p->unk34 = 0;
+    p->_36 = 0;
+    p->unk38 = 0;
+    if (((unsigned char*)def)[7] & 2) {
+        p->flags |= 1;
+        nxt = ((int**)def)[2];
+        p->next = nxt;
+        p->_18 = (nxt[3] & 0x3FFFFFF) | 0x24000000;
+    } else {
+        p->flags &= ~1;
+        p->_18 = (((int*)def)[2] & 0x3FFFFFF) | 0x20000000;
+    }
+    p->callback = callback;
+    p->_14 = data;
+    p->_4C = 0;
+    p->_4E = 0;
+    p->_50 = 0;
+    p->_52 = 0;
+    p->_54 = 0;
+    p->_0E = arg10;
+    p->_56 = D_80078248 - 2;
+    D_80078248 ^= 1;
+    p->_44 = (rand() & 0x3F) - 0x10;
+    p->_46 = (rand() & 0x3F) - 0x10;
+    p->_48 = (rand() & 0x3F) - 0x10;
+    MATH3D_SetUnityMatrix((char*)p->_14 + 0xC);
+    RotMatrixX(rand() & 0xFFF, (char*)p->_14 + 0xC);
+    RotMatrixY(rand() & 0xFFF, (char*)p->_14 + 0xC);
+    RotMatrixZ(rand() & 0xFFF, (char*)p->_14 + 0xC);
+}
 
 void func_8015BBA4_B3E54(short* arg0) {
     func_800162C0(arg0);

--- a/src/level/LOONEY.c
+++ b/src/level/LOONEY.c
@@ -554,7 +554,55 @@ void looney_leafgen_OnUpdate(Instance* instance, GameTracker* gameTracker) {
     *(int*)&fc[10] = 0;
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/LOONEY", looney_leafgen_OnCollide);
+void looney_leafgen_OnCollide(Instance* instance, GameTracker* gameTracker) {
+    extern MATRIX* D_800E97C8;
+    extern SVECTOR D_800EB800;
+    BSPTree* bsp;
+    LVECTOR out;
+    short code;
+    int zv;
+
+    bsp = instance->bspTree;
+    if (bsp->instanceSpline == gameTracker->player) {
+        code = bsp->_06;
+        switch (code) {
+            case 4:
+                WORK_AS_IDX(short, instance->work1, 0) = bsp->globalOffset.x;
+                WORK_AS_IDX(short, instance->work1, 1) = bsp->globalOffset.y;
+                zv = (unsigned short)bsp->globalOffset.z;
+                instance->work5 = 1;
+                WORK_AS_IDX(short, instance->work2, 0) = zv;
+                break;
+            case 1:
+                switch (bsp->_04) {
+                    case 2:
+                        instance->work5 = code;
+                        break;
+                    case 1:
+                        if ((bsp->_08[4] - 7) < 3U) {
+                            MATH3D_ApplyMatrixT(D_800E97C8, &D_800EB800, &out);
+                            WORK_AS_IDX(short, instance->work1, 0) = out.x;
+                            WORK_AS_IDX(short, instance->work1, 1) = out.y;
+                            zv = out.z;
+                            instance->work5 = code;
+                            WORK_AS_IDX(short, instance->work2, 0) = zv;
+                        }
+                        break;
+                    case 5:
+                        if ((bsp->_08[2] - 7) < 3U) {
+                            MATH3D_ApplyMatrixT(D_800E97C8, &D_800EB800, &out);
+                            WORK_AS_IDX(short, instance->work1, 0) = out.x;
+                            WORK_AS_IDX(short, instance->work1, 1) = out.y;
+                            zv = out.z;
+                            instance->work5 = code;
+                            WORK_AS_IDX(short, instance->work2, 0) = zv;
+                        }
+                        break;
+                }
+                break;
+        }
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/LOONEY", looney_funguy_OnCreate);
 

--- a/src/level/LOONEY.c
+++ b/src/level/LOONEY.c
@@ -662,7 +662,33 @@ void looney_leafgen_OnCollide(Instance* instance, GameTracker* gameTracker) {
     }
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/LOONEY", looney_funguy_OnCreate);
+extern int D_80161C34_B9EE4[];
+
+void looney_funguy_OnCreate(Instance* instance, GameTracker* gameTracker) {
+    int* intro = ((int*)instance->introData);
+    long* fca = &instance->work0;
+
+    if (instance->flags & 0x20000) {
+        if (intro != NULL) {
+            *intro = instance->work5;
+        }
+    } else {
+        if (instance->object->data == NULL) {
+            fca[0] = (long)D_80161C34_B9EE4;
+        }
+        else {
+            fca[0] = (long)instance->object->data;
+        }
+
+        if (intro != NULL) {
+            fca[5] = *intro;
+        } else {
+            fca[5]  = (long)((Instance*)((Instance*)fca)->node.prev)->matrix;
+        }
+
+        instance->flags |= 0x10000;
+    }
+}
 
 
 INCLUDE_ASM("asm/nonmatchings/level/LOONEY", func_8015BFCC_B427C);

--- a/src/level/LOONEY.c
+++ b/src/level/LOONEY.c
@@ -968,7 +968,34 @@ void looney_bullet_OnCreate(Instance* instance, GameTracker* gameTracker) {
 
 INCLUDE_ASM("asm/nonmatchings/level/LOONEY", looney_bullet_OnUpdate);
 
-INCLUDE_ASM("asm/nonmatchings/level/LOONEY", looney_bullet_OnCollide);
+void looney_bullet_OnCollide(Instance* instance, GameTracker* gameTracker) {
+    extern G2String D_80161E0C_BA0BC;
+    Instance* other;
+    long* fc;
+    short state;
+
+    fc = &instance->work0;
+    other = instance->bspTree->instanceSpline;
+    if (other == PlayerInstance) {
+        func_80022714(instance, gameTracker);
+    } else {
+        if (G2String_Compare_EQ(other->object->parentName, &D_80161E0C_BA0BC)) {
+            if (fc[1] != 1) {
+                state = ((short*)other->_D0)[0];
+                if (state != 0xC && state != 8) {
+                    ((short*)other->_D0)[0] = 0xC;
+                    ((short*)other->_D0)[1] = 1;
+                    ((unsigned short*)other->_D0)[3] -= 1;
+                }
+            }
+        }
+    }
+    fc[1] = 1;
+    if (func_80033220(0xD2) == 0) {
+        func_80050508(instance, 0xD2, (short)((rand() & 0x1F) - 0xF), 0x64, 0xDAC);
+    }
+    func_80050A80(2, 0);
+}
 
 INCLUDE_RODATA("asm/nonmatchings/level/LOONEY", D_80161E0C_BA0BC);
 

--- a/src/level/LOONEY.c
+++ b/src/level/LOONEY.c
@@ -895,7 +895,38 @@ INCLUDE_ASM("asm/nonmatchings/level/LOONEY", looney_trapsit_OnUpdate);
 void looney_trapsit_OnCollide(Instance* instance, GameTracker* gameTracker) {
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/LOONEY", looney_trapmuv_OnCreate);
+void looney_trapmuv_OnCreate(Instance* instance, GameTracker* gameTracker) {
+    extern short D_80161CE4_B9F94[];
+    extern int D_80161CA8_B9F58[];
+    short* intro;
+    long* fc;
+    short* wp;
+    SVECTOR d;
+
+    fc = &instance->work0;
+    intro = ((short*)instance->introData);
+    if (intro != 0) {
+        instance->work0 = intro[1];
+    } else {
+        instance->introData = D_80161CE4_B9F94;
+        intro = D_80161CE4_B9F94;
+    }
+    if (instance->object->data == 0) {
+        instance->object->data = D_80161CA8_B9F58;
+    }
+    fc[1] = 3;
+    if (((int**)intro)[1] != 0) {
+        fc[0]++;
+        if (fc[0] >= intro[0]) {
+            fc[0] = 0;
+        }
+        wp = ((short**)((int**)intro)[1])[fc[0]];
+        d.x = wp[0] - instance->position.x;
+        d.y = wp[1] - instance->position.y;
+        d.z = wp[2] - instance->position.z;
+        instance->rotation.z = ratan2(d.y, d.x) + 0x400;
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/LOONEY", looney_trapmuv_OnUpdate);
 

--- a/src/level/MOOSHU.c
+++ b/src/level/MOOSHU.c
@@ -448,7 +448,24 @@ void func_8015D084_C5A04(Instance* instance, GameTracker* gameTracker) {
     fc[4] = 0x28;
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/MOOSHU", func_8015D190_C5B10);
+void func_8015D190_C5B10(Instance* instance) {
+    int* data = instance->intro->data;
+    Intro** cur;
+    short i;
+
+    if (OBTABLE_FindObject("moodam__") != 0) {
+        cur = (Intro**)(data + 2);
+        i = 0;
+        if (data[1] > 0) {
+            do {
+                (*cur)->flags &= ~8;
+                func_8002E21C(*cur);
+                cur += 1;
+                i += 1;
+            } while (i < data[1]);
+        }
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/MOOSHU", func_8015D240_C5BC0);
 

--- a/src/level/MOOSHU.c
+++ b/src/level/MOOSHU.c
@@ -141,7 +141,41 @@ void mooshu_moobar_OnCollide(Instance* instance, GameTracker* gameTracker) {
     }
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/MOOSHU", mooshu_moo_OnCollide);
+void mooshu_moo_OnCollide(Instance* instance, GameTracker* gameTracker) {
+    BSPTree* bsp;
+    short* data;
+    unsigned char* other;
+    int flags;
+    short state;
+    short* pdata;
+
+    bsp = instance->bspTree;
+    data = ((short*)instance->object->data);
+    other = bsp->_08;
+    if (bsp->instanceSpline == gameTracker->player) {
+        flags = ((unsigned short*)data)[4 / 2];
+        data[4 / 2] = flags | 0x2000;
+        if (data[0xC / 2] == 6 && bsp->_04 == 5) {
+            if (bsp->_08[3] != 0) {
+                pdata = ((short*)gameTracker->player->data);
+                data[4 / 2] = flags | 0x2020;
+                func_80022714(instance, gameTracker, flags, other);
+                func_80022780(gameTracker->player, gameTracker);
+                gameTracker->player->_D0[2] = 0xC8;
+                pdata[0x90 / 2] = 0x96;
+                pdata[0x98 / 2] = -8;
+            }
+        } else {
+            state = data[0xC / 2];
+            if (state == 1 && bsp->_04 == state && other[4] != 0) {
+                func_80022738(instance, gameTracker, flags, other);
+                data[4 / 2] = ((unsigned short*)data)[4 / 2] | 0x4000;
+            } else {
+                data[4 / 2] = ((unsigned short*)data)[4 / 2] | 0x8000;
+            }
+        }
+    }
+}
 
 void func_8015B2FC_C3C7C(Instance* instance, int arg1, int arg2) {
     SVECTOR vec;

--- a/src/level/MOOSHU.c
+++ b/src/level/MOOSHU.c
@@ -4,6 +4,8 @@
 #include "OBTABLE.h"
 #include "INSTANCE.h"
 
+void func_8015D7B4_C6134(Instance* instance);
+
 /* quantize a stick/velocity pair into a direction code (0-3) */
 void func_80159720_C20A0(short* out, int arg1, short* vec) {
     if (vec[0] > 0x200) {
@@ -466,7 +468,40 @@ void mooshu_moosprk_OnCreate(Instance* instance, GameTracker* gameTracker)
     instance->_E0[1] = -0x10;
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/MOOSHU", mooshu_moosprk_OnUpdate);
+void mooshu_moosprk_OnUpdate(Instance* instance, GameTracker* gameTracker) {
+    short spread;
+    int sum;
+    int pz;
+    int dz;
+    int iz;
+
+    if (instance->currentMainState == 0) {
+        sum = instance->_D0[2] + instance->_E0[1];
+        if (sum >= -0x7F) {
+            instance->_D0[2] = sum;
+        } else {
+            instance->_D0[2] = -0x80;
+        }
+        if (instance->position.z + instance->_D0[2] > instance->intro->position.z - 0x200) {
+            instance->position.z = instance->position.z + instance->_D0[2];
+        } else {
+            instance->position.z = instance->intro->position.z - 0x280;
+            instance->currentMainState = 1;
+        }
+        instance->position.x += (instance->work0 * (short)func_8003A6AC(instance->work1)) >> 12;
+        instance->position.y += (instance->work0 * (short)func_8003A4E0(instance->work1)) >> 12;
+        return;
+    }
+    if (instance->currentMainState == 1) {
+        spread = 0x30;
+        func_80049B80(instance, &spread, 0x60, 0xDDB, 0x100, &gameTracker->player->position, 2);
+        instance->work2 += 1;
+        if (instance->work2 >= 0x5A) {
+            func_8015D7B4_C6134(instance->parent);
+            INSTANCE_KillInstance(instance);
+        }
+    }
+}
 
 void mooshu_moosprk_OnCollide(Instance* instance, GameTracker* gameTracker) {
     BSPTree* bsp = instance->bspTree;
@@ -563,7 +598,7 @@ void func_8015D6B0_C6030(Instance* instance, GameTracker* gameTracker) {
     fc[6] = 0x10;
 }
 
-void func_8015D7B4_C6134(Instance* instance, GameTracker* gameTracker)
+void func_8015D7B4_C6134(Instance* instance)
 {
     WORK_AS_IDX(short, instance->work0, 0)++;
 }

--- a/src/level/MOOSHU.c
+++ b/src/level/MOOSHU.c
@@ -261,7 +261,42 @@ INCLUDE_RODATA("asm/nonmatchings/level/MOOSHU", D_8015DDFC_C677C);
 
 INCLUDE_RODATA("asm/nonmatchings/level/MOOSHU", D_8015DE08_C6788);
 
-INCLUDE_ASM("asm/nonmatchings/level/MOOSHU", func_8015B8B0_C4230);
+void func_8015B8B0_C4230(Instance* instance, GameTracker* gameTracker) {
+    Intro* intro;
+    Object* obj;
+    Instance* born;
+    short count;
+
+    intro = instance->object->data;
+    obj = OBTABLE_FindObject("mooelec_");
+    if (((short*)intro)[0xE / 2] != 3 && (count = ((short*)intro)[6 / 2], count > 0)) {
+        ((short*)intro)[6 / 2] = count - 1;
+        if (((int*)intro)[0x1C / 4] == 0) {
+            if (obj != 0) {
+                born = INSTANCE_BirthObject(instance, obj);
+                if (born != 0) {
+                    ((int*)intro)[0x1C / 4] = (int)born;
+                    instance->currentModel = 1;
+                    born->flags |= 0x100400;
+                }
+            }
+            if (((int*)intro)[0x1C / 4] == 0) {
+                goto skip;
+            }
+        }
+        ((Instance*)((int*)intro)[0x1C / 4])->currentModelAnim = instance->currentModelAnim;
+        ((Instance*)((int*)intro)[0x1C / 4])->currentAnimFrame = instance->currentAnimFrame;
+skip:
+        if (((short*)intro)[6 / 2] <= 0) {
+            func_8015B75C_C40DC(instance, intro);
+            return;
+        }
+        instance->currentModelAnim = 3;
+        instance->currentAnimFrame = 0;
+        instance->flags2 &= ~0x10;
+        ((short*)intro)[0xE / 2] = 3;
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/MOOSHU", func_8015B9D0_C4350);
 

--- a/src/level/MOOSHU.c
+++ b/src/level/MOOSHU.c
@@ -3,6 +3,8 @@
 #include "level/MOOSHU.h"
 #include "OBTABLE.h"
 #include "INSTANCE.h"
+#include "SCRIPT.h"
+#include "SPLINE.h"
 
 void func_8015D7B4_C6134(Instance* instance);
 
@@ -36,6 +38,7 @@ INCLUDE_ASM("asm/nonmatchings/level/MOOSHU", func_80159EC4_C2844);
 void func_8015A07C_C29FC(Instance* instance, GameTracker* gameTracker) {
 }
 
+void func_8015B39C_C3D1C();
 void func_8015B4D4_C3E54(Instance* instance, short* arg1);
 int func_8015B510_C3E90(Instance* instance, short* arg1, int arg2, short arg3);
 void func_8015B5F0_C3F70(Instance* instance, short* arg1);
@@ -201,7 +204,32 @@ void func_8015B2FC_C3C7C(Instance* instance, int arg1, int arg2) {
     }
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/MOOSHU", func_8015B39C_C3D1C);
+void func_8015B39C_C3D1C(Instance* instance, int arg1, int arg2, short* arg3) {
+    int l1;
+    int l2;
+    MultiSpline* ms;
+    unsigned short frame;
+    short count;
+    short dir;
+
+    ms = SCRIPT_GetMultiSpline(instance, &l1, &l2);
+    func_8015B5F0_C3F70(instance, arg3);
+    frame = SplineGetFrameNumber(ms->positional, SCRIPT_GetPosSplineDef(instance, ms, l1, l2));
+    count = SCRIPT_CountFramesInSpline(instance);
+    dir = arg3[0xA / 2];
+    if (((dir > 0) && ((short)frame < count / 2)) || ((dir < 0) && ((short)frame > count / 2))) {
+        arg3[0x14 / 2] = 1;
+        if (func_8015B510_C3E90(instance, arg3, 0, 0x800) != 0) {
+            func_8015B5F0_C3F70(instance, arg3);
+        }
+        dir = 1;
+        if (arg3[0xA / 2] > 0) {
+            dir = -1;
+        }
+        arg3[0xA / 2] = dir;
+    }
+    arg3[0x4 / 2] |= 8;
+}
 
 void func_8015B4D4_C3E54(Instance* instance, short* arg1) {
     arg1[0x40/2]--;

--- a/src/level/REZOP.c
+++ b/src/level/REZOP.c
@@ -293,7 +293,50 @@ void rezop_crnkplt_OnCreate(Instance* instance, GameTracker* gameTracker) {
     COLLIDE_PointAndTerrain(gameTracker8->level->segmentAddress, &a, &b, instance);
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/REZOP", rezop_crnkplt_OnUpdate);
+void rezop_crnkplt_OnUpdate(Instance* instance, GameTracker* gameTracker) {
+    int fc;
+    int t0;
+    short lim;
+    short base;
+    short pos;
+    short* intro;
+    int one;
+    short target;
+
+    one = 1;
+    target = 0;
+    intro = ((short*)instance->introData);
+    if (instance->currentMainState != one) {
+        fc = instance->work0;
+        t0 = fc - 0x800;
+        lim = instance->intro->position.z;
+        if (instance->position.z + (t0 >> 12) > lim - 0x180) {
+            if (fc >= -0x7FFF) {
+                instance->work0 = t0;
+            }
+        } else {
+            instance->position.z = lim - 0x180;
+            instance->currentMainState = one;
+            instance->work0 = 0;
+        }
+        pos = instance->position.z;
+        target = intro[0];
+        base = instance->intro->position.z;
+        if (pos + (instance->work0 >> 12) <= base + target) {
+            instance->position.z = pos + (instance->work0 >> 12);
+        } else {
+            instance->position.z = base + target;
+        }
+    }
+    if (instance->intro->_2C != 0 && ((int*)instance->intro->_2C)[0] == 1) {
+        if (instance->work0 <= 0xFFFF) {
+            instance->work0 += 0x10000;
+        }
+        instance->currentMainState = 0;
+        instance->intro->_2C = 0;
+    }
+    GenericProcess(instance, gameTracker);
+}
 
 void rezop_crnkplt_OnCollide(Instance* instance, GameTracker* gameTracker) {
     GenericCollide(instance, gameTracker);

--- a/src/level/REZOP.c
+++ b/src/level/REZOP.c
@@ -572,7 +572,38 @@ INCLUDE_ASM("asm/nonmatchings/level/REZOP", func_8015E950_D70C0);
 
 INCLUDE_ASM("asm/nonmatchings/level/REZOP", func_8015EAB0_D7220);
 
-INCLUDE_ASM("asm/nonmatchings/level/REZOP", func_8015ECB8_D7428);
+void func_8015ECB8_D7428(void* arg0) {
+    unsigned short* p = (unsigned short*)arg0;
+
+    func_80016894(p);
+    if (((short*)p)[0xE/2] >= 0xB) {
+        p[0x24/2] -= 4;
+        p[0x28/2] += 4;
+        p[0x2C/2] += 4;
+        p[0x30/2] -= 4;
+        p[0x34/2] += 4;
+        p[0x38/2] += 4;
+        p = ((unsigned short**)p)[0x4/4];
+        if (p != NULL) {
+            p[0x24/2] -= 4;
+            p[0x28/2] += 4;
+            p[0x2C/2] -= 4;
+            p[0x30/2] -= 4;
+            p[0x34/2] += 4;
+            p[0x38/2] -= 4;
+        }
+    } else {
+        p[0x1C/2] += p[0x44/2];
+        p[0x1E/2] += p[0x46/2];
+        p[0x20/2] += p[0x48/2];
+        p = ((unsigned short**)p)[0x4/4];
+        if (p != NULL) {
+            p[0x1C/2] += p[0x44/2];
+            p[0x1E/2] += p[0x46/2];
+            p[0x20/2] += p[0x48/2];
+        }
+    }
+}
 
 INCLUDE_RODATA("asm/nonmatchings/level/REZOP", D_80161590_D9D00);
 

--- a/src/level/RTA.c
+++ b/src/level/RTA.c
@@ -32,7 +32,32 @@ void rta_zgrate_OnUpdate(Instance* instance, GameTracker* gameTracker) {
     }
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/RTA", rta_zshark_OnCreate);
+typedef struct {
+    int x, y, z, pad;
+} SharkVector;
+
+void rta_zshark_OnCreate(Instance* instance, GameTracker* gameTracker) {
+    extern SharkVector D_8015EE40_DF4B0;
+    SharkVector v;
+    MATRIX m;
+    LVECTOR out;
+    int f;
+
+    v = D_8015EE40_DF4B0;
+    f = instance->flags;
+    if (!(f & 0x20000)) {
+        instance->flags = f | 0x10400;
+        func_8003E758(&instance->rotation, &m);
+        MATH3D_ApplyMatrixLV(&m, ((LVECTOR*)&v), &out);
+        instance->currentModelAnim = 0;
+        instance->work0 = 0;
+        instance->work1 = 0;
+        instance->work6 = instance->position.x + out.x;
+        instance->work7 = instance->position.y + out.y;
+        instance->work8 = instance->position.z + out.z;
+        instance->work9 = 0;
+    }
+}
 
 INCLUDE_RODATA("asm/nonmatchings/level/RTA", D_8015ED10_DF380);
 
@@ -329,7 +354,26 @@ void rta_zwleak_OnUpdate(Instance* instance, GameTracker* gameTracker) {
     func_8015A2B0_DA920(instance, 0x9C4);
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/RTA", rta_zwleak_OnCollide);
+extern void func_8000B054();
+extern void func_800256A8();
+
+void rta_zwleak_OnCollide(Instance* instance, GameTracker* gameTracker) {
+    Instance* player;
+    short* d;
+
+    player = gameTracker->player;
+    d = ((short*)player->data);
+    d[0x8C / 2] = instance->work5 * instance->work1 >> 12;
+    d[0x8E / 2] = instance->work6 * instance->work1 >> 12;
+    d[0x90 / 2] = 0;
+    d[0x98 / 2] = 0;
+    d[0x94 / 2] = -(d[0x8C / 2] / 15);
+    d[0x96 / 2] = -(d[0x8E / 2] / 15);
+    if (player->currentMainState == 4) {
+        func_8000B054(gameTracker->camera);
+    }
+    func_800256A8(gameTracker);
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/RTA", func_8015B1D4_DB844);
 

--- a/src/level/RTA.c
+++ b/src/level/RTA.c
@@ -333,7 +333,32 @@ INCLUDE_ASM("asm/nonmatchings/level/RTA", rta_zwleak_OnCollide);
 
 INCLUDE_ASM("asm/nonmatchings/level/RTA", func_8015B1D4_DB844);
 
-INCLUDE_ASM("asm/nonmatchings/level/RTA", func_8015B4EC_DBB5C);
+void func_8015B4EC_DBB5C(short* arg0, int arg1) {
+    extern int D_8015EF1C_DF58C;
+    int x;
+    int a3;
+
+    x = arg0[0x20 / 2];
+    a3 = x + arg0[0x50 / 2] + arg0[0x56 / 2];
+    if (D_8015EF1C_DF58C < a3) {
+        ((unsigned short*)arg0)[0x52 / 2] += ((unsigned short*)arg0)[0x52 / 2] * 2;
+        a3 = D_8015EF1C_DF58C - arg0[0x20 / 2];
+        ((unsigned short*)arg0)[0x54 / 2] += ((unsigned short*)arg0)[0x54 / 2] * 2;
+        if (a3 > 0) {
+            arg0[0x50 / 2] = a3;
+            if (arg0[0xE / 2] >= 5) {
+                arg0[0xE / 2] = 4;
+            }
+        } else {
+            arg0[0xE / 2] = 0;
+        }
+    } else if (arg0[0x50 / 2] < 0) {
+        if (arg0[0xE / 2] >= 4) {
+            arg0[0xE / 2] = 3;
+        }
+    }
+    func_800162C0(arg0, arg1);
+}
 
 extern char D_8015EE74_DF4E4[];
 

--- a/src/level/RTA.c
+++ b/src/level/RTA.c
@@ -827,6 +827,22 @@ void func_8015E538_DEBA8(short* rot, short dist, LVECTOR* out) {
     MATH3D_ApplyMatrix(&m, (SVECTOR*)&v, out);
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/RTA", func_8015E5E0_DEC50);
+void func_8015E5E0_DEC50(short* p, short* target, short* rot, int dist) {
+    LVECTOR d;
+    LVECTOR q;
+    int unused[4];    /* dead local — reproduces the 0x60 frame */
+    LVECTOR v;
+
+    func_8015E538_DEBA8(rot, -dist, &d);
+    v.x = d.x + target[0];
+    v.y = d.y + target[1];
+    v.z = d.z + target[2];
+    q.x = (p[0] * 3 + v.x) / 4;
+    q.y = (p[1] * 3 + v.y) / 4;
+    q.z = (p[2] * 3 + v.z) / 4;
+    p[0] = q.x;
+    p[1] = q.y;
+    p[2] = q.z;
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/RTA", func_8015E6F4_DED64);

--- a/src/level/RTA.c
+++ b/src/level/RTA.c
@@ -509,7 +509,51 @@ int func_8015BD54_DC3C4(Instance* instance) {
     return done;
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/RTA", rta_zswitch_OnCreate);
+extern unsigned short D_8015EDFE_DF46E;
+
+void rta_zswitch_OnCreate(Instance* instance, GameTracker* gameTracker) {
+    void* introData;
+    int flags;
+    int frame;
+    int soundBit;
+    unsigned short v;
+
+    if (instance->flags & 0x20000) {
+        instance->intro->flags &= ~8;
+        return;
+    }
+    flags = instance->flags | 0x10000;
+    instance->flags = flags | 0x400;
+    if (instance->intro->flags & 0x1000) {
+        instance->intro->flags &= ~0x800;
+        return;
+    }
+    introData = instance->introData;
+    instance->flags = flags | 0x480;
+    if (((unsigned short*)introData)[0] & 0x12) {
+        instance->currentMainState = 1;
+    } else {
+        instance->currentMainState = 0;
+    }
+    instance->currentSubState = 0;
+    if (instance->intro->flags & 0x800) {
+        instance->currentMainState ^= 1;
+    }
+    memset(&instance->work0, 0, 0x28);
+    frame = func_8015C344_DC9B4(instance);
+    instance->work0 = frame;
+    if (instance->currentMainState == 0) {
+        instance->currentAnimFrame = 0;
+    } else {
+        instance->currentAnimFrame = frame;
+    }
+    soundBit = ((short*)introData)[1];
+    if (instance->currentMainState == 1) {
+        D_8015EDFE_DF46E = D_8015EDFE_DF46E | soundBit;
+    } else {
+        D_8015EDFE_DF46E = D_8015EDFE_DF46E & ~soundBit;
+    }
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/RTA", rta_zswitch_OnUpdate);
 

--- a/src/level/RTA.c
+++ b/src/level/RTA.c
@@ -921,7 +921,37 @@ void func_8015E228_DE898(Instance* instance) {
     D_8015EF14_DF584 = (int)OBTABLE_FindObject("zbubbl__");
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/RTA", func_8015E27C_DE8EC);
+extern unsigned short D_8015EED0_DF540[];
+
+void func_8015E27C_DE8EC(void* arg0) {
+    unsigned short* src = (unsigned short*)arg0;
+
+    D_8015EED0_DF540[0x0/2] = src[0x8/2];
+    D_8015EED0_DF540[0x2/2] = src[0xA/2];
+    D_8015EED0_DF540[0x4/2] = src[0xC/2];
+    D_8015EED0_DF540[0x8/2] = src[0x17C/2];
+    D_8015EED0_DF540[0xA/2] = src[0x17E/2];
+    D_8015EED0_DF540[0xC/2] = src[0x180/2];
+    D_8015EED0_DF540[0x10/2] = src[0x18/2];
+    D_8015EED0_DF540[0x12/2] = src[0x1A/2];
+    D_8015EED0_DF540[0x14/2] = src[0x1C/2];
+    D_8015EED0_DF540[0x18/2] = src[0x30/2];
+    D_8015EED0_DF540[0x1A/2] = src[0x32/2];
+    D_8015EED0_DF540[0x1C/2] = src[0x34/2];
+    D_8015EED0_DF540[0x20/2] = src[0x4C/2];
+    D_8015EED0_DF540[0x22/2] = src[0x4E/2];
+    D_8015EED0_DF540[0x24/2] = src[0x50/2];
+    D_8015EED0_DF540[0x26/2] = src[0x1AC/2];
+    D_8015EED0_DF540[0x28/2] = src[0x1AE/2];
+    D_8015EED0_DF540[0x2A/2] = src[0x1B0/2];
+    D_8015EED0_DF540[0x2C/2] = src[0x0/2];
+    D_8015EED0_DF540[0x2E/2] = src[0x2/2];
+    D_8015EED0_DF540[0x30/2] = src[0x4/2];
+    D_8015EED0_DF540[0x32/2] = src[0x10/2];
+    D_8015EED0_DF540[0x34/2] = src[0x12/2];
+    D_8015EED0_DF540[0x36/2] = src[0x14/2];
+    *(int*)&D_8015EED0_DF540[0x38/2] = *(int*)&src[0x54/2];
+}
 
 INCLUDE_ASM("asm/nonmatchings/level/RTA", func_8015E3AC_DEA1C);
 

--- a/src/level/RTA.c
+++ b/src/level/RTA.c
@@ -330,7 +330,34 @@ void rta_zcargo_OnCollide(Instance* instance, GameTracker* gameTracker) {
     }
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/RTA", rta_zwleak_OnCreate);
+void rta_zwleak_OnCreate(Instance* instance, GameTracker* gameTracker) {
+    extern unsigned short D_8015ED90_DF400;
+    extern int D_8015ED94_DF404;
+    extern int D_8015ED98_DF408;
+    short* intro;
+    short angle;
+    short c;
+    int w8;
+
+    intro = ((short*)instance->introData);
+    memset(&instance->work0, 0, 0x28);
+    angle = instance->intro->rotation.z + 0x400;
+    instance->work5 = (short)func_8003A6AC(angle);
+    c = func_8003A4E0(angle);
+    instance->work6 = c;
+    if (c != 0) {
+        instance->position.y += D_8015ED90_DF400;
+    }
+    w8 = (unsigned short)instance->position.z - (instance->work6 * D_8015ED98_DF408 >> 12);
+    WORK_AS_IDX(short, instance->work7, 0) = instance->position.x + (instance->work5 * D_8015ED94_DF404 >> 12);
+    WORK_AS_IDX(short, instance->work7, 1) = instance->position.y + (instance->work6 * D_8015ED94_DF404 >> 12);
+    WORK_AS_IDX(short, instance->work8, 0) = w8;
+    if (intro != 0) {
+        instance->work1 = intro[2 / 2];
+        return;
+    }
+    instance->work1 = 0x80;
+}
 
 extern short D_8015ED9C_DF40C;
 

--- a/src/level/RTA.c
+++ b/src/level/RTA.c
@@ -513,10 +513,52 @@ INCLUDE_ASM("asm/nonmatchings/level/RTA", rta_zswitch_OnCreate);
 
 INCLUDE_ASM("asm/nonmatchings/level/RTA", rta_zswitch_OnUpdate);
 
-INCLUDE_ASM("asm/nonmatchings/level/RTA", rta_zswitch_OnCollide);
+void rta_zswitch_OnCollide(Instance* instance, GameTracker* gameTracker) {
+    extern unsigned short D_8015EDFE_DF46E;
+    extern unsigned short D_8015EE00_DF470;
+    short* intro;
+    short state;
+    int a2;
 
-extern short D_8015EDFE_DF46E;
-extern short D_8015EE00_DF470;
+    a2 = 0;
+    if (instance->bspTree->instanceSpline == PlayerInstance) {
+        if (instance->work1 < 0x1E) {
+            instance->work1 = 0;
+            return;
+        }
+        intro = ((short*)instance->introData);
+        if ((D_8015EDFE_DF46E & 0x1000) || (((unsigned short*)intro)[2 / 2] & 0x1000)) {
+            instance->work1 = 0;
+            if (instance->currentSubState == 0) {
+                state = intro[0];
+                if (state == 0) {
+                    if (D_8015EE00_DF470 == 0) {
+                        goto block_15;
+                    }
+                    goto block_14;
+                }
+                if (state == 1 && instance->currentMainState == 0) {
+                    if (D_8015EE00_DF470 == 0) {
+                        a2 = 1;
+                    }
+                } else if (intro[0] == 2) {
+                block_14:
+                    if (instance->currentMainState == 1) {
+                    block_15:
+                        a2 = 1;
+                    }
+                }
+                if (a2 != 0) {
+                    instance->intro->flags ^= 0x800;
+                    instance->currentSubState = 1;
+                }
+            }
+        }
+    }
+}
+
+extern unsigned short D_8015EDFE_DF46E;
+extern unsigned short D_8015EE00_DF470;
 extern int D_8015EE04_DF474;
 extern int D_8015EE08_DF478;
 

--- a/src/level/RTA.c
+++ b/src/level/RTA.c
@@ -953,7 +953,37 @@ void func_8015E27C_DE8EC(void* arg0) {
     *(int*)&D_8015EED0_DF540[0x38/2] = *(int*)&src[0x54/2];
 }
 
-INCLUDE_ASM("asm/nonmatchings/level/RTA", func_8015E3AC_DEA1C);
+extern int D_8015EF08_DF578;
+
+void func_8015E3AC_DEA1C(void* arg0) {
+    unsigned short* dst = (unsigned short*)arg0;
+
+    dst[0x8/2] = D_8015EED0_DF540[0x0/2];
+    dst[0xA/2] = D_8015EED0_DF540[0x2/2];
+    dst[0xC/2] = D_8015EED0_DF540[0x4/2];
+    dst[0x17C/2] = D_8015EED0_DF540[0x8/2];
+    dst[0x17E/2] = D_8015EED0_DF540[0xA/2];
+    dst[0x180/2] = D_8015EED0_DF540[0xC/2];
+    dst[0x18/2] = D_8015EED0_DF540[0x10/2];
+    dst[0x1A/2] = D_8015EED0_DF540[0x12/2];
+    dst[0x1C/2] = D_8015EED0_DF540[0x14/2];
+    dst[0x30/2] = D_8015EED0_DF540[0x18/2];
+    dst[0x32/2] = D_8015EED0_DF540[0x1A/2];
+    dst[0x34/2] = D_8015EED0_DF540[0x1C/2];
+    dst[0x4C/2] = D_8015EED0_DF540[0x20/2];
+    dst[0x4E/2] = D_8015EED0_DF540[0x22/2];
+    dst[0x50/2] = D_8015EED0_DF540[0x24/2];
+    dst[0x1AC/2] = D_8015EED0_DF540[0x26/2];
+    dst[0x1AE/2] = D_8015EED0_DF540[0x28/2];
+    dst[0x1B0/2] = D_8015EED0_DF540[0x2A/2];
+    dst[0x0/2] = D_8015EED0_DF540[0x2C/2];
+    dst[0x2/2] = D_8015EED0_DF540[0x2E/2];
+    dst[0x4/2] = D_8015EED0_DF540[0x30/2];
+    dst[0x10/2] = D_8015EED0_DF540[0x32/2];
+    dst[0x12/2] = D_8015EED0_DF540[0x34/2];
+    dst[0x14/2] = D_8015EED0_DF540[0x36/2];
+    *(int*)&dst[0x54/2] = D_8015EF08_DF578;
+}
 
 void func_8015E538_DEBA8(short* rot, short dist, LVECTOR* out) {
     SVector v;


### PR DESCRIPTION
## Summary

Census-sweep batch stacked on the merged #134 — ~30 level functions across CIRCUIT, FINAL, GEXZIL, HORROR, KUNGFU, LOONEY, MOOSHU, REZOP, and RTA. The bulk are structural handlers (OnCreate/OnCollide/OnUpdate init, spawn, and state-machine functions), where the hit rate is much higher than the low-70s math/physics tier. All verified with a clean `make build && make diff` (No differences found).

## Functions

**CIRCUIT** — `func_8015D7F0` (spline object spawner), `func_8015DB80`, `circuit_follow_OnUpdate`
**FINAL** — `func_8015AC70` (camera-lock), `func_8015CDF0` / `func_8015CF08` (debug HUD), `func_8015D018` (particle spawner), `final_lectro_OnUpdate`
**GEXZIL** — `func_8015C208` (anim state machine), `func_8015E8C0` (bubble spawner), `func_8015B220`
**HORROR** — `horror_skelh_OnUpdate`, `horror_drawer_OnUpdate`, `horror_polter_OnUpdate`, `horror_fltchst_OnCollide`
**KUNGFU** — `kungfu_kbgen_OnUpdate`, `kungfu_swing_OnCreate`, `kungfu_joyride_OnCreate`, `kungfu_dragflm_OnCreate`
**LOONEY** — `looney_bullet_OnCollide`, `looney_trapmuv_OnCreate`
**MOOSHU** — `func_8015B39C` (spline midpoint check), `func_8015B8B0`, `mooshu_moo_OnCollide`, `mooshu_moosprk_OnUpdate`
**REZOP** — `func_8015ECB8` (particle RMW), `rezop_crnkplt_OnUpdate`
**RTA** — `func_8015E27C` / `func_8015E3AC` (save/restore twins), `func_8015E5E0`, `func_8015B4EC`, `rta_zwleak_OnCreate`, `rta_zswitch_OnCreate` / `_OnCollide`

## Techniques

- **Leftover-arg + unprototyped forward decl** (`func_8015B39C`): callee reads `a3` while callers pass 3 args; an unprototyped forward decl keeps the call sites warning-free.
- **Load-after-call to avoid an extra saved register** — loading a value after an intervening call keeps it in a temp instead of forcing a callee-saved slot.
- **Comparison-operand order** controls which operand's evaluation leads the block (both arms of a `<`/`>` split).
- **`unsigned short` / `short` return-type matching** to reproduce the target's `lhu` vs `lh` and per-arm promotions.
- **Chained assignment**, **postincrement-call-arg delay-slot store**, **increment-in-condition loops**, and **SVECTOR-vs-SVector** copy sizing across the spawner/particle functions.
